### PR TITLE
Add test coverage for calendar and timeline

### DIFF
--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -1,0 +1,19 @@
+"""Calendar implementation."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from .event import Event
+from .timeline import Timeline
+
+
+class Calendar(BaseModel):
+    """A calendar with events."""
+
+    events: list[Event] = Field(default=[])
+
+    @property
+    def timeline(self) -> Timeline:
+        """Return a timeline view of events on the calendar."""
+        return Timeline(self.events)

--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -1,0 +1,83 @@
+"""A Timeline is a set of events on a calendar."""
+
+from __future__ import annotations
+
+import datetime
+import heapq
+from collections.abc import Iterable, Iterator
+
+from .event import Event
+
+
+class Timeline(Iterable[Event]):
+    """A set of events on a calendar."""
+
+    def __init__(self, events: list[Event]) -> None:
+        """Initialize timeline."""
+        self._events = events
+
+    def __iter__(self) -> Iterator[Event]:
+        """Return an iterator as a traversal over events in chronological order."""
+
+        # Using a heap is faster than sorting if the number of events (n) is
+        # much bigger than the number of events we extract from the iterator (k).
+        # Complexity: O(n + k log n).
+        heap: list[tuple[datetime.date | datetime.datetime, Event]] = []
+        for event in self._events:
+            heapq.heappush(heap, (event.start, event))
+        while heap:
+            (_, event) = heapq.heappop(heap)
+            yield event
+
+    def included(
+        self,
+        start: datetime.date | datetime.datetime,
+        end: datetime.date | datetime.datetime,
+    ) -> Iterator[Event]:
+        """Return an iterator for all events active during the timespan."""
+        timespan = Event(summary="", start=start, end=end)
+        for event in self:
+            if event.is_included_in(timespan):
+                yield event
+
+    def overlapping(
+        self,
+        start: datetime.date | datetime.datetime,
+        end: datetime.date | datetime.datetime,
+    ) -> Iterator[Event]:
+        """Return an interator containing events active during the timespan."""
+        timespan = Event(summary="", start=start, end=end)
+        for event in self:
+            if event.intersects(timespan):
+                yield event
+
+    def start_after(
+        self,
+        instant: datetime.date | datetime.datetime,
+    ) -> Iterator[Event]:
+        """Return an interator containing events starting after the specified time."""
+        for event in self:
+            if event.start > instant:
+                yield event
+
+    def at_instant(
+        self,
+        instant: datetime.date | datetime.datetime,
+    ) -> Iterator[Event]:  # pylint: disable
+        """Return an interator containing events starting after the specified time."""
+        timespan = Event(summary="", start=instant, end=instant)
+        for event in self:
+            if event.includes(timespan):
+                yield event
+
+    def on_date(self, day: datetime.date) -> Iterator[Event]:  # pylint: disable
+        """Return an iterator containing all events active on the specified day."""
+        return self.overlapping(day, day + datetime.timedelta(days=1))
+
+    def today(self) -> Iterator[Event]:
+        """Return an iterator containing all events active on the specified day."""
+        return self.on_date(datetime.date.today())
+
+    def now(self) -> Iterator[Event]:
+        """Return an iterator containing all events active on the specified day."""
+        return self.at_instant(datetime.datetime.now())

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+freezegun==1.2.1
 pip==22.1.2
 pydantic==1.9.1
 pylint==2.14.4

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -1,0 +1,174 @@
+"""Tests for timeline related calendar eents."""
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from freezegun import freeze_time
+
+from ical.calendar import Calendar
+from ical.event import Event
+
+
+@pytest.fixture(name="calendar")
+def mock_calendar() -> Calendar:
+    """Fixture calendar with all day events to use in tests."""
+    cal = Calendar()
+    cal.events.extend(
+        [
+            Event(
+                summary="second",
+                start=datetime.date(2000, 2, 1),
+                end=datetime.date(2000, 2, 2),
+            ),
+            Event(
+                summary="fourth",
+                start=datetime.date(2000, 4, 1),
+                end=datetime.date(2000, 4, 2),
+            ),
+            Event(
+                summary="third",
+                start=datetime.date(2000, 3, 1),
+                end=datetime.date(2000, 3, 2),
+            ),
+            Event(
+                summary="first",
+                start=datetime.date(2000, 1, 1),
+                end=datetime.date(2000, 1, 2),
+            ),
+        ]
+    )
+    return cal
+
+
+@pytest.fixture(name="calendar_times")
+def mock_calendar_times() -> Calendar:
+    """Fixture calendar with datetime based events to use in tests."""
+    cal = Calendar()
+    cal.events.extend(
+        [
+            Event(
+                summary="first",
+                start=datetime.datetime(2000, 1, 1, 11, 0),
+                end=datetime.datetime(2000, 1, 1, 11, 30),
+            ),
+            Event(
+                summary="second",
+                start=datetime.datetime(2000, 1, 1, 12, 0),
+                end=datetime.datetime(2000, 1, 1, 13, 0),
+            ),
+            Event(
+                summary="third",
+                start=datetime.datetime(2000, 1, 2, 12, 0),
+                end=datetime.datetime(2000, 1, 2, 13, 0),
+            ),
+        ]
+    )
+    return cal
+
+
+def test_iteration(calendar: Calendar) -> None:
+    """Test chronological iteration of a timeline."""
+    assert [e.summary for e in calendar.timeline] == [
+        "first",
+        "second",
+        "third",
+        "fourth",
+    ]
+
+
+@pytest.mark.parametrize(
+    "when,expected_events",
+    [
+        (datetime.date(2000, 1, 1), ["first"]),
+        (datetime.date(2000, 2, 1), ["second"]),
+        (datetime.date(2000, 3, 1), ["third"]),
+    ],
+)
+def test_on_date(
+    calendar: Calendar, when: datetime.date, expected_events: list[str]
+) -> None:
+    """Test returning events on a particualr day."""
+    assert [e.summary for e in calendar.timeline.on_date(when)] == expected_events
+
+
+def test_start_after(calendar: Calendar) -> None:
+    """Test chronological iteration starting at a specific time."""
+    assert [
+        e.summary for e in calendar.timeline.start_after(datetime.date(2000, 1, 1))
+    ] == ["second", "third", "fourth"]
+
+
+@pytest.mark.parametrize(
+    "at_datetime,expected_events",
+    [
+        (datetime.datetime(2000, 1, 1, 11, 15), ["first"]),
+        (datetime.datetime(2000, 1, 1, 11, 59), []),
+        (datetime.datetime(2000, 1, 1, 12, 0), ["second"]),
+        (datetime.datetime(2000, 1, 1, 12, 30), ["second"]),
+        (datetime.datetime(2000, 1, 1, 12, 59), ["second"]),
+        (datetime.datetime(2000, 1, 1, 13, 0), []),
+    ],
+)
+def test_at_instant(
+    calendar_times: Calendar, at_datetime: datetime.datetime, expected_events: list[str]
+) -> None:
+    """Test returning events at a specific time."""
+    assert [
+        e.summary for e in calendar_times.timeline.at_instant(at_datetime)
+    ] == expected_events
+
+
+@freeze_time("2000-01-01 12:30:00")
+def test_now(calendar_times: Calendar) -> None:
+    """Test events happening at the current time."""
+    assert [e.summary for e in calendar_times.timeline.now()] == ["second"]
+
+
+@freeze_time("2000-01-01 13:00:00")
+def test_now_no_match(calendar_times: Calendar) -> None:
+    """Test no events happening at the current time."""
+    assert [e.summary for e in calendar_times.timeline.now()] == []
+
+
+@freeze_time("2000-01-01 12:30:00")
+def test_today(calendar_times: Calendar) -> None:
+    """Test events active today."""
+    assert [e.summary for e in calendar_times.timeline.today()] == ["first", "second"]
+
+
+@pytest.mark.parametrize(
+    "start,end,expected_events",
+    [
+        (
+            datetime.datetime(2000, 1, 1, 10, 00),
+            datetime.datetime(2000, 1, 2, 14, 00),
+            ["first", "second", "third"],
+        ),
+        (
+            datetime.datetime(2000, 1, 1, 10, 00),
+            datetime.datetime(2000, 1, 1, 14, 00),
+            ["first", "second"],
+        ),
+        (
+            datetime.datetime(2000, 1, 1, 12, 00),
+            datetime.datetime(2000, 1, 2, 14, 00),
+            ["second", "third"],
+        ),
+        (
+            datetime.datetime(2000, 1, 1, 12, 00),
+            datetime.datetime(2000, 1, 1, 14, 00),
+            ["second"],
+        ),
+    ],
+)
+def test_included(
+    calendar_times: Calendar,
+    start: datetime.datetime,
+    end: datetime.datetime,
+    expected_events: list[str],
+) -> None:
+    """Test calendar timeline inclusions."""
+    assert [
+        e.summary for e in calendar_times.timeline.included(start, end)
+    ] == expected_events


### PR DESCRIPTION
Add test coverage for calendar and timeline. The class structure and methods are borrowed directly from isc-py, which simplifications and some features removed.