### PR TITLE
Bump pytest and pytest-golden

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,6 @@ freezegun==1.2.1
 pip==22.1.2
 pydantic==1.9.1
 pylint==2.14.4
-pytest==6.2.5  # TODO: Upgrade to 7.1.2
-pytest-golden==0.2.1
+pytest==7.1.2
+pytest-golden==0.2.2
 wheel==0.37.1


### PR DESCRIPTION
Bump pytest and pytest-golden now that a new version of pytest-golden is released with a more lenient pin https://github.com/oprypin/pytest-golden/issues/2