### PR TITLE
Separate contentlines + parsed property complexity out of field type

### DIFF
--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 from importlib import metadata
 from typing import Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, root_validator
 
 from .event import Event
 from .property_values import Text
 from .timeline import Timeline
 from .todo import Todo
+from .validators import parse_property_fields
 
 _VERSION = metadata.version("ical")
 _PRODID = metadata.metadata("ical")["prodid"]
@@ -33,3 +34,8 @@ class Calendar(BaseModel):
     def timeline(self) -> Timeline:
         """Return a timeline view of events on the calendar."""
         return Timeline(self.events)
+
+    # Flatten list[ParsedProperty] to ParsedProperty where appropriate
+    _parse_property_fields = root_validator(pre=True, allow_reuse=True)(
+        parse_property_fields
+    )

--- a/ical/property_values.py
+++ b/ical/property_values.py
@@ -32,19 +32,11 @@ ESCAPE_CHAR = {"\\\\": "\\", "\\;": ";", "\\,": ",", "\\N": "\n", "\\n": "\n"}
 TZID = "TZID"
 
 
-def parse_property_value(props: list[ParsedProperty]) -> ParsedProperty:
-    """Parse a potential list of properties into a single property."""
-    if not props or len(props) > 1:
-        raise ValueError(f"Expected one value for property: {props}")
-    return props[0]
-
-
 class Date(datetime.date):
     """Parser for rfc5545 date."""
 
     @classmethod
     def __get_validators__(cls) -> Generator[Callable, None, None]:  # type: ignore[type-arg]
-        yield parse_property_value
         yield cls.parse_date
 
     @classmethod
@@ -65,7 +57,6 @@ class DateTime(datetime.datetime):
 
     @classmethod
     def __get_validators__(cls) -> Generator[Callable, None, None]:  # type: ignore[type-arg]
-        yield parse_property_value
         yield cls.parse_date_time
 
     @classmethod
@@ -110,7 +101,6 @@ class Text(str):
 
     @classmethod
     def __get_validators__(cls) -> Generator[Callable, None, None]:  # type: ignore[type-arg]
-        yield parse_property_value
         yield cls.parse_text
         yield cls.unescape_text
 
@@ -132,7 +122,6 @@ class Integer(int):
 
     @classmethod
     def __get_validators__(cls) -> Generator[Callable, None, None]:  # type: ignore[type-arg]
-        yield parse_property_value
         yield cls.parse_int
 
     @classmethod

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, root_validator, validator
 from .contentlines import ParsedProperty
 from .properties import Priority, TodoStatus
 from .property_values import Date, DateTime, Text
+from .validators import parse_property_fields
 
 
 class Todo(BaseModel):
@@ -26,9 +27,14 @@ class Todo(BaseModel):
 
     priority: Optional[Priority] = None
 
-    categories: Optional[list[str]] = None
+    categories: list[str] = Field(default_factory=list)
     status: Optional[TodoStatus] = None
-    extras: Optional[list[tuple[str, ParsedProperty]]] = None
+    extras: list[tuple[str, ParsedProperty]] = Field(default_factory=list)
+
+    # Flatten list[ParsedProperty] to ParsedProperty where appropriate
+    _parse_property_fields = root_validator(pre=True, allow_reuse=True)(
+        parse_property_fields
+    )
 
     @validator("status", pre=True)
     def parse_status(cls, value: Any) -> str | None:
@@ -40,15 +46,17 @@ class Todo(BaseModel):
         return value
 
     @validator("categories", pre=True)
-    def parse_categories(cls, value: Any) -> list[str] | None:
-        """Parse Categories from a ParsedPropertyValue."""
-        for func in Text.__get_validators__():
-            value = func(value)
-        if not value:
-            return []
-        if not isinstance(value, str):
-            raise ValueError("Expected Text value as a string")
-        return value.split(",")
+    def parse_categories(cls, value: Any) -> list[str]:
+        """Parse Categories from a list of ParsedProperty."""
+        values: list[str] = []
+        for prop in value:
+            # Extract string from text value
+            for func in Text.__get_validators__():
+                prop = func(prop)
+            if not isinstance(prop, str):
+                raise ValueError("Expected Text value as a string")
+            values.extend(prop.split(","))
+        return values
 
     @root_validator(pre=True)
     def parse_extra_fields(cls, values: dict[str, Any]) -> dict[str, Any]:

--- a/ical/validators.py
+++ b/ical/validators.py
@@ -1,10 +1,12 @@
 """Libraries for translating parsed properties into pydantic data model.
 
 The data model returned by the contentlines parsing is a bag of ParsedProperty
-objects that support all the flexibility of the rfc5545 spec. This library
-helps reduce boilerplate for translating that complex structure into the
-simpler pydantic data model e.g. translating a list of properties with
-repeated values into a single string property specified by the pydantic model.
+objects that support all the flexibility of the rfc5545 spec. However in the
+common case the spec has a lot more flexibility than is needed for handling
+simple property types e.g. a single summary field that is specified only once.
+
+This library helps reduce boilerplate for translating that complex structure
+into the simpler pydantic data model.
 """
 
 from typing import Any, Union, get_args, get_origin
@@ -34,7 +36,7 @@ def _is_single_property(value: Any, field_type: type) -> bool:
     return False
 
 
-def parse_single_property(props: list[ParsedProperty]) -> ParsedProperty:
+def _parse_single_property(props: list[ParsedProperty]) -> ParsedProperty:
     """Convert a list of ParsedProperty into a single property."""
     if not props or len(props) > 1:
         raise ValueError(f"Expected one value for property: {props}")
@@ -47,5 +49,5 @@ def parse_property_fields(cls: BaseModel, values: dict[str, Any]) -> dict[str, A
         if not (prop_list := values.get(field.alias)):
             continue
         if field.shape != SHAPE_LIST and _is_single_property(prop_list, field.type_):
-            values[field.alias] = parse_single_property(prop_list)
+            values[field.alias] = _parse_single_property(prop_list)
     return values

--- a/ical/validators.py
+++ b/ical/validators.py
@@ -1,0 +1,51 @@
+"""Libraries for translating parsed properties into pydantic data model.
+
+The data model returned by the contentlines parsing is a bag of ParsedProperty
+objects that support all the flexibility of the rfc5545 spec. This library
+helps reduce boilerplate for translating that complex structure into the
+simpler pydantic data model e.g. translating a list of properties with
+repeated values into a single string property specified by the pydantic model.
+"""
+
+from typing import Any, Union, get_args, get_origin
+
+from pydantic import BaseModel
+from pydantic.fields import SHAPE_LIST
+
+from .contentlines import ParsedProperty
+
+
+def _is_single_property(value: Any, field_type: type) -> bool:
+    """Return true if pydantic field typing indicates a single value property."""
+
+    if not isinstance(value, list):
+        return False
+
+    origin = get_origin(field_type)
+    if origin is Union:
+        args = get_args(field_type)
+        if args and args[0] is not list:
+            return True
+        return False
+
+    if origin is not list:
+        return True
+
+    return False
+
+
+def parse_single_property(props: list[ParsedProperty]) -> ParsedProperty:
+    """Convert a list of ParsedProperty into a single property."""
+    if not props or len(props) > 1:
+        raise ValueError(f"Expected one value for property: {props}")
+    return props[0]
+
+
+def parse_property_fields(cls: BaseModel, values: dict[str, Any]) -> dict[str, Any]:
+    """Parse the contentlines schema of repeated items into single fields if needed."""
+    for field in cls.__fields__.values():
+        if not (prop_list := values.get(field.alias)):
+            continue
+        if field.shape != SHAPE_LIST and _is_single_property(prop_list, field.type_):
+            values[field.alias] = parse_single_property(prop_list)
+    return values

--- a/tests/test_property_values.py
+++ b/tests/test_property_values.py
@@ -14,13 +14,10 @@ class TextModel(BaseModel):
 
 def test_text() -> None:
     """Test for a text property value."""
-
     prop = ParsedProperty(
         value="Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared."
     )
-
-    # Introspect the type rather than passing in a list here.
-    model = TextModel.parse_obj({"text_value": [prop]})
+    model = TextModel.parse_obj({"text_value": prop})
     assert model == {
         "text_value": "\n".join(
             ["Project XYZ Final Review", "Conference Room - 3B", "Come Prepared."]


### PR DESCRIPTION
Separate contentlines + parsed property complexity out of field type so that the field types can just focus on a single value at a time. The pydantic validator inspects the field type, then automatically reduces the unnecessary structure to more closely match the pydantic data model.