### PR TITLE
Add contentline encoding library and tests

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,3 +6,5 @@ TODO tracker so they are not forgotten. This is not meant to be fully exhaustive
 - Ignore and preserve x-comp and iana-comp values unrecognized
 - Complete todo properties
 - Complete vevent properties
+- Reduce visibility of internal parsers (e.g. contentlines)
+- Encoding escaped characters in properties

--- a/ical/unicode.py
+++ b/ical/unicode.py
@@ -7,6 +7,7 @@ input files, intended to be used by the contentlines parsing code.
 from __future__ import annotations
 
 import logging
+import re
 from typing import cast
 
 from pyparsing import unicode_set
@@ -62,13 +63,16 @@ class NonUsAscii(CharRange):
 
 NON_US_ASCII = NonUsAscii.all()
 
+# Characters that should be encoded in quotes
+UNSAFE_CHAR_RE = re.compile(r"[,:;]")
+
 
 class SafeChar(CharRange):
     """Any character except CONTROL, DQUOTE, ";", ":", ","."""
 
     _ranges: UnicodeRangeList = [
         (0x21,),  # Control charts before 0x21. 0x22 is "
-        (0x23, 0x2B),  # 0x2X is ,
+        (0x23, 0x2B),  # 0x2C is ,
         (0x2D, 0x39),  # 0x3A is : and 0x3B is ;
         (0x3C, 0x7E),  # 0x7E is DEL (control)
     ]

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -9,8 +9,15 @@ from ical.calendar_stream import CalendarStream
 
 
 @pytest.mark.golden_test("testdata/calendar_stream/*.yaml")
-def test_golden_files(golden: GoldenTestFixture) -> None:
+def test_parse(golden: GoldenTestFixture) -> None:
     """Fixture to read golden file and compare to golden output."""
     cal = CalendarStream.from_ics(golden["input"])
     data = json.loads(cal.json(exclude_unset=True))
     assert data == golden["output"]
+
+
+# @pytest.mark.golden_test("testdata/calendar_stream/*.yaml")
+# def test_serialize(golden: GoldenTestFixture) -> None:
+#    """Fixture to read golden file and compare to golden output."""
+#    cal = CalendarStream.from_ics(golden["input"])
+#    assert cal.ics() == golden["input"]

--- a/tests/test_contentlines.py
+++ b/tests/test_contentlines.py
@@ -5,14 +5,22 @@ import json
 import pytest
 from pytest_golden.plugin import GoldenTestFixture
 
-from ical.contentlines import parse_content
+from ical.contentlines import encode_content, parse_content
 
 
 @pytest.mark.golden_test("testdata/contentlines/*.yaml")
-def test_golden_files(
+def test_parse_contentlines(
     golden: GoldenTestFixture, json_encoder: json.JSONEncoder
 ) -> None:
     """Fixture to read golden file and compare to golden output."""
     values = parse_content(golden["input"])
     values = json.loads(json_encoder.encode(values))
     assert values == golden["output"]
+
+
+@pytest.mark.golden_test("testdata/contentlines/*.yaml")
+def test_encode_contentlines(golden: GoldenTestFixture) -> None:
+    """Fixture to read golden file and serialize back to same format."""
+    values = parse_content(golden["input"])
+    ics = encode_content(values)
+    assert ics == golden.get("encoded", golden["input"])

--- a/tests/testdata/calendar_stream/todo.yaml
+++ b/tests/testdata/calendar_stream/todo.yaml
@@ -32,8 +32,8 @@ output:
       due: '2007-05-01'
       summary: Submit Quebec Income Tax Return for 2006
       categories:
-        - FAMILY
-        - FINANCE
+      - FAMILY
+      - FINANCE
       classification: CONFIDENTIAL
       status: NEEDS-ACTION
     - uid: 20070514T103211Z-123404@example.com

--- a/tests/testdata/contentlines/attendee.yaml
+++ b/tests/testdata/contentlines/attendee.yaml
@@ -22,3 +22,9 @@ output:
         - mailto:jdoe@example.com
         - mailto:jqpublic@example.com
       value: mailto:jsmith@example.com
+encoded: |-
+  BEGIN:VEVENT
+  ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT:mailto:jsmith@example.com
+  ATTENDEE;DELEGATED-TO="mailto:jdoe@example.com","mailto:jqpublic@example.co
+   m":mailto:jsmith@example.com
+  END:VEVENT

--- a/tests/testdata/contentlines/comma.yaml
+++ b/tests/testdata/contentlines/comma.yaml
@@ -8,3 +8,5 @@ output:
     - name: ALTREP
       values:
       - cid:part1.0001@example.org
+encoded: "DESCRIPTION;ALTREP=\"cid:part1.0001@example.org\":The Fall'98 Wild Wizards\
+  \ \n Conference - - Las Vegas\\, NV\\, USA"

--- a/tests/testdata/contentlines/fold.yaml
+++ b/tests/testdata/contentlines/fold.yaml
@@ -5,3 +5,4 @@ input: |-
 output:
   description:
   - value: This is a long description that exists on a long line.
+encoded: DESCRIPTION:This is a long description that exists on a long line.

--- a/tests/testdata/contentlines/params_quoted.yaml
+++ b/tests/testdata/contentlines/params_quoted.yaml
@@ -1,5 +1,6 @@
 input: |-
   NAME;PARAM-NAME="PARAM-VALUE":VALUE
+  NAME;PARAM-NAME="PARAM:VALUE":VALUE
 output:
   name:
   - params:
@@ -7,3 +8,11 @@ output:
       values:
       - PARAM-VALUE
     value: VALUE
+  - params:
+    - name: PARAM-NAME
+      values:
+      - PARAM:VALUE
+    value: VALUE
+encoded: |-
+  NAME;PARAM-NAME=PARAM-VALUE:VALUE
+  NAME;PARAM-NAME="PARAM:VALUE":VALUE


### PR DESCRIPTION
Add contentline encoding library and tests. This uses the existing test golden files to exercise decoding and encoding. The existing input is the default encoded output, but also can be overridden when the input test is exercising a corner case
that is different from the encoded output.