### PR TITLE
Update parser output and use common translator to pydantic

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,3 +8,4 @@ TODO tracker so they are not forgotten. This is not meant to be fully exhaustive
 - Complete vevent properties
 - Reduce visibility of internal parsers (e.g. contentlines)
 - Encoding escaped characters in properties
+- Unknown components (fix extra field parsing)

--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -34,8 +34,3 @@ class Calendar(ComponentModel):
     def timeline(self) -> Timeline:
         """Return a timeline view of events on the calendar."""
         return Timeline(self.events)
-
-
-#    class Config:
-#        """Pydantic configuration for ComponentModel."""
-#        orm_mode = True

--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -5,19 +5,19 @@ from __future__ import annotations
 from importlib import metadata
 from typing import Optional
 
-from pydantic import BaseModel, Field, root_validator
+from pydantic import Field
 
 from .event import Event
+from .model import ComponentModel
 from .property_values import Text
 from .timeline import Timeline
 from .todo import Todo
-from .validators import parse_property_fields
 
 _VERSION = metadata.version("ical")
 _PRODID = metadata.metadata("ical")["prodid"]
 
 
-class Calendar(BaseModel):
+class Calendar(ComponentModel):
     """A sequence of calendar properities and calendar components."""
 
     prodid: Text = Field(default=_PRODID)
@@ -35,7 +35,7 @@ class Calendar(BaseModel):
         """Return a timeline view of events on the calendar."""
         return Timeline(self.events)
 
-    # Flatten list[ParsedProperty] to ParsedProperty where appropriate
-    _parse_property_fields = root_validator(pre=True, allow_reuse=True)(
-        parse_property_fields
-    )
+
+#    class Config:
+#        """Pydantic configuration for ComponentModel."""
+#        orm_mode = True

--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -1,14 +1,21 @@
 """The core, a collection of Calendar and Scheduling objects."""
 
+# mypy: allow-any-generics
+
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+import logging
+
+from pydantic import Field
 
 from .calendar import Calendar
 from .contentlines import parse_content
+from .model import ComponentModel
+
+_LOGGER = logging.getLogger(__name__)
 
 
-class CalendarStream(BaseModel):
+class CalendarStream(ComponentModel):
     """A container that is a collection of calendaring information."""
 
     calendars: list[Calendar] = Field(alias="vcalendar")
@@ -16,4 +23,9 @@ class CalendarStream(BaseModel):
     @staticmethod
     def from_ics(content: str) -> "CalendarStream":
         """Factory method to create a new instance from an rfc5545 iCalendar content."""
-        return CalendarStream.parse_obj(parse_content(content))
+        components = parse_content(content)
+        result: dict[str, list] = {}
+        for component in components:
+            result.setdefault(component.name, [])
+            result[component.name].append(component.as_dict())
+        return CalendarStream.parse_obj(result)

--- a/ical/event.py
+++ b/ical/event.py
@@ -160,9 +160,3 @@ class Event(ComponentModel):
                 raise ValueError("Expected Text value as a string")
             values.extend(prop.split(","))
         return values
-
-
-#    class Config:
-#        """Pydantic configuration for ComponentModel."""
-#
-#        orm_mode = True

--- a/ical/model.py
+++ b/ical/model.py
@@ -1,0 +1,14 @@
+"""Library for pydantic models used for rfc5545 parsing."""
+
+from pydantic import BaseModel, root_validator
+
+from .validators import parse_extra_fields, parse_property_fields
+
+
+class ComponentModel(BaseModel):
+    """Abstract class for rfc5545 component model."""
+
+    _parse_extra_fields = root_validator(pre=True, allow_reuse=True)(parse_extra_fields)
+    _parse_property_fields = root_validator(pre=True, allow_reuse=True)(
+        parse_property_fields
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,8 @@ class DataclassEncoder(json.JSONEncoder):
         if dataclasses.is_dataclass(o):
             # Omit empty
             return {k: v for (k, v) in dataclasses.asdict(o).items() if v}
+        if isinstance(o, dict):
+            return {k: v for (k, v) in o.items() if v}
         return super().default(o)
 
 

--- a/tests/test_property_values.py
+++ b/tests/test_property_values.py
@@ -10,11 +10,6 @@ class TextModel(ComponentModel):
 
     text_value: Text
 
-    class Config:
-        """Configuration for TextModel."""
-
-        orm_mode = True
-
 
 def test_text() -> None:
     """Test for a text property value."""

--- a/tests/test_property_values.py
+++ b/tests/test_property_values.py
@@ -1,23 +1,31 @@
 """Tests for property values."""
 
-from pydantic import BaseModel
-
-from ical.contentlines import ParsedProperty
+from ical.contentlines import ParsedComponent, ParsedProperty
+from ical.model import ComponentModel
 from ical.property_values import Text
 
 
-class TextModel(BaseModel):
+class TextModel(ComponentModel):
     """Model with a Text value."""
 
     text_value: Text
 
+    class Config:
+        """Configuration for TextModel."""
+
+        orm_mode = True
+
 
 def test_text() -> None:
     """Test for a text property value."""
-    prop = ParsedProperty(
-        value="Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared."
+    component = ParsedComponent(name="text-model")
+    component.properties.append(
+        ParsedProperty(
+            name="text_value",
+            value="Project XYZ Final Review\\nConference Room - 3B\\nCome Prepared.",
+        )
     )
-    model = TextModel.parse_obj({"text_value": prop})
+    model = TextModel.parse_obj(component.as_dict())
     assert model == {
         "text_value": "\n".join(
             ["Project XYZ Final Review", "Conference Room - 3B", "Come Prepared."]

--- a/tests/testdata/calendar_stream/event_multi_day.yaml
+++ b/tests/testdata/calendar_stream/event_multi_day.yaml
@@ -32,6 +32,6 @@ output:
       categories:
       - CONFERENCE
       extras:
-      - - organizer
-        - params:
-          value: mailto:jsmith@example.com
+      - name: organizer
+        params:
+        value: mailto:jsmith@example.com

--- a/tests/testdata/calendar_stream/iana_property_boolean.yaml
+++ b/tests/testdata/calendar_stream/iana_property_boolean.yaml
@@ -23,12 +23,12 @@ output:
       dtend: '1996-09-20T22:00:00+00:00'
       summary: Event Summary
       extras:
-      - - dresscode
-        - params:
-          value: CASUAL
-      - - non-smoking
-        - params:
-          - name: VALUE
-            values:
-            - BOOLEAN
-          value: 'TRUE'
+      - name: dresscode
+        params:
+        value: CASUAL
+      - name: non-smoking
+        params:
+        - name: VALUE
+          values:
+          - BOOLEAN
+        value: 'TRUE'

--- a/tests/testdata/contentlines/attendee.yaml
+++ b/tests/testdata/contentlines/attendee.yaml
@@ -6,22 +6,24 @@ input: |-
    @example.com":mailto:jsmith@example.com
   END:VEVENT
 output:
-  vevent:
-  - attendee:
-    - params:
-      - name: RSVP
-        values:
-        - 'TRUE'
-      - name: ROLE
-        values:
-        - REQ-PARTICIPANT
-      value: mailto:jsmith@example.com
-    - params:
-      - name: DELEGATED-TO
-        values:
-        - mailto:jdoe@example.com
-        - mailto:jqpublic@example.com
-      value: mailto:jsmith@example.com
+  - name: vevent
+    properties:
+      - name: attendee
+        params:
+        - name: RSVP
+          values:
+          - 'TRUE'
+        - name: ROLE
+          values:
+          - REQ-PARTICIPANT
+        value: mailto:jsmith@example.com
+      - name: attendee
+        params:
+        - name: DELEGATED-TO
+          values:
+          - mailto:jdoe@example.com
+          - mailto:jqpublic@example.com
+        value: mailto:jsmith@example.com
 encoded: |-
   BEGIN:VEVENT
   ATTENDEE;RSVP=TRUE;ROLE=REQ-PARTICIPANT:mailto:jsmith@example.com

--- a/tests/testdata/contentlines/comma.yaml
+++ b/tests/testdata/contentlines/comma.yaml
@@ -1,12 +1,16 @@
 input: |-
+  BEGIN:VEVENT
   DESCRIPTION;ALTREP="cid:part1.0001@example.org":The Fall'98 Wild
     Wizards Conference - - Las Vegas\, NV\, USA
+  END:VEVENT
 output:
-  description:
-  - value: The Fall'98 Wild Wizards Conference - - Las Vegas\, NV\, USA
-    params:
-    - name: ALTREP
-      values:
-      - cid:part1.0001@example.org
-encoded: "DESCRIPTION;ALTREP=\"cid:part1.0001@example.org\":The Fall'98 Wild Wizards\
-  \ \n Conference - - Las Vegas\\, NV\\, USA"
+  - name: vevent
+    properties:
+      - name: description
+        value: The Fall'98 Wild Wizards Conference - - Las Vegas\, NV\, USA
+        params:
+        - name: ALTREP
+          values:
+          - cid:part1.0001@example.org
+encoded: "BEGIN:VEVENT\nDESCRIPTION;ALTREP=\"cid:part1.0001@example.org\":The Fall'98 Wild Wizards\
+  \ \n Conference - - Las Vegas\\, NV\\, USA\nEND:VEVENT"

--- a/tests/testdata/contentlines/fold.yaml
+++ b/tests/testdata/contentlines/fold.yaml
@@ -1,8 +1,16 @@
 input: |-
+  BEGIN:VEVENT
   DESCRIPTION:This is a lo
    ng description
     that exists on a long line.
+  END:VEVENT
 output:
-  description:
-  - value: This is a long description that exists on a long line.
-encoded: DESCRIPTION:This is a long description that exists on a long line.
+  - name: vevent
+    properties:
+      - name: description
+        value: This is a long description that exists on a long line.
+        params:
+encoded: |-
+  BEGIN:VEVENT
+  DESCRIPTION:This is a long description that exists on a long line.
+  END:VEVENT

--- a/tests/testdata/contentlines/icalendar_object.yaml
+++ b/tests/testdata/contentlines/icalendar_object.yaml
@@ -11,19 +11,30 @@ input: |-
   END:VEVENT
   END:VCALENDAR
 output:
-  vcalendar:
-  - version:
-    - value: '2.0'
-    prodid:
-    - value: -//hacksw/handcal//NONSGML v1.0//EN
-    vevent:
-    - uid:
-      - value: 19970610T172345Z-AF23B2@example.com
-      dtstamp:
-      - value: 19970610T172345Z
-      dtstart:
-      - value: 19970714T170000Z
-      dtend:
-      - value: 19970715T040000Z
-      summary:
-      - value: Bastille Day Party
+  - name: vcalendar
+    properties:
+    - name: version
+      value: '2.0'
+      params:
+    - name: prodid
+      value: -//hacksw/handcal//NONSGML v1.0//EN
+      params:
+    components:
+    - name: vevent
+      properties:
+        - name: uid
+          value: 19970610T172345Z-AF23B2@example.com
+          params:
+        - name: dtstamp
+          value: 19970610T172345Z
+          params:
+        - name: dtstart
+          value: 19970714T170000Z
+          params:
+        - name: dtend
+          value: 19970715T040000Z
+          params:
+        - name: summary
+          value: Bastille Day Party
+          params:
+      components: []

--- a/tests/testdata/contentlines/params.yaml
+++ b/tests/testdata/contentlines/params.yaml
@@ -1,9 +1,13 @@
 input: |-
+  BEGIN:VCALENDAR
   NAME;PARAM-NAME=PARAM-VALUE:VALUE
+  END:VCALENDAR
 output:
-  name:
-  - value: VALUE
-    params:
-    - name: PARAM-NAME
-      values:
-      - PARAM-VALUE
+  - name: vcalendar
+    properties:
+      - name: name
+        value: VALUE
+        params:
+        - name: PARAM-NAME
+          values:
+          - PARAM-VALUE

--- a/tests/testdata/contentlines/params_quoted.yaml
+++ b/tests/testdata/contentlines/params_quoted.yaml
@@ -1,18 +1,25 @@
 input: |-
+  BEGIN:VCALENDAR
   NAME;PARAM-NAME="PARAM-VALUE":VALUE
   NAME;PARAM-NAME="PARAM:VALUE":VALUE
+  END:VCALENDAR
 output:
-  name:
-  - params:
-    - name: PARAM-NAME
-      values:
-      - PARAM-VALUE
-    value: VALUE
-  - params:
-    - name: PARAM-NAME
-      values:
-      - PARAM:VALUE
-    value: VALUE
+  - name: vcalendar
+    properties:
+      - name: name
+        params:
+          - name: PARAM-NAME
+            values:
+            - PARAM-VALUE
+        value: VALUE
+      - name: name
+        params:
+        - name: PARAM-NAME
+          values:
+          - PARAM:VALUE
+        value: VALUE
 encoded: |-
+  BEGIN:VCALENDAR
   NAME;PARAM-NAME=PARAM-VALUE:VALUE
   NAME;PARAM-NAME="PARAM:VALUE":VALUE
+  END:VCALENDAR

--- a/tests/testdata/contentlines/rdate.yaml
+++ b/tests/testdata/contentlines/rdate.yaml
@@ -1,9 +1,13 @@
 input: |-
+  BEGIN:VCALENDAR
   RDATE;VALUE=DATE:19970304,19970504,19970704,19970904
+  END:VCALENDAR
 output:
-  rdate:
-  - params:
-    - name: VALUE
-      values:
-      - DATE
-    value: 19970304,19970504,19970704,19970904
+  - name: vcalendar
+    properties:
+      - name: rdate
+        params:
+        - name: VALUE
+          values:
+          - DATE
+        value: 19970304,19970504,19970704,19970904

--- a/tests/testdata/contentlines/vevent.yaml
+++ b/tests/testdata/contentlines/vevent.yaml
@@ -9,18 +9,26 @@ input: |-
   CATEGORIES:BUSINESS,HUMAN RESOURCES
   END:VEVENT
 output:
-  vevent:
-  - uid:
-    - value: 19970901T130000Z-123401@example.com
-    dtstamp:
-    - value: 19970901T130000Z
-    dtstart:
-    - value: 19970903T163000Z
-    dtend:
-    - value: 19970903T190000Z
-    summary:
-    - value: Annual Employee Review
-    class:
-    - value: PRIVATE
-    categories:
-    - value: BUSINESS,HUMAN RESOURCES
+  - name: vevent
+    properties:
+    - name: uid
+      value: 19970901T130000Z-123401@example.com
+      params:
+    - name: dtstamp
+      value: 19970901T130000Z
+      params:
+    - name: dtstart
+      value: 19970903T163000Z
+      params:
+    - name: dtend
+      value: 19970903T190000Z
+      params:
+    - name: summary
+      value: Annual Employee Review
+      params:
+    - name: class
+      value: PRIVATE
+      params:
+    - name: categories
+      value: BUSINESS,HUMAN RESOURCES
+      params:

--- a/tests/testdata/contentlines/vtodo.yaml
+++ b/tests/testdata/contentlines/vtodo.yaml
@@ -9,22 +9,29 @@ input: |-
   STATUS:NEEDS-ACTION
   END:VTODO
 output:
-  vtodo:
-  - uid:
-    - value: 20070313T123432Z-456553@example.com
-    dtstamp:
-    - value: 20070313T123432Z
-    due:
-    - value: '20070501'
-      params:
-      - name: VALUE
-        values:
-        - DATE
-    summary:
-    - value: Submit Quebec Income Tax Return for 2006
-    class:
-    - value: CONFIDENTIAL
-    categories:
-    - value: FAMILY,FINANCE
-    status:
-    - value: NEEDS-ACTION
+  - name: vtodo
+    properties:
+      - name: uid
+        value: 20070313T123432Z-456553@example.com
+        params:
+      - name: dtstamp
+        value: 20070313T123432Z
+        params:
+      - name: due
+        value: '20070501'
+        params:
+          - name: VALUE
+            values:
+            - DATE
+      - name: summary
+        value: Submit Quebec Income Tax Return for 2006
+        params:
+      - name: class
+        value: CONFIDENTIAL
+        params:
+      - name: categories
+        value: FAMILY,FINANCE
+        params:
+      - name: status
+        value: NEEDS-ACTION
+        params:


### PR DESCRIPTION
Update parser output and use common translator to pydantic:
- Move the name of the components and properties into the parsed component and property objects to simplify the stack building
- Introduce a common pydantic base class with generic validators used in all components
- Has the side effect of making the golden parser output files more readable

The motivation is to make it easier to further support calendar ics encoding in a future PR.