### PR TITLE
Validation for start/end date matching

### DIFF
--- a/ical/event.py
+++ b/ical/event.py
@@ -214,7 +214,7 @@ class Event(ComponentModel):
         if not (dtstart := values.get("dtstart")) or not (dtend := values.get("dtend")):
             return values
         if not isinstance(dtstart, datetime.datetime) or not isinstance(
-            dtstart, datetime.datetime
+            dtend, datetime.datetime
         ):
             return values
         if dtstart.tzinfo is None and dtend.tzinfo is not None:

--- a/ical/event.py
+++ b/ical/event.py
@@ -6,7 +6,7 @@ import datetime
 import uuid
 from typing import Any, Optional, Union
 
-from pydantic import Field, validator
+from pydantic import Field, root_validator, validator
 
 from .contentlines import ParsedProperty
 from .types import Classification, ComponentModel, EventStatus, Geo, parse_text
@@ -198,3 +198,29 @@ class Event(ComponentModel):
         if value and not isinstance(value, str):
             raise ValueError(f"Expected text value as a string: {value}")
         return value
+
+    @root_validator
+    def validate_date_types(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate that start and end values are the same date or datetime type."""
+        if not (dtstart := values.get("dtstart")) or not (dtend := values.get("dtend")):
+            return values
+        if type(dtstart) != type(dtend):  # pylint: disable=unidiomatic-typecheck
+            raise ValueError("Expected end value type to match start")
+        return values
+
+    @root_validator
+    def validate_date_time_timezone(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate that start and end values have the same timezone information."""
+        if not (dtstart := values.get("dtstart")) or not (dtend := values.get("dtend")):
+            return values
+        if not isinstance(dtstart, datetime.datetime) or not isinstance(
+            dtstart, datetime.datetime
+        ):
+            return values
+        if dtstart.tzinfo is None and dtend.tzinfo is not None:
+            raise ValueError(
+                f"Expected end datetime value in localtime but was {dtend}"
+            )
+        if dtstart.tzinfo is not None and dtend.tzinfo is None:
+            raise ValueError(f"Expected end datetime with timezone but was {dtend}")
+        return values

--- a/ical/event.py
+++ b/ical/event.py
@@ -202,19 +202,22 @@ class Event(ComponentModel):
     @root_validator
     def validate_date_types(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate that start and end values are the same date or datetime type."""
-        if not (dtstart := values.get("dtstart")) or not (dtend := values.get("dtend")):
-            return values
-        if type(dtstart) != type(dtend):  # pylint: disable=unidiomatic-typecheck
+        if (
+            not (dtstart := values.get("dtstart"))
+            or not (dtend := values.get("dtend"))
+            or type(dtstart) != type(dtend)  # pylint: disable=unidiomatic-typecheck
+        ):
             raise ValueError("Expected end value type to match start")
         return values
 
     @root_validator
     def validate_date_time_timezone(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate that start and end values have the same timezone information."""
-        if not (dtstart := values.get("dtstart")) or not (dtend := values.get("dtend")):
-            return values
-        if not isinstance(dtstart, datetime.datetime) or not isinstance(
-            dtend, datetime.datetime
+        if (
+            not (dtstart := values.get("dtstart"))
+            or not (dtend := values.get("dtend"))
+            or not isinstance(dtstart, datetime.datetime)
+            or not isinstance(dtend, datetime.datetime)
         ):
             return values
         if dtstart.tzinfo is None and dtend.tzinfo is not None:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,8 +1,9 @@
 """Tests for Event library."""
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
+from pydantic import ValidationError
 
 from ical.event import Event
 
@@ -96,3 +97,47 @@ def test_within_and_includes() -> None:
     assert not event2.is_included_in(event3)
     assert not event3.is_included_in(event1)
     assert not event3.is_included_in(event2)
+
+
+def test_start_end_same_type() -> None:
+    """Verify that the start and end value are the same type."""
+
+    with pytest.raises(ValidationError):
+        Event(
+            summary=SUMMARY, start=date(2022, 9, 9), end=datetime(2022, 9, 9, 11, 0, 0)
+        )
+
+    with pytest.raises(ValidationError):
+        Event(
+            summary=SUMMARY, start=datetime(2022, 9, 9, 10, 0, 0), end=date(2022, 9, 9)
+        )
+
+
+def test_start_end_local_time() -> None:
+    """Verify that the start and end value are the same type."""
+
+    # Valid
+    Event(
+        summary=SUMMARY,
+        start=datetime(2022, 9, 9, 10, 0, 0),
+        end=datetime(2022, 9, 9, 11, 0, 0),
+    )
+    Event(
+        summary=SUMMARY,
+        start=datetime(2022, 9, 9, 10, 0, 0, tzinfo=timezone.utc),
+        end=datetime(2022, 9, 9, 11, 0, 0, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(ValidationError):
+        Event(
+            summary=SUMMARY,
+            start=datetime(2022, 9, 9, 10, 0, 0, tzinfo=timezone.utc),
+            end=datetime(2022, 9, 9, 11, 0, 0),
+        )
+
+    with pytest.raises(ValidationError):
+        Event(
+            summary=SUMMARY,
+            start=datetime(2022, 9, 9, 10, 0, 0),
+            end=datetime(2022, 9, 9, 11, 0, 0, tzinfo=timezone.utc),
+        )


### PR DESCRIPTION
Validation for start/end date matching logic in the RFC https://datatracker.ietf.org/doc/html/rfc5545#section-3.8.2.4