### PR TITLE
Add input duration as optional alternative to end time

### DIFF
--- a/ical/types.py
+++ b/ical/types.py
@@ -332,7 +332,6 @@ class PropertyDataType(enum.Enum):
     # Types to support
     #   BINARY
     #   CAL-ADDRESS
-    #   DURATION
     #   FLOAT
     #   PERIOD
     #   RECUR


### PR DESCRIPTION
Add support for duration fields, as an alternative to end time input fields. Verify duration is the right type of units (e.g. only days when input is a date), and that only end date or duration can be specified.