### PR TITLE
Add attendee and organizer to events

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -13,8 +13,8 @@ TODO tracker so they are not forgotten. This is not meant to be fully exhaustive
 - Serializing property parameters
 - Serializing extra properties
 - Encoded timezones
-- Add Organizer fields
 - Repeated property serialization e.g. 'resources.yaml'. Multi-line vs repeated, and preserving property parameters
+- Property parameters for attendee, organizer fields
 
 
 - Components
@@ -29,13 +29,8 @@ TODO tracker so they are not forgotten. This is not meant to be fully exhaustive
     - url
     - recurid
 
-    -- one or other
-    - dtend
-    - duration
-
     -- multiple
     - attach
-    - attendee
     - categories
     - contact
     - related

--- a/ical/event.py
+++ b/ical/event.py
@@ -9,7 +9,14 @@ from typing import Any, Optional, Union
 from pydantic import Field, root_validator, validator
 
 from .contentlines import ParsedProperty
-from .types import Classification, ComponentModel, EventStatus, Geo, parse_text
+from .types import (
+    CalAddress,
+    Classification,
+    ComponentModel,
+    EventStatus,
+    Geo,
+    parse_text,
+)
 
 MIDNIGHT = datetime.time()
 
@@ -47,6 +54,8 @@ class Event(ComponentModel):
         alias="last-modified", default=None
     )
     resources: list[str] = Field(default_factory=list)
+    organizer: Optional[CalAddress] = None
+    attendees: list[CalAddress] = Field(alias="attendee", default_factory=list)
 
     extras: list[ParsedProperty] = Field(default_factory=list)
 
@@ -59,7 +68,6 @@ class Event(ComponentModel):
     # - recurid
     # -- multiple
     # - attach
-    # - attendee
     # - contact
     # - related
 

--- a/ical/types.py
+++ b/ical/types.py
@@ -21,6 +21,7 @@ import zoneinfo
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Generator, TypeVar, Union, get_args, get_origin
+from urllib.parse import urlparse
 
 from pydantic import BaseModel, root_validator
 from pydantic.fields import SHAPE_LIST
@@ -111,6 +112,20 @@ def parse_geo(value: Any) -> Geo:
 def encode_geo_ics(value: Geo) -> str:
     """Serialize as an ICS value."""
     return f"{value.lat};{value.lng}"
+
+
+class CalAddress(str):
+    """A property that contains a calendar user address."""
+
+    @classmethod
+    def __get_valiators__(cls) -> Generator[Callable[[Any], Any], None, None]:
+        yield cls.parse
+
+    @classmethod
+    def parse(cls, prop: ParsedProperty) -> CalAddress:
+        """Parse a calendar user address."""
+        urlparse(prop.value)
+        return CalAddress(prop.value)
 
 
 def parse_date(prop: ParsedProperty) -> datetime.date | None:
@@ -344,6 +359,7 @@ class PropertyDataType(enum.Enum):
     INTEGER = ("INTEGER", int, parse_int, str)
     # Note: Has special handling, not json encoder
     TEXT = ("TEXT", str, parse_text, encode_text)
+    CAL_ADDRESS = ("CAL-ADDRESS", CalAddress, CalAddress.parse, str)
 
     def __init__(
         self,

--- a/tests/testdata/calendar_stream/event_attendee.yaml
+++ b/tests/testdata/calendar_stream/event_attendee.yaml
@@ -1,0 +1,46 @@
+input: |-
+ BEGIN:VCALENDAR
+ VERSION:2.0
+ PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+ BEGIN:VEVENT
+ DTSTAMP:20070423T123432Z
+ UID:20070423T123432Z-541111@example.com
+ SUMMARY:Festival International de Jazz de Montreal
+ DTSTART:20070628
+ DTEND:20070709
+ ATTENDEE;MEMBER="mailto:DEV-GROUP@example.com":
+  mailto:joecool@example.com
+ ATTENDEE;DELEGATED-FROM="mailto:immud@example.com":
+  mailto:ildoit@example.com
+ ORGANIZER;CN=John Smith:mailto:jsmith@example.com
+ END:VEVENT
+ END:VCALENDAR
+output:
+  calendars:
+    - version: "2.0"
+      prodid: "-//hacksw/handcal//NONSGML v1.0//EN"
+      events:
+        - dtstamp: "2007-04-23T12:34:32+00:00"
+          uid: 20070423T123432Z-541111@example.com
+          summary: "Festival International de Jazz de Montreal"
+          dtstart: "2007-06-28"
+          dtend: "2007-07-09"
+          attendees:
+            - mailto:joecool@example.com
+            - mailto:ildoit@example.com
+          organizer: mailto:jsmith@example.com
+encoded: |-
+ BEGIN:VCALENDAR
+ VERSION:2.0
+ PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+ BEGIN:VEVENT
+ DTSTAMP:20070423T123432Z
+ UID:20070423T123432Z-541111@example.com
+ SUMMARY:Festival International de Jazz de Montreal
+ DTSTART:20070628
+ DTEND:20070709
+ ORGANIZER:mailto:jsmith@example.com
+ ATTENDEE:mailto:joecool@example.com
+ ATTENDEE:mailto:ildoit@example.com
+ END:VEVENT
+ END:VCALENDAR

--- a/tests/testdata/calendar_stream/event_multi_day.yaml
+++ b/tests/testdata/calendar_stream/event_multi_day.yaml
@@ -31,10 +31,7 @@ output:
       status: CONFIRMED
       categories:
       - CONFERENCE
-      extras:
-      - name: organizer
-        params:
-        value: mailto:jsmith@example.com
+      organizer: mailto:jsmith@example.com
 encoded: |-
   BEGIN:VCALENDAR
   VERSION:2.0
@@ -49,5 +46,6 @@ encoded: |-
     Center\nAtlanta\, Georgia
   CATEGORIES:CONFERENCE
   STATUS:CONFIRMED
+  ORGANIZER:mailto:jsmith@example.com
   END:VEVENT
   END:VCALENDAR


### PR DESCRIPTION
Add attendee and organizer to events. These are `CalAddress` fields, which is a new type added that is effectively a url.