### PR TITLE
Recurrence improvements for monthly and unbounded ranges

### DIFF
--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -9,7 +9,7 @@ from pydantic import Field
 
 from .contentlines import ParsedProperty
 from .event import Event
-from .timeline import Timeline
+from .timeline import SortedIterable, Timeline
 from .todo import Todo
 from .types import ComponentModel
 
@@ -35,4 +35,4 @@ class Calendar(ComponentModel):
     @property
     def timeline(self) -> Timeline:
         """Return a timeline view of events on the calendar."""
-        return Timeline(self.events)
+        return Timeline(SortedIterable(self.events))

--- a/ical/event.py
+++ b/ical/event.py
@@ -135,9 +135,9 @@ class Event(ComponentModel):
         """Return True if this event overlaps with the other event."""
         return (
             other.start_datetime <= self.start_datetime < other.end_datetime
-            or other.start_datetime <= self.end_datetime < other.end_datetime
+            or other.start_datetime < self.end_datetime <= other.end_datetime
             or self.start_datetime <= other.start_datetime < self.end_datetime
-            or self.start_datetime <= other.end_datetime < self.end_datetime
+            or self.start_datetime < other.end_datetime <= self.end_datetime
         )
 
     def includes(self, other: "Event") -> bool:

--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -15,8 +15,8 @@ from .types import Frequency, Weekday
 _LOGGER = logging.getLogger(__name__)
 
 
-class Timeline(Iterable[Event]):
-    """A set of events on a calendar."""
+class SortedIterable(Iterable[Event]):
+    """Iterable that returns events in sorted order."""
 
     def __init__(self, iterable: Iterable[Event]) -> None:
         """Initialize timeline."""
@@ -34,6 +34,18 @@ class Timeline(Iterable[Event]):
             (_, event) = heapq.heappop(heap)
             yield event
 
+
+class Timeline(Iterable[Event]):
+    """A set of events on a calendar."""
+
+    def __init__(self, iterable: Iterable[Event]) -> None:
+        """Initialize timeline."""
+        self._iterable = iterable
+
+    def __iter__(self) -> Iterator[Event]:
+        """Return an iterator as a traversal over events in chronological order."""
+        return iter(self._iterable)
+
     def included(
         self,
         start: datetime.date | datetime.datetime,
@@ -44,6 +56,8 @@ class Timeline(Iterable[Event]):
         for event in self:
             if event.is_included_in(timespan):
                 yield event
+            elif event > timespan:
+                break
 
     def overlapping(
         self,
@@ -55,6 +69,8 @@ class Timeline(Iterable[Event]):
         for event in self:
             if event.intersects(timespan):
                 yield event
+            elif event > timespan:
+                break
 
     def start_after(
         self,
@@ -74,6 +90,8 @@ class Timeline(Iterable[Event]):
         for event in self:
             if event.includes(timespan):
                 yield event
+            elif event > timespan:
+                break
 
     def on_date(self, day: datetime.date) -> Iterator[Event]:  # pylint: disable
         """Return an iterator containing all events active on the specified day."""

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -168,3 +168,69 @@ def test_start_and_duration() -> None:
     assert event.end == datetime(2022, 9, 9, 10, 1, 0)
     assert event.duration == timedelta(seconds=60)
     assert event.computed_duration == timedelta(seconds=60)
+
+
+@pytest.mark.parametrize(
+    "range1,range2,expected",
+    [
+        (
+            (date(2022, 8, 1), date(2022, 8, 2)),
+            (date(2022, 8, 1), date(2022, 8, 2)),
+            True,
+        ),
+        (
+            (date(2022, 8, 1), date(2022, 8, 4)),
+            (date(2022, 8, 2), date(2022, 8, 3)),
+            True,
+        ),
+        (
+            (date(2022, 8, 1), date(2022, 8, 3)),
+            (date(2022, 8, 2), date(2022, 8, 4)),
+            True,
+        ),
+        (
+            (date(2022, 8, 2), date(2022, 8, 3)),
+            (date(2022, 8, 1), date(2022, 8, 4)),
+            True,
+        ),
+        (
+            (date(2022, 8, 3), date(2022, 8, 4)),
+            (date(2022, 8, 1), date(2022, 8, 4)),
+            True,
+        ),
+        (
+            (date(2022, 8, 2), date(2022, 8, 4)),
+            (date(2022, 8, 1), date(2022, 8, 4)),
+            True,
+        ),
+        (
+            (date(2022, 8, 1), date(2022, 8, 2)),
+            (date(2022, 8, 3), date(2022, 8, 4)),
+            False,
+        ),
+        (
+            (date(2022, 8, 3), date(2022, 8, 4)),
+            (date(2022, 8, 1), date(2022, 8, 2)),
+            False,
+        ),
+        (
+            (date(2022, 8, 1), date(2022, 8, 2)),
+            (date(2022, 8, 2), date(2022, 8, 3)),
+            False,
+        ),
+        (
+            (date(2022, 8, 2), date(2022, 8, 3)),
+            (date(2022, 8, 1), date(2022, 8, 2)),
+            False,
+        ),
+    ],
+)
+def test_date_intersects(
+    range1: tuple[date, date],
+    range2: tuple[date, date],
+    expected: bool,
+) -> None:
+    """Test event intersection."""
+    event1 = Event(summary=SUMMARY, start=range1[0], end=range1[1])
+    event2 = Event(summary=SUMMARY, start=range2[0], end=range2[1])
+    assert event1.intersects(event2) == expected

--- a/tests/test_recur.py
+++ b/tests/test_recur.py
@@ -84,7 +84,7 @@ def test_day_iteration(
     rrule: Recur,
     expected: list[tuple[datetime.date, datetime.date]],
 ) -> None:
-    """Test chronological iteration of a timeline."""
+    """Test recurrence rules for day frequency."""
     event = Event(
         summary="summary",
         start=start,
@@ -160,7 +160,117 @@ def test_weekly_iteration(
     rrule: Recur,
     expected: list[tuple[datetime.date, datetime.date]],
 ) -> None:
-    """Test chronological iteration of a timeline."""
+    """Test recurrence rules for weekly frequency."""
+    event = Event(
+        summary="summary",
+        start=start,
+        end=end,
+        rrule=rrule,
+    )
+    timeline = recur_timeline(event)
+    assert [(e.start, e.end) for e in timeline] == expected
+
+
+@pytest.mark.parametrize(
+    "start,end,rrule,expected",
+    [
+        (
+            datetime.date(2022, 8, 1),
+            datetime.date(2022, 8, 2),
+            Recur(
+                freq=Frequency.MONTHLY,
+                until=datetime.date(2023, 1, 1),
+                by_month_day=[1],
+            ),
+            [
+                (datetime.date(2022, 8, 1), datetime.date(2022, 8, 2)),
+                (datetime.date(2022, 9, 1), datetime.date(2022, 9, 2)),
+                (datetime.date(2022, 10, 1), datetime.date(2022, 10, 2)),
+                (datetime.date(2022, 11, 1), datetime.date(2022, 11, 2)),
+                (datetime.date(2022, 12, 1), datetime.date(2022, 12, 2)),
+                (datetime.date(2023, 1, 1), datetime.date(2023, 1, 2)),
+            ],
+        ),
+        (
+            datetime.date(2022, 8, 1),
+            datetime.date(2022, 8, 2),
+            Recur(
+                freq=Frequency.MONTHLY,
+                until=datetime.date(2023, 1, 1),
+                interval=2,
+                by_month_day=[1],
+            ),
+            [
+                (datetime.date(2022, 8, 1), datetime.date(2022, 8, 2)),
+                (datetime.date(2022, 10, 1), datetime.date(2022, 10, 2)),
+                (datetime.date(2022, 12, 1), datetime.date(2022, 12, 2)),
+            ],
+        ),
+        (
+            datetime.date(2022, 8, 1),
+            datetime.date(2022, 8, 2),
+            Recur(freq=Frequency.MONTHLY, count=3, by_month_day=[1]),
+            [
+                (datetime.date(2022, 8, 1), datetime.date(2022, 8, 2)),
+                (datetime.date(2022, 9, 1), datetime.date(2022, 9, 2)),
+                (datetime.date(2022, 10, 1), datetime.date(2022, 10, 2)),
+            ],
+        ),
+        (
+            datetime.date(2022, 8, 1),
+            datetime.date(2022, 8, 2),
+            Recur(
+                freq=Frequency.MONTHLY,
+                interval=2,
+                count=3,
+                by_month_day=[1],
+            ),
+            [
+                (datetime.date(2022, 8, 1), datetime.date(2022, 8, 2)),
+                (datetime.date(2022, 10, 1), datetime.date(2022, 10, 2)),
+                (datetime.date(2022, 12, 1), datetime.date(2022, 12, 2)),
+            ],
+        ),
+        (
+            datetime.datetime(2022, 8, 2, 9, 0, 0),
+            datetime.datetime(2022, 8, 2, 9, 30, 0),
+            Recur(
+                freq=Frequency.MONTHLY,
+                until=datetime.date(2023, 1, 1),
+                by_month_day=[2],
+            ),
+            [
+                (
+                    datetime.datetime(2022, 8, 2, 9, 0, 0),
+                    datetime.datetime(2022, 8, 2, 9, 30, 0),
+                ),
+                (
+                    datetime.datetime(2022, 9, 2, 9, 0, 0),
+                    datetime.datetime(2022, 9, 2, 9, 30, 0),
+                ),
+                (
+                    datetime.datetime(2022, 10, 2, 9, 0, 0),
+                    datetime.datetime(2022, 10, 2, 9, 30, 0),
+                ),
+                (
+                    datetime.datetime(2022, 11, 2, 9, 0, 0),
+                    datetime.datetime(2022, 11, 2, 9, 30, 0),
+                ),
+                (
+                    datetime.datetime(2022, 12, 2, 9, 0, 0),
+                    datetime.datetime(2022, 12, 2, 9, 30, 0),
+                ),
+            ],
+        ),
+    ],
+)
+def test_monthly_iteration(
+    start: datetime.date | datetime.date,
+    end: datetime.date | datetime.date,
+    rrule: Recur,
+    expected: list[tuple[datetime.date, datetime.date]],
+) -> None:
+    """Test recurrency rules for monthly frequency."""
     event = Event(
         summary="summary",
         start=start,

--- a/tests/test_recur.py
+++ b/tests/test_recur.py
@@ -279,3 +279,30 @@ def test_monthly_iteration(
     )
     timeline = recur_timeline(event)
     assert [(e.start, e.end) for e in timeline] == expected
+
+
+def test_recur_no_bound() -> None:
+    """Test a recurrence rule with no end date."""
+
+    event = Event(
+        summary="summary",
+        start=datetime.date(2022, 8, 1),
+        end=datetime.date(2022, 8, 2),
+        rrule=Recur(freq=Frequency.DAILY, interval=2),
+    )
+    timeline = recur_timeline(event)
+
+    def on_date(day: datetime.date) -> list[datetime.date]:
+        return [e.start for e in timeline.on_date(day)]
+
+    assert on_date(datetime.date(2022, 8, 1)) == [datetime.date(2022, 8, 1)]
+    assert on_date(datetime.date(2022, 8, 2)) == []
+    assert on_date(datetime.date(2022, 8, 3)) == [datetime.date(2022, 8, 3)]
+
+    assert on_date(datetime.date(2025, 1, 1)) == [datetime.date(2025, 1, 1)]
+    assert on_date(datetime.date(2025, 1, 2)) == []
+    assert on_date(datetime.date(2025, 1, 3)) == [datetime.date(2025, 1, 3)]
+
+    assert on_date(datetime.date(2035, 9, 1)) == []
+    assert on_date(datetime.date(2035, 9, 2)) == [datetime.date(2035, 9, 2)]
+    assert on_date(datetime.date(2035, 9, 3)) == []


### PR DESCRIPTION
Update recurrences with test coverage for monthly recurrences. Implement unbounded ranges which requires iterating over events and stopping when a condition is met, rather than bounding forever.