### PR TITLE
Add support for EXDATE recurrence rule date exclusions

### DIFF
--- a/ical/event.py
+++ b/ical/event.py
@@ -53,6 +53,9 @@ class Event(ComponentModel):
     contacts: list[str] = Field(alias="contact", default_factory=list)
     created: Optional[datetime.datetime] = None
     description: str = ""
+    exdates: list[Union[datetime.datetime, datetime.date]] = Field(
+        alias="exdate", default_factory=list
+    )
     geo: Optional[Geo] = None
     last_modified: Optional[datetime.datetime] = Field(
         alias="last-modified", default=None
@@ -177,7 +180,7 @@ class Event(ComponentModel):
             return NotImplemented
         return self._tuple() >= other._tuple()
 
-    @validator("status", pre=True, allow_reuse=True)
+    @validator("status", pre=True)
     def parse_status(cls, value: Any) -> str | None:
         """Parse an EventStatus from a ParsedPropertyValue."""
         value = parse_text(value)
@@ -185,27 +188,7 @@ class Event(ComponentModel):
             raise ValueError(f"Expected text value as a string: {value}")
         return value
 
-    @validator("categories", pre=True, allow_reuse=True)
-    def parse_categories(cls, value: Any) -> list[str]:
-        """Parse Categories from a list of ParsedProperty."""
-        values: list[str] = []
-        for prop in value:
-            if not isinstance(prop, str):
-                raise ValueError(f"Expected text value as a string: {value}")
-            values.extend(prop.split(","))
-        return values
-
-    @validator("resources", pre=True, allow_reuse=True)
-    def parse_resources(cls, value: Any) -> list[str]:
-        """Parse resources from a list of ParsedProperty."""
-        values: list[str] = []
-        for prop in value:
-            if not isinstance(prop, str):
-                raise ValueError(f"Expected text value as a string: {value}")
-            values.extend(prop.split(","))
-        return values
-
-    @validator("classification", pre=True, allow_reuse=True)
+    @validator("classification", pre=True)
     def parse_classification(cls, value: Any) -> str | None:
         """Parse a Classification from a ParsedPropertyValue."""
         value = parse_text(value)

--- a/tests/test_recur.py
+++ b/tests/test_recur.py
@@ -396,3 +396,34 @@ def test_merged_recur_event_timeline() -> None:
         (datetime.datetime(2022, 8, 31, 6, 0, 0), "Morning exercise"),
         (datetime.datetime(2022, 9, 1, 6, 0, 0), "Morning exercise"),
     ]
+
+
+def test_exclude_date() -> None:
+    """Test recurrence rule with date exclusions."""
+    calendar = Calendar()
+    calendar.events.extend(
+        [
+            Event(
+                summary="Morning exercise",
+                start=datetime.datetime(2022, 8, 2, 6, 0, 0),
+                end=datetime.datetime(2022, 8, 2, 7, 0, 0),
+                rrule=Recur(
+                    freq=Frequency.DAILY, until=datetime.datetime(2022, 8, 10, 6, 0, 0)
+                ),
+                exdate=[
+                    datetime.datetime(2022, 8, 3, 6, 0, 0),
+                    datetime.datetime(2022, 8, 4, 6, 0, 0),
+                    datetime.datetime(2022, 8, 6, 6, 0, 0),
+                    datetime.datetime(2022, 8, 7, 6, 0, 0),
+                ],
+            ),
+        ]
+    )
+    events = list(calendar.timeline)
+    assert [(event.start, event.summary) for event in events] == [
+        (datetime.datetime(2022, 8, 2, 6, 0, 0), "Morning exercise"),
+        (datetime.datetime(2022, 8, 5, 6, 0, 0), "Morning exercise"),
+        (datetime.datetime(2022, 8, 8, 6, 0, 0), "Morning exercise"),
+        (datetime.datetime(2022, 8, 9, 6, 0, 0), "Morning exercise"),
+        (datetime.datetime(2022, 8, 10, 6, 0, 0), "Morning exercise"),
+    ]

--- a/tests/testdata/calendar_stream/rrule-exdate.yaml
+++ b/tests/testdata/calendar_stream/rrule-exdate.yaml
@@ -1,0 +1,49 @@
+input: |-
+  BEGIN:VCALENDAR
+  PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+  VERSION:2.0
+  BEGIN:VEVENT
+  DTSTART;VALUE=DATE:20220801
+  DTEND;VALUE=DATE:20220802
+  RRULE:FREQ=MONTHLY;BYMONTHDAY=1
+  EXDATE:20220901,20221001
+  EXDATE:20230101
+  DTSTAMP:20220731T190408Z
+  UID:2b83520vueebk0muv6osv1qci6@google.com
+  SUMMARY:First of the month
+  END:VEVENT
+  END:VCALENDAR
+output:
+  calendars:
+    - prodid: -//hacksw/handcal//NONSGML v1.0//EN
+      version: "2.0"
+      events:
+        - dtstamp: "2022-07-31T19:04:08+00:00"
+          uid: 2b83520vueebk0muv6osv1qci6@google.com
+          dtstart: "2022-08-01"
+          dtend: "2022-08-02"
+          exdates:
+            - "2022-09-01"
+            - "2022-10-01"
+            - "2023-01-01"
+          summary: First of the month
+          rrule:
+            freq: MONTHLY
+            by_month_day:
+              - 1
+encoded: |-
+  BEGIN:VCALENDAR
+  PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+  VERSION:2.0
+  BEGIN:VEVENT
+  DTSTAMP:20220731T190408Z
+  UID:2b83520vueebk0muv6osv1qci6@google.com
+  DTSTART:20220801
+  DTEND:20220802
+  SUMMARY:First of the month
+  EXDATE:20220901
+  EXDATE:20221001
+  EXDATE:20230101
+  RRULE:FREQ=MONTHLY;BYMONTHDAY=1
+  END:VEVENT
+  END:VCALENDAR


### PR DESCRIPTION
Add support for EXDATE recurrence rule date exclusions. This also cleans up how repeated lists of items are handled to be done generically, inferred based on the type in the main root validator, rather than in a separate validator for each field.