### PR TITLE
Add tests for date and time parsing

### DIFF
--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable, Iterator
 
 from dateutil import rrule
 
-from .event import Event
+from .event import Event, normalize_datetime
 from .types import Frequency, Recur, Weekday
 
 _LOGGER = logging.getLogger(__name__)
@@ -60,11 +60,22 @@ class Timeline(Iterable[Event]):
 
     def start_after(
         self,
-        instant: datetime.date | datetime.datetime,
+        instant: datetime.datetime | datetime.date,
     ) -> Iterator[Event]:
         """Return an iterator containing events starting after the specified time."""
+        instant_value = normalize_datetime(instant)
         for event in self:
-            if event.start > instant:
+            if event.start_datetime > instant_value:
+                yield event
+
+    def active_after(
+        self,
+        instant: datetime.datetime | datetime.date,
+    ) -> Iterator[Event]:
+        """Return an iterator containing events active after the specified time."""
+        instant_value = normalize_datetime(instant)
+        for event in self:
+            if event.start_datetime > instant or event.end_datetime > instant_value:
                 yield event
 
     def at_instant(

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -104,6 +104,14 @@ def test_start_after(calendar: Calendar) -> None:
     ] == ["second", "third", "fourth"]
 
 
+def test_active_after(calendar: Calendar) -> None:
+    """Test chronological iteration starting at a specific time."""
+    assert [
+        e.summary
+        for e in calendar.timeline.start_after(datetime.datetime(2000, 1, 1, 12, 0, 0))
+    ] == ["second", "third", "fourth"]
+
+
 @pytest.mark.parametrize(
     "at_datetime,expected_events",
     [

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -277,3 +277,67 @@ def test_date_intersects(
     event1 = Event(summary=SUMMARY, start=range1[0], end=range1[1])
     event2 = Event(summary=SUMMARY, start=range2[0], end=range2[1])
     assert event1.intersects(event2) == expected
+
+
+@pytest.mark.parametrize(
+    "start_str,end_str,start,end",
+    [
+        (
+            "2022-09-16 12:00",
+            "2022-09-16 12:30",
+            datetime(2022, 9, 16, 12, 0, 0),
+            datetime(2022, 9, 16, 12, 30, 0),
+        ),
+        (
+            "2022-09-16",
+            "2022-09-17",
+            date(2022, 9, 16),
+            date(2022, 9, 17),
+        ),
+        (
+            "2022-09-16 06:00",
+            "2022-09-17 08:30",
+            datetime(2022, 9, 16, 6, 0, 0),
+            datetime(2022, 9, 17, 8, 30, 0),
+        ),
+        (
+            "2022-09-16T06:00",
+            "2022-09-17T08:30",
+            datetime(2022, 9, 16, 6, 0, 0),
+            datetime(2022, 9, 17, 8, 30, 0),
+        ),
+        (
+            "2022-09-16T06:00Z",
+            "2022-09-17T08:30Z",
+            datetime(2022, 9, 16, 6, 0, 0, tzinfo=timezone.utc),
+            datetime(2022, 9, 17, 8, 30, 0, tzinfo=timezone.utc),
+        ),
+        (
+            "2022-09-16T06:00+00:00",
+            "2022-09-17T08:30+00:00",
+            datetime(2022, 9, 16, 6, 0, 0, tzinfo=timezone.utc),
+            datetime(2022, 9, 17, 8, 30, 0, tzinfo=timezone.utc),
+        ),
+        (
+            "2022-09-16T06:00-07:00",
+            "2022-09-17T08:30-07:00",
+            datetime(2022, 9, 16, 6, 0, 0, tzinfo=timezone(offset=timedelta(hours=-7))),
+            datetime(
+                2022, 9, 17, 8, 30, 0, tzinfo=timezone(offset=timedelta(hours=-7))
+            ),
+        ),
+    ],
+)
+def test_parse_event_timezones(
+    start_str: str, end_str: str, start: datetime | date, end: datetime | date
+) -> None:
+    """Test parsing date/times from strings."""
+    event = Event.parse_obj(
+        {
+            "summary": SUMMARY,
+            "start": start_str,
+            "end": end_str,
+        }
+    )
+    assert event.start == start
+    assert event.end == end


### PR DESCRIPTION
Update comparsions for date values to use local timezone when comparing against times. Fixes normalization to use a shared function.
Add tests for date and time parsing, acting as examples for API usage.
