### PR TITLE
Improvements to parsing for all native python objects

### DIFF
--- a/ical/types.py
+++ b/ical/types.py
@@ -120,6 +120,8 @@ class Geo:
     @classmethod
     def parse_geo(cls, value: Any) -> Geo:
         """Parse a rfc5545 lat long geo values."""
+        if isinstance(value, dict):
+            return Geo(**value)
         parts = parse_text(value).split(";", 2)
         if len(parts) != 2:
             raise ValueError(f"Value was not valid geo lat;long: {value}")
@@ -264,10 +266,10 @@ def encode_duration_ics(value: Any) -> str:
     return "".join(parts)
 
 
-def parse_text(prop: ParsedProperty) -> str:
+def parse_text(prop: Any) -> str:
     """Parse a rfc5545 into a text value."""
     if not isinstance(prop, ParsedProperty):
-        raise ValueError("Text value was not a ParsedProperty")
+        return str(prop)
     for key, vin in UNESCAPE_CHAR.items():
         if key not in prop.value:
             continue
@@ -284,18 +286,30 @@ def encode_text(value: str) -> str:
     return value
 
 
-def parse_int(prop: ParsedProperty) -> int:
+def parse_int(prop: Any) -> int:
     """Parse a rfc5545 property into a text value."""
-    return int(prop.value)
+    if isinstance(prop, int):
+        return prop
+    if isinstance(prop, ParsedProperty):
+        return int(prop.value)
+    if isinstance(prop, str):
+        return int(prop)
+    raise ValueError("Int was not ParsedProperty or string: %s")
 
 
-def parse_float(prop: ParsedProperty) -> float:
+def parse_float(prop: Any) -> float:
     """Parse a rfc5545 property into a text value."""
-    return float(prop.value)
+    if isinstance(prop, ParsedProperty):
+        return float(prop.value)
+    if isinstance(prop, str):
+        return float(prop)
+    raise ValueError("Float was not ParsedProperty or string")
 
 
-def parse_boolean(prop: ParsedProperty) -> bool:
+def parse_boolean(prop: Any) -> bool:
     """Parse an rfc5545 property into a boolean."""
+    if not isinstance(prop, ParsedProperty):
+        return bool(prop)
     if prop.value == "TRUE":
         return True
     if prop.value == "FALSE":

--- a/ical/types.py
+++ b/ical/types.py
@@ -288,33 +288,30 @@ def encode_text(value: str) -> str:
 
 def parse_int(prop: Any) -> int:
     """Parse a rfc5545 property into a text value."""
-    if isinstance(prop, int):
-        return prop
     if isinstance(prop, ParsedProperty):
         return int(prop.value)
-    if isinstance(prop, str):
-        return int(prop)
-    raise ValueError("Int was not ParsedProperty or string: %s")
+    return int(prop)
 
 
 def parse_float(prop: Any) -> float:
     """Parse a rfc5545 property into a text value."""
     if isinstance(prop, ParsedProperty):
         return float(prop.value)
-    if isinstance(prop, str):
-        return float(prop)
-    raise ValueError("Float was not ParsedProperty or string")
+    return float(prop)
 
 
 def parse_boolean(prop: Any) -> bool:
     """Parse an rfc5545 property into a boolean."""
-    if not isinstance(prop, ParsedProperty):
-        return bool(prop)
-    if prop.value == "TRUE":
+    if isinstance(prop, bool):
+        return prop
+    value = prop
+    if isinstance(prop, ParsedProperty):
+        value = prop.value
+    if value == "TRUE":
         return True
-    if prop.value == "FALSE":
+    if value == "FALSE":
         return False
-    raise ValueError(f"Invalid boolean value: {prop.value}")
+    raise ValueError(f"Unable to parse value as boolean: {prop}")
 
 
 def encode_boolean_ics(value: bool) -> str:

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -15,6 +15,13 @@ def test_parse(golden: GoldenTestFixture) -> None:
     data = json.loads(cal.json(exclude_unset=True))
     assert data == golden["output"]
 
+    # Re-parse the data object to verify we get the original data values
+    # back. This effectively confirms that all fields can be parsed from the
+    # python native format in addition to rfc5545.
+    cal_reparsed = CalendarStream.parse_obj(data)
+    data_reparsed = json.loads(cal_reparsed.json(exclude_unset=True))
+    assert data_reparsed == data
+
 
 @pytest.mark.golden_test("testdata/*.yaml")
 def test_serialize(golden: GoldenTestFixture) -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -335,6 +335,12 @@ def test_bool() -> None:
     with pytest.raises(ValidationError):
         TestModel.parse_obj({"example": [ParsedProperty(name="example", value="efd")]})
 
+    # Populate based on bool object
+    model = TestModel(example=True)
+    assert model.example
+    model = TestModel(example=False)
+    assert not model.example
+
 
 @pytest.mark.parametrize(
     "value,duration,encoded_value",
@@ -428,6 +434,9 @@ def test_float() -> None:
 
     with pytest.raises(ValidationError):
         TestModel.parse_obj({"example": [ParsedProperty(name="example", value="a")]})
+
+    model = TestModel(example=[1, -2.2, 3.5])
+    assert model.example == [1, -2.2, 3.5]
 
 
 def test_period() -> None:


### PR DESCRIPTION
Improvements to parsing for all native python objects by allowing parsers to accept either a ParsedPropertyValue or the python value of an appropriate type.

Add a test that verifies a successful round trip parse from the output data objects.