### PR TITLE
Implement additional properties for VTODO and VALARM components

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,11 +4,7 @@ This captures known parts of rfc5545 that are currently missing, mostly as a
 TODO tracker so they are not forgotten. This is not meant to be fully exhaustive.
 
 - Testing example (e.g. using shared fixtures)
-- Ignore and preserve x-comp and iana-comp values unrecognized
-- Complete todo properties
-- Complete vevent properties
 - Reduce visibility of internal parsers (e.g. contentlines)
-- Encoding escaped characters in property values (e.g. commas)
 - Unknown components (fix extra field parsing)
 - Accessing non-formatting property parameters
 - Serializing property parameters
@@ -26,6 +22,9 @@ TODO tracker so they are not forgotten. This is not meant to be fully exhaustive
 - Recurrence timezone formattings
 - Recurrence datetime field encoded properly
 - Ignore and preserve unsupported Recurrence rules
+- Attendee parameters, e.g.
+    ATTENDEE;PARTSTAT=ACCEPTED:mailto:jqpublic@example.com
+    ATTENDEE:mailto:jqpublic@example.com
 
 - Components
   - Event

--- a/TODO.md
+++ b/TODO.md
@@ -26,12 +26,14 @@ TODO tracker so they are not forgotten. This is not meant to be fully exhaustive
     ATTENDEE;PARTSTAT=ACCEPTED:mailto:jqpublic@example.com
     ATTENDEE:mailto:jqpublic@example.com
 
+- Related TO:
+    - VTODO can be related to VTODO or VEVENT
+
 - Components
   - Event
     -- multiple
     - attach
     - related
-  - todo
   - journal
   - free/busy
   - time zone

--- a/ical/alarm.py
+++ b/ical/alarm.py
@@ -62,34 +62,30 @@ class Alarm(ComponentModel):
     # - attach
 
     @root_validator
-    def parse_audio_required_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Validate required fields for audio actions."""
-        if values["action"] != ACTION_AUDIO:
-            return values
-        if not values.get("trigger"):
-            raise ValueError("Trigger value is required for action AUDIO")
-        return values
-
-    @root_validator
     def parse_display_required_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate required fields for display actions."""
-        if values["action"] != ACTION_DISPLAY:
+        if values.get("action") != ACTION_DISPLAY:
             return values
         if not values.get("description"):
             raise ValueError("Description value is required for action AUDIO")
-        if not values.get("trigger"):
-            raise ValueError("Trigger value is required for action AUDIO")
         return values
 
     @root_validator
     def parse_email_required_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate required fields for email actions."""
-        if values["action"] != ACTION_EMAIL:
+        if values.get("action") != ACTION_EMAIL:
             return values
         if not values.get("description"):
             raise ValueError("Description value is required for action AUDIO")
-        if not values.get("trigger"):
-            raise ValueError("Trigger value is required for action AUDIO")
         if not values.get("summary"):
             raise ValueError("Summary value is required for action AUDIO")
+        return values
+
+    @root_validator
+    def parse_repeat_duration(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Assert the relationship between repeat and duration."""
+        if (values.get("duration") is None) != (values.get("repeat") is None):
+            raise ValueError(
+                "Duration and Repeat must both be specified or both omitted"
+            )
         return values

--- a/ical/alarm.py
+++ b/ical/alarm.py
@@ -1,0 +1,95 @@
+"""Alarm information for calendar components."""
+
+import datetime
+from typing import Any, Optional, Union
+
+from pydantic import Field, root_validator
+
+from .parsing.property import ParsedProperty
+from .types import CalAddress, ComponentModel
+
+# Common values for an Alarm action
+ACTION_AUDIO = "ACTION"
+ACTION_DISPLAY = "DISPLAY"
+ACTION_EMAIL = "EMAIL"
+
+
+class Alarm(ComponentModel):
+    """An alarm component for a calendar.
+
+    The action (e.g. "AUDIO", "DISPLAY", "EMAIL" or something else) determine
+    which properties are also specified.
+    """
+
+    action: str
+    """Action to be taken when the alarm is triggered."""
+
+    trigger: Union[datetime.timedelta, datetime.datetime]
+    """May be either a relative time or absolute time."""
+
+    duration: Optional[datetime.timedelta] = None
+    """A duration in time for the alarm.
+
+    If duration is specified then repeat must also be specified.
+    """
+
+    repeat: Optional[int] = None
+    """The number of times an alarm should be repeated.
+
+    If repeate is specified then duration must also be specified.
+    """
+
+    #
+    # Properties for DISPLAY and EMAIL actions
+    #
+
+    description: Optional[str] = None
+    """A description of the notification or email body."""
+
+    #
+    # Properties for EMAIL actions
+    #
+
+    summary: Optional[str] = None
+    """A summary for the email action."""
+
+    attendees: list[CalAddress] = Field(alias="attendee", default_factory=list)
+    """Email recipients for the alarm."""
+
+    extras: list[ParsedProperty] = Field(default_factory=list)
+
+    # Future properties:
+    # - attach
+
+    @root_validator
+    def parse_audio_required_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate required fields for audio actions."""
+        if values["action"] != ACTION_AUDIO:
+            return values
+        if not values.get("trigger"):
+            raise ValueError("Trigger value is required for action AUDIO")
+        return values
+
+    @root_validator
+    def parse_display_required_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate required fields for display actions."""
+        if values["action"] != ACTION_DISPLAY:
+            return values
+        if not values.get("description"):
+            raise ValueError("Description value is required for action AUDIO")
+        if not values.get("trigger"):
+            raise ValueError("Trigger value is required for action AUDIO")
+        return values
+
+    @root_validator
+    def parse_email_required_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate required fields for email actions."""
+        if values["action"] != ACTION_EMAIL:
+            return values
+        if not values.get("description"):
+            raise ValueError("Description value is required for action AUDIO")
+        if not values.get("trigger"):
+            raise ValueError("Trigger value is required for action AUDIO")
+        if not values.get("summary"):
+            raise ValueError("Summary value is required for action AUDIO")
+        return values

--- a/ical/event.py
+++ b/ical/event.py
@@ -9,10 +9,10 @@ from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator, validator
 
+from .alarm import Alarm
 from .parsing.property import ParsedProperty
 from .types import (
     CalAddress,
-    Classification,
     ComponentModel,
     EventStatus,
     Geo,
@@ -76,7 +76,7 @@ class Event(ComponentModel):
 
     attendees: list[CalAddress] = Field(alias="attendee", default_factory=list)
     categories: list[str] = Field(default_factory=list)
-    classification: Optional[Classification] = Field(alias="class", default=None)
+    classification: Optional[str] = Field(alias="class", default=None)
     comment: list[str] = Field(default_factory=list)
     contacts: list[str] = Field(alias="contact", default_factory=list)
     created: Optional[datetime.datetime] = None
@@ -97,7 +97,9 @@ class Event(ComponentModel):
     resources: list[str] = Field(default_factory=list)
     rrule: Optional[Recur] = None
     rdate: list[Union[datetime.datetime, datetime.date]] = Field(default_factory=list)
-    request_status: Optional[RequestStatus] = Field(alias="request-status")
+    request_status: Optional[RequestStatus] = Field(
+        alias="request-status", default_value=None
+    )
     sequence: Optional[int] = None
     status: Optional[EventStatus] = None
     transparency: Optional[str] = Field(alias="transp", default=None)
@@ -105,6 +107,8 @@ class Event(ComponentModel):
 
     # Unknown or unsupported properties
     extras: list[ParsedProperty] = Field(default_factory=list)
+
+    alarm: list[Alarm] = Field(alias="valarm", default_factory=list)
 
     # Other properties needed:
     # -- multiple

--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -9,8 +9,9 @@ from collections.abc import Iterable, Iterator
 
 from dateutil import rrule
 
-from .event import Event, normalize_datetime
+from .event import Event
 from .types import Frequency, Recur, Weekday
+from .util import normalize_datetime
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/ical/types.py
+++ b/ical/types.py
@@ -608,7 +608,6 @@ class PropertyDataType(enum.Enum):
     # Types to support
     #   BINARY
     #   PERIOD
-    #   RECUR
     #   TIME
     BOOLEAN = ("BOOLEAN", bool, parse_boolean, encode_boolean_ics)
     CAL_ADDRESS = ("CAL-ADDRESS", CalAddress, CalAddress.parse, str)
@@ -708,7 +707,7 @@ def _validate_field(value: Any, validators: list[Callable[[Any], Any]]) -> Any:
                 f"Property parameter specified unsupported type: {value_type}"
             )
         return data_type.decode(value)
-    _LOGGER.info("_validate_field: %s", value)
+
     for validator in validators:
         try:
             return validator(value)

--- a/ical/types.py
+++ b/ical/types.py
@@ -273,9 +273,15 @@ def parse_duration(prop: ParsedProperty) -> datetime.timedelta:
 
 def encode_duration_ics(value: Any) -> str:
     """Serialize a time delta as a DURATION ICS value."""
-    if not isinstance(value, float):
-        raise ValueError("Unexpected value type")
-    duration = datetime.timedelta(seconds=value)
+    duration: datetime.timedelta
+    if isinstance(value, str):
+        return value  # Already encoded as ics
+    if isinstance(value, datetime.timedelta):
+        duration = value
+    elif isinstance(value, float):
+        duration = datetime.timedelta(seconds=value)
+    else:
+        raise ValueError(f"Unexpected value type: {value}")
     parts = []
     if duration < datetime.timedelta(days=0):
         parts.append("-")
@@ -702,7 +708,7 @@ def _validate_field(value: Any, validators: list[Callable[[Any], Any]]) -> Any:
                 f"Property parameter specified unsupported type: {value_type}"
             )
         return data_type.decode(value)
-
+    _LOGGER.info("_validate_field: %s", value)
     for validator in validators:
         try:
             return validator(value)

--- a/ical/util.py
+++ b/ical/util.py
@@ -1,0 +1,35 @@
+"""Utility methods used by multiple components."""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+
+MIDNIGHT = datetime.time()
+
+
+def dtstamp_factory() -> datetime.datetime:
+    """Factory method for new event timestamps to facilitate mocking."""
+    return datetime.datetime.utcnow()
+
+
+def uid_factory() -> str:
+    """Factory method for new uids to facilitate mocking."""
+    return str(uuid.uuid1())
+
+
+def local_timezone() -> datetime.tzinfo:
+    """Get the local timezone to use when converting date to datetime."""
+    local_tz = datetime.datetime.now().astimezone().tzinfo
+    if not local_tz:
+        return datetime.timezone.utc
+    return local_tz
+
+
+def normalize_datetime(value: datetime.date | datetime.datetime) -> datetime.datetime:
+    """Convert date or datetime to a value that can be used for comparison."""
+    if not isinstance(value, datetime.datetime):
+        value = datetime.datetime.combine(value, MIDNIGHT)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=local_timezone())
+    return value

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -1,0 +1,93 @@
+"""Tests for Alarm component."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from ical.alarm import Alarm
+
+
+def test_todo() -> None:
+    """Test a valid Alarm."""
+    alarm = Alarm(action="AUDIO", trigger=datetime.timedelta(minutes=-5))
+    assert alarm.action == "AUDIO"
+    assert alarm.trigger == datetime.timedelta(minutes=-5)
+    assert not alarm.duration
+    assert not alarm.repeat
+
+
+def test_duration_and_repeat() -> None:
+    """Test relationship between the duration and repeat fields."""
+
+    alarm = Alarm(
+        action="AUDIO",
+        trigger=datetime.timedelta(minutes=-5),
+        duration=datetime.timedelta(seconds=30),
+        repeat=2,
+    )
+    assert alarm.action
+    assert alarm.trigger
+    assert alarm.duration
+    assert alarm.repeat == 2
+
+    # Duration but no repeat
+    with pytest.raises(ValidationError):
+        Alarm(
+            action="AUDIO",
+            trigger=datetime.timedelta(minutes=-5),
+            duration=datetime.timedelta(seconds=30),
+        )
+
+    # Repeat but no duration
+    with pytest.raises(ValidationError):
+        Alarm(action="AUDIO", trigger=datetime.timedelta(minutes=-5), repeat=2)
+
+
+def test_display_required_fields() -> None:
+    """Test required fields for action DISPLAY."""
+    with pytest.raises(ValidationError):
+        Alarm(action="DISPLAY", trigger=datetime.timedelta(minutes=-5))
+
+    alarm = Alarm(
+        action="DISPLAY",
+        trigger=datetime.timedelta(minutes=-5),
+        description="Notification description",
+    )
+    assert alarm.action == "DISPLAY"
+    assert alarm.description == "Notification description"
+
+
+def test_email_required_fields() -> None:
+    """Test required fields for action EMAIL."""
+    # Missing multiple fields
+    with pytest.raises(ValidationError):
+        Alarm(action="EMAIL", trigger=datetime.timedelta(minutes=-5))
+
+    # Missing summary
+    with pytest.raises(ValidationError):
+        Alarm(
+            action="EMAIL",
+            trigger=datetime.timedelta(minutes=-5),
+            description="Email description",
+        )
+
+    # Missing description
+    with pytest.raises(ValidationError):
+        Alarm(
+            action="EMAIL",
+            trigger=datetime.timedelta(minutes=-5),
+            summary="Email summary",
+        )
+
+    alarm = Alarm(
+        action="DISPLAY",
+        trigger=datetime.timedelta(minutes=-5),
+        description="Email description",
+        summary="Email summary",
+    )
+    assert alarm.action == "DISPLAY"
+    assert alarm.summary == "Email summary"
+    assert alarm.description == "Email description"

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -244,7 +244,7 @@ def mock_uid() -> Generator[str, None, None]:
     """Patch out uuid creation with a fixed value."""
     value = str(uuid.uuid3(uuid.NAMESPACE_DNS, "fixed-name"))
     with patch(
-        "ical.event.uuid.uuid1",
+        "ical.event.uid_factory",
         return_value=value,
     ):
         yield value

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,4 +1,4 @@
-"""Tests for Event components."""
+"""Tests for Event component."""
 
 from __future__ import annotations
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,4 +1,4 @@
-"""Tests for Event library."""
+"""Tests for Event components."""
 
 from __future__ import annotations
 
@@ -359,7 +359,7 @@ def test_parse_event_timezones(
 def test_all_day_timezones() -> None:
     """Test behavior of all day events interacting with timezones."""
     with patch(
-        "ical.event.local_timezone", return_value=zoneinfo.ZoneInfo("America/Regina")
+        "ical.util.local_timezone", return_value=zoneinfo.ZoneInfo("America/Regina")
     ):
         event = Event(summary=SUMMARY, start=date(2022, 8, 1), end=date(2022, 8, 2))
         assert event.start_datetime == datetime(

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,0 +1,47 @@
+"""Tests for Todo components."""
+
+from __future__ import annotations
+
+import datetime
+
+import pytest
+from pydantic import ValidationError
+
+from ical.todo import Todo
+
+
+def test_empty() -> None:
+    """Test that in practice a Todo requires no fields."""
+    todo = Todo()
+    assert not todo.summary
+
+
+def test_todo() -> None:
+    """Test a valid Todo object."""
+    todo = Todo(summary="Example", due=datetime.date(2022, 8, 7))
+    assert todo.summary == "Example"
+    assert todo.due == datetime.date(2022, 8, 7)
+
+
+def test_duration() -> None:
+    """Test relationship between the due and duration fields."""
+
+    todo = Todo(start=datetime.date(2022, 8, 7), duration=datetime.timedelta(days=1))
+    assert todo.start
+    assert todo.duration
+
+    # Both due and Duration can't be set
+    with pytest.raises(ValidationError):
+        Todo(
+            start=datetime.date(2022, 8, 7),
+            duration=datetime.timedelta(days=1),
+            due=datetime.date(2022, 8, 8),
+        )
+
+    # Duration requires start date
+    with pytest.raises(ValidationError):
+        Todo(duration=datetime.timedelta(days=1))
+
+    todo = Todo(start=datetime.date(2022, 8, 7), due=datetime.date(2022, 8, 8))
+    assert todo.start
+    assert todo.due

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import datetime
+import zoneinfo
+from unittest.mock import patch
 
 import pytest
 from pydantic import ValidationError
@@ -45,3 +47,9 @@ def test_duration() -> None:
     todo = Todo(start=datetime.date(2022, 8, 7), due=datetime.date(2022, 8, 8))
     assert todo.start
     assert todo.due
+    assert todo.start_datetime
+
+    with patch(
+        "ical.util.local_timezone", return_value=zoneinfo.ZoneInfo("America/Regina")
+    ):
+        assert todo.start_datetime.isoformat() == "2022-08-07T06:00:00+00:00"

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,4 +1,4 @@
-"""Tests for Todo components."""
+"""Tests for Todo component."""
 
 from __future__ import annotations
 

--- a/tests/testdata/todo.yaml
+++ b/tests/testdata/todo.yaml
@@ -27,8 +27,8 @@ output:
   - version: '2.0'
     prodid: -//hacksw/handcal//NONSGML v1.0//EN
     todos:
-    - uid: 20070313T123432Z-456553@example.com
-      dtstamp: '2007-03-13T12:34:32+00:00'
+    - dtstamp: '2007-03-13T12:34:32+00:00'
+      uid: 20070313T123432Z-456553@example.com
       due: '2007-05-01'
       summary: Submit Quebec Income Tax Return for 2006
       categories:
@@ -49,23 +49,23 @@ encoded: |-
   PRODID:-//hacksw/handcal//NONSGML v1.0//EN
   VERSION:2.0
   BEGIN:VTODO
-  UID:20070313T123432Z-456553@example.com
   DTSTAMP:20070313T123432Z
-  SUMMARY:Submit Quebec Income Tax Return for 2006
-  DUE:20070501
-  CLASS:CONFIDENTIAL
+  UID:20070313T123432Z-456553@example.com
   CATEGORIES:FAMILY
   CATEGORIES:FINANCE
+  CLASS:CONFIDENTIAL
+  DUE:20070501
   STATUS:NEEDS-ACTION
+  SUMMARY:Submit Quebec Income Tax Return for 2006
   END:VTODO
   BEGIN:VTODO
-  UID:20070514T103211Z-123404@example.com
   DTSTAMP:20070514T103211Z
-  SUMMARY:Submit Revised Internet-Draft
+  UID:20070514T103211Z-123404@example.com
+  COMPLETED:20070707T100000Z
   DTSTART:20070514T110000Z
   DUE:20070709T130000Z
-  COMPLETED:20070707T100000Z
   PRIORITY:1
   STATUS:NEEDS-ACTION
+  SUMMARY:Submit Revised Internet-Draft
   END:VTODO
   END:VCALENDAR

--- a/tests/testdata/todo_valarm.yaml
+++ b/tests/testdata/todo_valarm.yaml
@@ -1,0 +1,70 @@
+input: |-
+  BEGIN:VCALENDAR
+  PRODID:-//ABC Corporation//NONSGML My Product//EN
+  VERSION:2.0
+  BEGIN:VTODO
+  DTSTAMP:19980130T134500Z
+  SEQUENCE:2
+  UID:uid4@example.com
+  ORGANIZER:mailto:unclesam@example.com
+  ATTENDEE;PARTSTAT=ACCEPTED:mailto:jqpublic@example.com
+  DUE:19980415T000000
+  STATUS:NEEDS-ACTION
+  SUMMARY:Submit Income Taxes
+  BEGIN:VALARM
+  ACTION:AUDIO
+  TRIGGER:19980403T120000Z
+  ATTACH;FMTTYPE=audio/basic:http://example.com/pub/audio-
+   files/ssbanner.aud
+  REPEAT:4
+  DURATION:PT1H
+  END:VALARM
+  END:VTODO
+  END:VCALENDAR
+output:
+  calendars:
+    - prodid: -//ABC Corporation//NONSGML My Product//EN
+      version: "2.0"
+      todos:
+        - dtstamp: "1998-01-30T13:45:00+00:00"
+          uid: uid4@example.com
+          attendees:
+            - mailto:jqpublic@example.com
+          due: "1998-04-15T00:00:00"
+          organizer: mailto:unclesam@example.com
+          sequence: 2
+          status: NEEDS-ACTION
+          summary: Submit Income Taxes
+          alarms:
+            - action: AUDIO
+              trigger: "1998-04-03T12:00:00+00:00"
+              repeat: 4
+              duration: 3600.0
+              extras:
+                - name: attach
+                  value: http://example.com/pub/audio-files/ssbanner.aud
+                  params:
+                    - name: FMTTYPE
+                      values:
+                        - audio/basic
+encoded: |-
+  BEGIN:VCALENDAR
+  PRODID:-//ABC Corporation//NONSGML My Product//EN
+  VERSION:2.0
+  BEGIN:VTODO
+  DTSTAMP:19980130T134500Z
+  UID:uid4@example.com
+  ATTENDEE:mailto:jqpublic@example.com
+  DUE:19980415T000000
+  ORGANIZER:mailto:unclesam@example.com
+  SEQUENCE:2
+  STATUS:NEEDS-ACTION
+  SUMMARY:Submit Income Taxes
+  BEGIN:VALARM
+  ACTION:AUDIO
+  TRIGGER:19980403T120000Z
+  DURATION:PT1H
+  REPEAT:4
+  END:VALARM
+  END:VTODO
+  END:VCALENDAR


### PR DESCRIPTION
Update additional missing properties for `Todo` components, copying from the existing fields implemented for `Event`. 

Add an implementation of `Alarm` for the `VALARM` component. Supports the fields in the rfc for `AUDIO`, `DISPLAY`, and `EMAIL` actions. Adds validation for required properties that must be set for each action type.