### PR TITLE
Add pydantic model for parsing POSIX TZ strings

### DIFF
--- a/ical/tzif/tz_rule.py
+++ b/ical/tzif/tz_rule.py
@@ -1,0 +1,186 @@
+"""Library for parsing TZ rules.
+
+TZ supports these two formats
+
+No DST: std offset
+  - std: Name of the timezone
+  - offset: Time added to local time to get UTC
+  Example: EST+5
+
+DST: std offset dst [offset],start[/time],end[/time]
+  - dst: Name of the Daylight savings time timezone
+  - offset: Defaults to 1 hour ahead of STD offset if not specified
+  - start & end: Time period when DST is in effect. The start/end have
+    the following formats:
+      Jn: A julian day between 1 and 365 (Feb 29th never counted)
+      n: A julian day between 0 and 364 (Feb 29th is counted in leap years)
+      Mm.w.d:
+          m: Month between 1 and 12
+          d: Between 0 (Sunday) and 6 (Saturday)
+          w: Between 1 and 5. Week 1 is first week d occurs
+      The time field is in hh:mm:ss. The hour can be 167 to -167.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from pydantic import BaseModel, root_validator, validator
+
+_LOGGER = logging.getLogger(__name__)
+
+_ZERO = datetime.timedelta(seconds=0)
+
+
+def _parse_time(value: str) -> str | int:
+    """Convert an offset from [+/-]hh[:mm[:ss]] to a valid timedelta pydantic format."""
+    if not value:
+        return 0
+    parts = value.split(":")
+    if len(parts) < 2:
+        parts.append("00")
+    if len(parts) < 3:
+        parts.append("00")
+    if parts[0].startswith("+"):  # Strip a leading +
+        parts[0] = parts[0][1:]
+    return ":".join(parts)
+
+
+@dataclass
+class RuleDate:
+    """A date referenced in a timezone rule."""
+
+    month: int
+    """A month between 1 and 12."""
+
+    day_of_week: int
+    """A day of the week between 0 (Sunday) and 6 (Saturday)."""
+
+    week_of_month: int
+    """A week number of the month (1 to 5) based on the first occurrence of day_of_week."""
+
+    time: Optional[datetime.time] = None
+    """Time in current local time when the rule goes into effect, defaulting to 02:00:00."""
+
+    _parse_time = validator("time", pre=True, allow_reuse=True)(_parse_time)
+
+    @validator("month", pre=True)
+    def parse_month(cls, value: str) -> str:
+        """Convert a TZ month to an integer."""
+        if not value.startswith("M"):
+            raise ValueError(f"Unexpected month date format missing M prefix: {value}")
+        return value[1:]
+
+
+@dataclass
+class RuleOccurrence:
+    """A TimeZone rule occurrence."""
+
+    name: str
+    """The name of the timezone occurrence e.g. EST."""
+
+    offset: datetime.timedelta
+    """UTC offset for this timezone occurrence (not time added to local time)."""
+
+    _parse_offset = validator("offset", pre=True, allow_reuse=True)(_parse_time)
+
+    @validator("offset")
+    def negate_offset(cls, value: datetime.timedelta) -> datetime.timedelta:
+        """Convert the offset from time added to local time to get UTC to a UTC offset."""
+        return _ZERO - value
+
+
+# RE for matching: std offset dst [offset]
+_OCURRENCE_RE = re.compile(
+    r"^(?P<std>[a-zA-Z]+[-+:0-9]*?)(?P<dst>[a-zA-Z]+[-+0-9]*?)?$"
+)
+_OCURRENCE_SPLIT_RE = re.compile(r"^(?P<name>[a-zA-Z]+)(?P<offset>[-+:0-9]+)?$")
+
+
+def _parse_rule_occurrence(value: str) -> dict[str, Any]:
+    """Rule for parsing a rule occurrence into input for RuleOcurrence."""
+    if not (match := _OCURRENCE_SPLIT_RE.match(value)):
+        raise ValueError(f"Occurrence did not match pattern: {value}")
+    (name, offset) = match.group("name", "offset")
+    if not offset:
+        offset = ""
+    return {"name": name, "offset": offset}
+
+
+def _parse_rule_date(value: str) -> dict[str, Any]:
+    """Rule for parsing a rule occurrence into input for RuleOcurrence."""
+    _LOGGER.debug("_parse_rule_date=%s", value)
+    if "/" in value:
+        (date, time) = value.split("/", maxsplit=2)
+    else:
+        date = value
+        time = None
+    parts = date.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"Rule date had unexpected number of parts: {value}")
+    return {
+        "month": parts[0],
+        "week_of_month": parts[1],
+        "day_of_week": parts[2],
+        "time": time,
+    }
+
+
+class Rule(BaseModel):
+    """A rule for evaluating future timezone transitions."""
+
+    std: RuleOccurrence
+    """An occurrence of a timezone transition for standard time."""
+
+    dst: Optional[RuleOccurrence] = None
+    """An occurrence of a timezone transition for standard time."""
+
+    dst_start: Optional[RuleDate] = None
+    """Describes when dst goes into effect."""
+
+    dst_end: Optional[RuleDate] = None
+    """Describes when dst ends."""
+
+    _parse_std = validator("std", pre=True, allow_reuse=True)(_parse_rule_occurrence)
+    _parse_dst = validator("dst", pre=True, allow_reuse=True)(_parse_rule_occurrence)
+    _parse_dst_start = validator("dst_start", pre=True, allow_reuse=True)(
+        _parse_rule_date
+    )
+    _parse_dst_end = validator("dst_end", pre=True, allow_reuse=True)(_parse_rule_date)
+
+    @root_validator
+    def default_dst_offset(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Infer the default DST offset based on STD offset if not specified."""
+        if values.get("dst") and not values["dst"].offset:
+            # If the dst offset is omitted, it defaults to one hour ahead of standard time.
+            values["dst"].offset = values["std"].offset + datetime.timedelta(hours=1)
+            _LOGGER.info("std offset=%s", values["std"].offset)
+            _LOGGER.info("new dst offset=%s", values["dst"].offset)
+        return values
+
+
+def parse_tz_rule(tz_str: str) -> Rule:
+    """Parse a Rule object from a string."""
+    parts = tz_str.split(",")
+    if len(parts) not in (1, 3):
+        raise ValueError(f"TZ rule had unexpected ',': {tz_str}")
+    match = _OCURRENCE_RE.match(parts[0])
+    if not match:
+        raise ValueError(f"Unable to parse TZ rule occurrence: {tz_str}")
+    result = {
+        "std": match.group("std"),
+    }
+    if dst := match.group("dst"):
+        result["dst"] = dst
+    if len(parts) == 3:
+        result.update(
+            {
+                "dst_start": parts[1],
+                "dst_end": parts[2],
+            }
+        )
+    return Rule.parse_obj(result)

--- a/ical/tzif/tz_rule.py
+++ b/ical/tzif/tz_rule.py
@@ -118,7 +118,7 @@ def _parse_rule_date(value: str) -> dict[str, Any]:
         (date, time) = value.split("/", maxsplit=2)
     else:
         date = value
-        time = None
+        time = "02:00:00"  # If omitted, the default is 02:00:00
     parts = date.split(".")
     if len(parts) != 3:
         raise ValueError(f"Rule date had unexpected number of parts: {value}")

--- a/tests/tzif/test_tz_rule.py
+++ b/tests/tzif/test_tz_rule.py
@@ -1,0 +1,107 @@
+"""Tests for the tzif library."""
+
+import datetime
+
+import pytest
+
+from ical.tzif import tz_rule
+
+
+def test_standard() -> None:
+    """Test standard time with no daylight savings time."""
+    rule = tz_rule.parse_tz_rule("EST5")
+    assert rule.std.name == "EST"
+    assert rule.std.offset == datetime.timedelta(hours=-5)
+    assert rule.dst is None
+    assert rule.dst_start is None
+    assert rule.dst_end is None
+
+
+def test_standard_plus_offset() -> None:
+    """Test standard time with an offset with an explicit plus."""
+    rule = tz_rule.parse_tz_rule("EST+5")
+    assert rule.std.name == "EST"
+    assert rule.std.offset == datetime.timedelta(hours=-5)
+    assert rule.dst is None
+    assert rule.dst_start is None
+    assert rule.dst_end is None
+
+
+def test_hours_minutes_offset() -> None:
+    """Test standard time offset with hours and minutes."""
+    rule = tz_rule.parse_tz_rule("EX05:30")
+    assert rule.std.name == "EX"
+    assert rule.std.offset == datetime.timedelta(hours=-5, minutes=-30)
+    assert rule.dst is None
+    assert rule.dst_start is None
+    assert rule.dst_end is None
+
+
+def test_hours_minutes_seconds_offset() -> None:
+    """Test standard time offset with hours, minutes, and seconds."""
+    rule = tz_rule.parse_tz_rule("EX05:30:20")
+    assert rule.std.name == "EX"
+    assert rule.std.offset == datetime.timedelta(hours=-5, minutes=-30, seconds=-20)
+    assert rule.dst is None
+    assert rule.dst_start is None
+    assert rule.dst_end is None
+
+
+def test_standard_minus_offset() -> None:
+    """Test standard time offset with a negative offset."""
+    rule = tz_rule.parse_tz_rule("JST-9")
+    assert rule.std.name == "JST"
+    assert rule.std.offset == datetime.timedelta(hours=9)
+    assert rule.dst is None
+    assert rule.dst_start is None
+    assert rule.dst_end is None
+
+
+def test_dst_implicit_offset() -> None:
+    """Test daylight savings time with an implicit offset."""
+    rule = tz_rule.parse_tz_rule("EST5EDT")
+    assert rule.std.name == "EST"
+    assert rule.std.offset == datetime.timedelta(hours=-5)
+    assert rule.dst
+    assert rule.dst.name == "EDT"
+    assert rule.dst.offset == datetime.timedelta(hours=-4)
+    assert rule.dst_start is None
+    assert rule.dst_end is None
+
+
+def test_dst_explicit_offset() -> None:
+    """Test standard time with no daylight savings time."""
+    rule = tz_rule.parse_tz_rule("EST5EDT4")
+    assert rule.std.name == "EST"
+    assert rule.std.offset == datetime.timedelta(hours=-5)
+    assert rule.dst
+    assert rule.dst.name == "EDT"
+    assert rule.dst.offset == datetime.timedelta(hours=-4)
+    assert rule.dst_start is None
+    assert rule.dst_end is None
+
+
+def test_daylight_savings() -> None:
+    """Test daylight savings value."""
+    rule = tz_rule.parse_tz_rule("EST+5EDT,M3.2.0/2,M11.1.0/2")
+    assert rule.std.name == "EST"
+    assert rule.std.offset == datetime.timedelta(hours=-5)
+    assert rule.dst
+    assert rule.dst.name == "EDT"
+    assert rule.dst.offset == datetime.timedelta(hours=-4)
+    assert rule.dst_start
+    assert rule.dst_start.month == 3
+    assert rule.dst_start.week_of_month == 2
+    assert rule.dst_start.day_of_week == 0
+    assert rule.dst_start.time == datetime.time(2, 0, 0)
+    assert rule.dst_end
+    assert rule.dst_end.month == 11
+    assert rule.dst_end.week_of_month == 1
+    assert rule.dst_end.day_of_week == 0
+    assert rule.dst_end.time == datetime.time(2, 0, 0)
+
+
+def test_invalid() -> None:
+    """Test an invalid rule occurrence"""
+    with pytest.raises(ValueError):
+        tz_rule.parse_tz_rule("1234")

--- a/tests/tzif/test_tz_rule.py
+++ b/tests/tzif/test_tz_rule.py
@@ -81,8 +81,8 @@ def test_dst_explicit_offset() -> None:
     assert rule.dst_end is None
 
 
-def test_daylight_savings() -> None:
-    """Test daylight savings value."""
+def test_dst_rules() -> None:
+    """Test daylight savings start/end value."""
     rule = tz_rule.parse_tz_rule("EST+5EDT,M3.2.0/2,M11.1.0/2")
     assert rule.std.name == "EST"
     assert rule.std.offset == datetime.timedelta(hours=-5)
@@ -101,7 +101,39 @@ def test_daylight_savings() -> None:
     assert rule.dst_end.time == datetime.time(2, 0, 0)
 
 
-def test_invalid() -> None:
+def test_dst_implement_time_rules() -> None:
+    """Test daylight savings values rules with no explicit time."""
+    rule = tz_rule.parse_tz_rule("EST+5EDT,M3.2.0,M11.1.0")
+    assert rule.std.name == "EST"
+    assert rule.std.offset == datetime.timedelta(hours=-5)
+    assert rule.dst
+    assert rule.dst.name == "EDT"
+    assert rule.dst.offset == datetime.timedelta(hours=-4)
+    assert rule.dst_start
+    assert rule.dst_start.month == 3
+    assert rule.dst_start.week_of_month == 2
+    assert rule.dst_start.day_of_week == 0
+    assert rule.dst_start.time == datetime.time(2, 0, 0)
+    assert rule.dst_end
+    assert rule.dst_end.month == 11
+    assert rule.dst_end.week_of_month == 1
+    assert rule.dst_end.day_of_week == 0
+    assert rule.dst_end.time == datetime.time(2, 0, 0)
+
+
+@pytest.mark.parametrize(
+    "tz_string,match",
+    [
+        ("", "Unable to parse TZ rule occurrence"),
+        ("1234", "Unable to parse TZ rule occurrence"),
+        ("EST+5EDT,M3.2.0/2", "TZ rule had unexpected ','"),
+        ("EST+5EDT,M3.2.0/2,M11.1.0/2,M3", "TZ rule had unexpected ','"),
+        ("EST+5EDT,3.2.0/2,M11.1.0/2", "missing M prefix"),
+        ("EST+5EDT,M3.2/2,M11.1.0/2", "Rule date had unexpected number of parts"),
+        ("EST+5EDT,M3.2.0.4/2,M11.1.0/2", "Rule date had unexpected number of parts"),
+    ],
+)
+def test_invalid(tz_string: str, match: str) -> None:
     """Test an invalid rule occurrence"""
-    with pytest.raises(ValueError):
-        tz_rule.parse_tz_rule("1234")
+    with pytest.raises(ValueError, match=match):
+        tz_rule.parse_tz_rule(tz_string)


### PR DESCRIPTION
Add pydantic model for parsing POSIX TZ strings, which specify a go forward recurrence rule for timezones.

The primary source of logic is https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html as well as the version 3 extensions in https://datatracker.ietf.org/doc/html/rfc8536#section-3.3.1