### PR TITLE
Add a tzinfo implementation for v3 tzif data.

### DIFF
--- a/ical/tzif/model.py
+++ b/ical/tzif/model.py
@@ -24,7 +24,7 @@ class Transition:
     """Determines if the transition time is standard time (else, wall clock time)."""
 
     isutccnt: bool
-    """Determines if the transition time is UCT time, else is a local time."""
+    """Determines if the transition time is UTC time, else is a local time."""
 
     designation: str
     """A designation string."""

--- a/ical/tzif/timezoneinfo.py
+++ b/ical/tzif/timezoneinfo.py
@@ -16,7 +16,7 @@ from functools import cache
 from importlib import resources
 
 from .model import TimezoneInfo
-from .tz_rule import Rule
+from .tz_rule import Rule, RuleDate
 from .tzif import read_tzif
 
 _LOGGER = logging.getLogger(__name__)
@@ -115,7 +115,7 @@ class TzInfo(datetime.tzinfo):
     @classmethod
     def from_timezoneinfo(cls, timezoneinfo: TimezoneInfo) -> TzInfo:
         """Create a new instance of a TzInfo."""
-        if not timezoneinfo.rule or not timezoneinfo.rule.std:
+        if not timezoneinfo.rule:
             raise ValueError("Unable to make TzInfo from TimezoneInfo, missing rule")
         return cls(timezoneinfo.rule)
 
@@ -141,8 +141,8 @@ class TzInfo(datetime.tzinfo):
         if (
             dt is None
             or not self._rule.dst
-            or not self._rule.dst_start
-            or not self._rule.dst_end
+            or not isinstance(self._rule.dst_start, RuleDate)
+            or not isinstance(self._rule.dst_end, RuleDate)
             or not self._rule.dst.offset
         ):
             return None

--- a/ical/tzif/tz_rule.py
+++ b/ical/tzif/tz_rule.py
@@ -46,10 +46,14 @@ _LOGGER = logging.getLogger(__name__)
 _ZERO = datetime.timedelta(seconds=0)
 
 
-def _parse_time(values: dict[str, Any]) -> str | int:
+def _parse_time(values: Any) -> int | str:
     """Convert an offset from [+/-]hh[:mm[:ss]] to a valid timedelta pydantic format."""
     if not values:
         return 0
+    if not isinstance(values, dict):
+        if isinstance(values, (int, str)):
+            return values
+        raise ValueError("time was not dict, string, or int")
     hour = values["hour"]
     sign = 1
     if hour.startswith("+"):

--- a/ical/tzif/tz_rule.py
+++ b/ical/tzif/tz_rule.py
@@ -46,14 +46,17 @@ _LOGGER = logging.getLogger(__name__)
 _ZERO = datetime.timedelta(seconds=0)
 
 
-def _parse_time(values: Any) -> int | str:
-    """Convert an offset from [+/-]hh[:mm[:ss]] to a valid timedelta pydantic format."""
+def _parse_time(values: Any) -> int | str | datetime.timedelta:
+    """Convert an offset from [+/-]hh[:mm[:ss]] to a valid timedelta pydantic format.
+
+    The parse tree dict expects fields of hour, minutes, seconds (see tz_time rule in parser).
+    """
     if not values:
         return 0
+    if isinstance(values, (int, str, datetime.timedelta)):
+        return values
     if not isinstance(values, dict):
-        if isinstance(values, (int, str)):
-            return values
-        raise ValueError("time was not dict, string, or int")
+        raise ValueError("time was not parse tree dict, timedelta, string, or int")
     hour = values["hour"]
     sign = 1
     if hour.startswith("+"):

--- a/tests/tzif/test_timezoneinfo.py
+++ b/tests/tzif/test_timezoneinfo.py
@@ -1,5 +1,6 @@
 """Tests for the tzif library."""
 
+import datetime
 import zoneinfo
 
 import pytest
@@ -14,6 +15,82 @@ def test_invalid_zoneinfo() -> None:
         timezoneinfo.read("invalid")
 
 
+@pytest.mark.parametrize(
+    "key,dtstarts,expected_tzname,expected_offset",
+    [
+        (
+            "America/Los_Angeles",
+            [
+                datetime.datetime(2021, 3, 14, 1, 59, 0),
+                datetime.datetime(2021, 11, 7, 2, 0, 0),
+                datetime.datetime(2022, 3, 13, 1, 59, 0),
+                datetime.datetime(2022, 11, 6, 2, 0, 0),
+                datetime.datetime(2023, 3, 12, 1, 59, 0),
+                datetime.datetime(2023, 11, 5, 2, 0, 0),
+            ],
+            "PST",
+            datetime.timedelta(hours=-8),
+        ),
+        (
+            "America/Los_Angeles",
+            [
+                datetime.datetime(2021, 3, 14, 2, 0, 0),
+                datetime.datetime(2021, 11, 7, 1, 59, 0),
+                datetime.datetime(2022, 3, 13, 2, 0, 0),
+                datetime.datetime(2022, 11, 6, 1, 59, 0),
+                datetime.datetime(2023, 3, 12, 2, 0, 0),
+                datetime.datetime(2023, 11, 5, 1, 59, 0),
+            ],
+            "PDT",
+            datetime.timedelta(hours=-7),
+        ),
+        (
+            "Europe/Warsaw",
+            [
+                datetime.datetime(2021, 3, 28, 1, 59, 0),
+                datetime.datetime(2021, 10, 31, 3, 0, 0),
+                datetime.datetime(2022, 3, 27, 1, 59, 0),
+                datetime.datetime(2022, 10, 30, 3, 0, 0),
+                datetime.datetime(2023, 3, 26, 1, 59, 0),
+                datetime.datetime(2023, 10, 29, 3, 0, 0),
+                datetime.datetime(2024, 3, 31, 1, 59, 0),
+                datetime.datetime(2024, 10, 27, 3, 0, 0),
+            ],
+            "CET",
+            datetime.timedelta(hours=1),
+        ),
+        (
+            "Europe/Warsaw",
+            [
+                datetime.datetime(2021, 3, 28, 2, 0, 0),
+                datetime.datetime(2021, 10, 31, 2, 59, 0),
+                datetime.datetime(2022, 3, 27, 2, 0, 0),
+                datetime.datetime(2022, 10, 30, 2, 59, 0),
+                datetime.datetime(2023, 3, 26, 2, 0, 0),
+                datetime.datetime(2023, 10, 29, 2, 59, 0),
+                datetime.datetime(2024, 3, 31, 2, 0, 0),
+                datetime.datetime(2024, 10, 27, 2, 59, 0),
+            ],
+            "CEST",
+            datetime.timedelta(hours=2),
+        ),
+    ],
+)
+def test_tzinfo(
+    key: str,
+    dtstarts: list[datetime.datetime],
+    expected_tzname: str,
+    expected_offset: datetime.timedelta,
+) -> None:
+    """Test TzInfo implementation for known date/times."""
+    result = timezoneinfo.read(key)
+    tz_info = timezoneinfo.TzInfo.from_timezoneinfo(result)
+    for dtstart in dtstarts:
+        value = dtstart.replace(tzinfo=tz_info)
+        assert tz_info.tzname(value) == expected_tzname, f"For {dtstart}"
+        assert tz_info.utcoffset(value) == expected_offset, f"For {dtstart}"
+
+
 @pytest.mark.parametrize("key", zoneinfo.available_timezones())
 def test_all_zoneinfo(key: str) -> None:
     """Verify that all available timezones in the system have valid tzdata."""
@@ -21,3 +98,21 @@ def test_all_zoneinfo(key: str) -> None:
         return
     result = timezoneinfo.read(key)
     assert result.rule or result.transitions or result.leap_seconds
+
+    # Iran uses julian dates, not yet supported. Iran TZ rules have changed
+    # such that it no longer observes DST anyway
+    if key in ("Asia/Tehran", "Iran"):
+        return
+
+    assert result.rule
+    if result.rule.dst_start:
+        assert result.rule.dst_end
+        # Verify a rule can be constructed
+        assert next(iter(result.rule.dst_start.as_rrule()))
+        assert next(iter(result.rule.dst_end.as_rrule()))
+    else:
+        # Fixed offset
+        assert result.rule
+        assert result.rule.std
+        assert result.rule.std.name
+        assert not result.rule.dst

--- a/tests/tzif/test_timezoneinfo.py
+++ b/tests/tzif/test_timezoneinfo.py
@@ -74,6 +74,32 @@ def test_invalid_zoneinfo() -> None:
             "CEST",
             datetime.timedelta(hours=2),
         ),
+        (
+            "Asia/Tokyo",
+            [
+                # Fixed offset anytime of year
+                datetime.datetime(2021, 1, 1, 0, 0, 0),
+                datetime.datetime(2022, 3, 1, 0, 0, 0),
+                datetime.datetime(2022, 6, 1, 0, 0, 0),
+                datetime.datetime(2023, 7, 1, 0, 0, 0),
+                datetime.datetime(2023, 12, 1, 0, 0, 0),
+            ],
+            "JST",
+            datetime.timedelta(hours=9),
+        ),
+        (
+            "America/St_Thomas",
+            [
+                # Fixed offset anytime of year
+                datetime.datetime(2021, 1, 1, 0, 0, 0),
+                datetime.datetime(2022, 3, 1, 0, 0, 0),
+                datetime.datetime(2022, 6, 1, 0, 0, 0),
+                datetime.datetime(2023, 7, 1, 0, 0, 0),
+                datetime.datetime(2023, 12, 1, 0, 0, 0),
+            ],
+            "AST",
+            datetime.timedelta(hours=-4),
+        ),
     ],
 )
 def test_tzinfo(
@@ -89,6 +115,10 @@ def test_tzinfo(
         value = dtstart.replace(tzinfo=tz_info)
         assert tz_info.tzname(value) == expected_tzname, f"For {dtstart}"
         assert tz_info.utcoffset(value) == expected_offset, f"For {dtstart}"
+
+    assert not tz_info.utcoffset(None)
+    assert not tz_info.tzname(None)
+    assert not tz_info.dst(None)
 
 
 @pytest.mark.parametrize("key", zoneinfo.available_timezones())
@@ -116,3 +146,6 @@ def test_all_zoneinfo(key: str) -> None:
         assert result.rule.std
         assert result.rule.std.name
         assert not result.rule.dst
+
+    # Verify there is a paresable tz rule
+    timezoneinfo.TzInfo.from_timezoneinfo(result)

--- a/tests/tzif/test_timezoneinfo.py
+++ b/tests/tzif/test_timezoneinfo.py
@@ -121,6 +121,16 @@ def test_tzinfo(
     assert not tz_info.dst(None)
 
 
+def test_rrule_str() -> None:
+    """Test rule implementations for std and dst."""
+    result = timezoneinfo.read("America/New_York")
+    assert result.rule
+    assert result.rule.dst_start
+    assert result.rule.dst_start.rrule_str() == "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU"
+    assert result.rule.dst_end
+    assert result.rule.dst_end.rrule_str() == "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU"
+
+
 @pytest.mark.parametrize("key", zoneinfo.available_timezones())
 def test_all_zoneinfo(key: str) -> None:
     """Verify that all available timezones in the system have valid tzdata."""

--- a/tests/tzif/test_tz_rule.py
+++ b/tests/tzif/test_tz_rule.py
@@ -110,11 +110,13 @@ def test_dst_rules() -> None:
     assert rule.dst.name == "EDT"
     assert rule.dst.offset == datetime.timedelta(hours=-4)
     assert rule.dst_start
+    assert isinstance(rule.dst_start, tz_rule.RuleDate)
     assert rule.dst_start.month == 3
     assert rule.dst_start.week_of_month == 2
     assert rule.dst_start.day_of_week == 0
     assert rule.dst_start.time == datetime.timedelta(hours=2)
     assert rule.dst_end
+    assert isinstance(rule.dst_end, tz_rule.RuleDate)
     assert rule.dst_end.month == 11
     assert rule.dst_end.week_of_month == 1
     assert rule.dst_end.day_of_week == 0
@@ -127,8 +129,8 @@ def test_dst_rules() -> None:
         iter(rule.dst_end.as_rrule(datetime.datetime(2022, 1, 1)))
     ) == datetime.datetime(2022, 11, 6, 2, 0, 0)
 
-    assert rule.dst_start.rrule_str() == "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU"
-    assert rule.dst_end.rrule_str() == "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU"
+    assert rule.dst_start.rrule_str == "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU"
+    assert rule.dst_end.rrule_str == "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU"
 
 
 def test_dst_implement_time_rules() -> None:
@@ -140,11 +142,13 @@ def test_dst_implement_time_rules() -> None:
     assert rule.dst.name == "EDT"
     assert rule.dst.offset == datetime.timedelta(hours=-4)
     assert rule.dst_start
+    assert isinstance(rule.dst_start, tz_rule.RuleDate)
     assert rule.dst_start.month == 3
     assert rule.dst_start.week_of_month == 2
     assert rule.dst_start.day_of_week == 0
     assert rule.dst_start.time == datetime.timedelta(hours=2)
     assert rule.dst_end
+    assert isinstance(rule.dst_end, tz_rule.RuleDate)
     assert rule.dst_end.month == 11
     assert rule.dst_end.week_of_month == 1
     assert rule.dst_end.day_of_week == 0
@@ -178,11 +182,13 @@ def test_tz_offset() -> None:
     assert rule.dst.name == "<-02>"
     assert rule.dst.offset == datetime.timedelta(hours=-2)
     assert rule.dst_start
+    assert isinstance(rule.dst_start, tz_rule.RuleDate)
     assert rule.dst_start.month == 3
     assert rule.dst_start.week_of_month == 5
     assert rule.dst_start.day_of_week == 0
     assert rule.dst_start.time == datetime.timedelta(hours=-2)
     assert rule.dst_end
+    assert isinstance(rule.dst_end, tz_rule.RuleDate)
     assert rule.dst_end.month == 10
     assert rule.dst_end.week_of_month == 5
     assert rule.dst_end.day_of_week == 0
@@ -198,37 +204,13 @@ def test_iran_rule_offset() -> None:
     assert rule.dst.name == "<+0430>"
     assert rule.dst.offset == datetime.timedelta(hours=4, minutes=30)
     assert rule.dst_start
+    assert isinstance(rule.dst_start, tz_rule.RuleDay)
     assert rule.dst_start.day_of_year == 79
     assert rule.dst_start.time == datetime.timedelta(hours=24)
     assert rule.dst_end
+    assert isinstance(rule.dst_end, tz_rule.RuleDay)
     assert rule.dst_end.day_of_year == 263
     assert rule.dst_end.time == datetime.timedelta(hours=24)
-
-
-def test_rrule_required_fields() -> None:
-    """Test validation fields required for rrule."""
-    t_time = datetime.timedelta(hours=4)
-
-    rule_date = tz_rule.RuleDate(month=3, week_of_month=1, day_of_week=0, time=t_time)
-    assert expand_rule(rule_date) == datetime.datetime(2022, 3, 6, 4, 0, 0)
-
-    rule_date = tz_rule.RuleDate(month=3, week_of_month=1, time=t_time)
-    with pytest.raises(ValueError, match="missing day_of_week"):
-        expand_rule(rule_date)
-
-    rule_date = tz_rule.RuleDate(week_of_month=1, day_of_week=0, time=t_time)
-    with pytest.raises(ValueError, match="missing month"):
-        expand_rule(rule_date)
-
-    rule_date = tz_rule.RuleDate(month=3, day_of_week=0, time=t_time)
-    with pytest.raises(ValueError, match="missing week_of_month"):
-        expand_rule(rule_date)
-
-    rule_date = tz_rule.RuleDate(day_of_year=10, time=t_time)
-    with pytest.raises(
-        ValueError, match="Unable to create recurrence rule for julian day rule"
-    ):
-        expand_rule(rule_date)
 
 
 def test_invalid_time() -> None:

--- a/tests/tzif/test_tz_rule.py
+++ b/tests/tzif/test_tz_rule.py
@@ -127,6 +127,9 @@ def test_dst_rules() -> None:
         iter(rule.dst_end.as_rrule(datetime.datetime(2022, 1, 1)))
     ) == datetime.datetime(2022, 11, 6, 2, 0, 0)
 
+    assert rule.dst_start.rrule_str() == "FREQ=YEARLY;BYMONTH=3;BYDAY=2SU"
+    assert rule.dst_end.rrule_str() == "FREQ=YEARLY;BYMONTH=11;BYDAY=1SU"
+
 
 def test_dst_implement_time_rules() -> None:
     """Test daylight savings values rules with no explicit time."""

--- a/tests/tzif/test_tz_rule.py
+++ b/tests/tzif/test_tz_rule.py
@@ -112,6 +112,13 @@ def test_dst_rules() -> None:
     assert rule.dst_end.day_of_week == 0
     assert rule.dst_end.time == datetime.timedelta(hours=2)
 
+    assert next(
+        iter(rule.dst_start.as_rrule(datetime.datetime(2022, 1, 1)))
+    ) == datetime.datetime(2022, 3, 13, 2, 0, 0)
+    assert next(
+        iter(rule.dst_end.as_rrule(datetime.datetime(2022, 1, 1)))
+    ) == datetime.datetime(2022, 11, 6, 2, 0, 0)
+
 
 def test_dst_implement_time_rules() -> None:
     """Test daylight savings values rules with no explicit time."""

--- a/tests/tzif/test_tz_rule.py
+++ b/tests/tzif/test_tz_rule.py
@@ -226,3 +226,16 @@ def test_rrule_required_fields() -> None:
         ValueError, match="Unable to create recurrence rule for julian day rule"
     ):
         expand_rule(rule_date)
+
+
+def test_invalid_time() -> None:
+    """Test validation of fields with an invalid time value."""
+    with pytest.raises(ValueError, match="time was not parse tree dict"):
+        tz_rule.RuleDate.parse_obj(
+            {
+                "month": 3,
+                "week_of_month": 1,
+                "day_of_week": 0,
+                "time": 0.12345,
+            }
+        )


### PR DESCRIPTION
Use a `dateutil.rrule` to implement a `tzinfo` implementation.