### PR TITLE
Add APIs for creating a timezone from a zoneinfo file

### DIFF
--- a/ical/types.py
+++ b/ical/types.py
@@ -737,11 +737,14 @@ def parse_recur(prop: Any) -> dict[str, Any]:
     An input rule like 'FREQ=YEARLY;BYMONTH=4' is converted
     into dictionary.
     """
-    _LOGGER.info("parse_recur=%s", prop)
-    if not isinstance(prop, ParsedProperty):
+    if isinstance(prop, str):
+        value = prop
+    elif not isinstance(prop, ParsedProperty):
         raise ValueError(f"Expected recurrence rule as ParsedProperty: {prop}")
+    else:
+        value = prop.value
     result: dict[str, datetime.datetime | str | list[str] | list[dict[str, str]]] = {}
-    for part in prop.value.split(";"):
+    for part in value.split(";"):
         if "=" not in part:
             raise ValueError(
                 f"Recurrence rule had unexpected format missing '=': {prop.value}"

--- a/ical/tzif/tzif.py
+++ b/ical/tzif/tzif.py
@@ -19,6 +19,7 @@ as a resource for understanding the format. See rfc8536 for TZif file format.
 
 import enum
 import io
+import logging
 import struct
 from collections import namedtuple
 from collections.abc import Callable
@@ -28,6 +29,8 @@ from typing import Sequence
 
 from .model import LeapSecond, TimezoneInfo, Transition
 from .tz_rule import parse_tz_rule
+
+_LOGGER = logging.getLogger(__name__)
 
 # Records specifying the local time type
 _LOCAL_TIME_TYPE_STRUCT_FORMAT = "".join(
@@ -216,23 +219,23 @@ def _read_datablock(
 
     # Standard/wall indicators determine if the transition times are standard time (1)
     # or wall clock time (0).
-    isstdcnt_types: Sequence[bool]
+    isstdcnt_types: list[bool]
     if header.isstdcnt > 0:
-        isstdcnt_types = struct.unpack(
-            f">{header.isstdcnt}?",
-            buf.read(header.isstdcnt),
+        isstdcnt_types = list(
+            struct.unpack(
+                f">{header.isstdcnt}?",
+                buf.read(header.isstdcnt),
+            )
         )
-    else:
-        isstdcnt_types = [False] * header.timecnt
+    isstdcnt_types += [False] * (header.timecnt - header.isstdcnt)
 
     # UTC/local indicators determine if the transition times are UTC (1) or local time (0).
-    isutccnt_types: Sequence[bool]
+    isutccnt_types: list[bool]
     if header.isutccnt > 0:
-        isutccnt_types = struct.unpack(
-            f">{header.isutccnt}?", buf.read(header.isutccnt)
+        isutccnt_types = list(
+            struct.unpack(f">{header.isutccnt}?", buf.read(header.isutccnt))
         )
-    else:
-        isutccnt_types = [False] * header.timecnt
+    isutccnt_types += [False] * (header.timecnt - header.isutccnt)
 
     transitions = [
         _new_transition(

--- a/ical/tzif/tzif.py
+++ b/ical/tzif/tzif.py
@@ -219,23 +219,23 @@ def _read_datablock(
 
     # Standard/wall indicators determine if the transition times are standard time (1)
     # or wall clock time (0).
-    isstdcnt_types: list[bool]
+    isstdcnt_types: list[bool] = []
     if header.isstdcnt > 0:
-        isstdcnt_types = list(
+        isstdcnt_types.extend(
             struct.unpack(
                 f">{header.isstdcnt}?",
                 buf.read(header.isstdcnt),
             )
         )
-    isstdcnt_types += [False] * (header.timecnt - header.isstdcnt)
+    isstdcnt_types.extend([False] * (header.timecnt - header.isstdcnt))
 
     # UTC/local indicators determine if the transition times are UTC (1) or local time (0).
-    isutccnt_types: list[bool]
+    isutccnt_types: list[bool] = []
     if header.isutccnt > 0:
-        isutccnt_types = list(
+        isutccnt_types.extend(
             struct.unpack(f">{header.isutccnt}?", buf.read(header.isutccnt))
         )
-    isutccnt_types += [False] * (header.timecnt - header.isutccnt)
+    isutccnt_types.extend([False] * (header.timecnt - header.isutccnt))
 
     transitions = [
         _new_transition(

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -64,8 +64,8 @@ def test_timezone_observence_start_time_validation() -> None:
 
 
 @freeze_time("2022-08-22 12:30:00")
-def test_from_tzif_timezoneinfo() -> None:
-    """Verify a timezone created from a tzif timezone info."""
+def test_from_tzif_timezoneinfo_with_dst() -> None:
+    """Verify a timezone created from a tzif timezone info with DST information."""
 
     timezone = Timezone.from_tzif("America/New_York")
 
@@ -93,6 +93,34 @@ def test_from_tzif_timezoneinfo() -> None:
        RRULE:FREQ=YEARLY;BYDAY=2SU;BYMONTH=3
        TZNAME:EDT
        END:DAYLIGHT
+       END:VTIMEZONE
+       END:VCALENDAR
+    """
+    )
+
+
+@freeze_time("2022-08-22 12:30:00")
+def test_from_tzif_timezoneinfo_fixed_offset() -> None:
+    """Verify a timezone created from a tzif timezone info with a fixed offset"""
+
+    timezone = Timezone.from_tzif("Asia/Tokyo")
+
+    calendar = Calendar()
+    calendar.timezones.append(timezone)
+
+    stream = IcsCalendarStream(calendars=[calendar])
+    assert stream.ics() == inspect.cleandoc(
+        """
+       BEGIN:VCALENDAR
+       BEGIN:VTIMEZONE
+       DTSTAMP:20220822T123000
+       TZID:Asia/Tokyo
+       BEGIN:STANDARD
+       DTSTART:20100101T000000
+       TZOFFSETTO:0900
+       TZOFFSETFROM:0900
+       TZNAME:JST
+       END:STANDARD
        END:VTIMEZONE
        END:VCALENDAR
     """

--- a/tests/tzif/testdata/rfc8536-v2.yaml
+++ b/tests/tzif/testdata/rfc8536-v2.yaml
@@ -218,6 +218,12 @@ output:
     isstdcnt: false
     isutccnt: false
     designation: HST
+  - transition_time: -712150200
+    utoff: -36000
+    dst: false
+    isstdcnt: false
+    isutccnt: false
+    designation: HST
   rule:
     std:
       name: HST


### PR DESCRIPTION
Add APIs for creating a timezone from a tzif zoneinfo file or tzdata package. Adds support for fixed offset timezones as well as standard and daylight savings cases.
Fixes a bug in tzif parsing.

Issue #71