### PR TITLE
Add vtimezone tzinfo implementation

### DIFF
--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -28,7 +28,10 @@ class Calendar(ComponentModel):
     prodid: str = Field(default=_PRODID)
     version: str = Field(default=_VERSION)
 
+    #
     # Calendar components
+    #
+
     events: list[Event] = Field(alias="vevent", default_factory=list)
     todos: list[Todo] = Field(alias="vtodo", default_factory=list)
     journal: list[Journal] = Field(alias="vjournal", default_factory=list)

--- a/ical/event.py
+++ b/ical/event.py
@@ -22,6 +22,7 @@ from .types import (
     Recur,
     RequestStatus,
     Uri,
+    validate_until_dtstart,
 )
 from .util import dtstamp_factory, normalize_datetime, uid_factory
 
@@ -181,7 +182,7 @@ class Event(ComponentModel):
             return NotImplemented
         return self._tuple() >= other._tuple()
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def validate_date_types(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate that start and end values are the same date or datetime type."""
         if (
@@ -192,7 +193,7 @@ class Event(ComponentModel):
             raise ValueError("Expected end value type to match start")
         return values
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def validate_datetime_timezone(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate that start and end values have the same timezone information."""
         if (
@@ -210,14 +211,14 @@ class Event(ComponentModel):
             raise ValueError(f"Expected end datetime with timezone but was {dtend}")
         return values
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def validate_one_end_or_duration(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate that only one of duration or end date may be set."""
         if values.get("dtend") and values.get("duration"):
             raise ValueError("Only one of dtend or duration may be set." "")
         return values
 
-    @root_validator
+    @root_validator(allow_reuse=True)
     def validate_duration_unit(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate the duration is the appropriate units."""
         if not (duration := values.get("duration")):
@@ -229,3 +230,5 @@ class Event(ComponentModel):
         if duration < datetime.timedelta(seconds=0):
             raise ValueError(f"Expected duration to be positive but was {duration}")
         return values
+
+    _validate_until_dtstart = root_validator(allow_reuse=True)(validate_until_dtstart)

--- a/ical/iter.py
+++ b/ical/iter.py
@@ -1,0 +1,111 @@
+"""Library for iterators used in ical.."""
+
+from __future__ import annotations
+
+import datetime
+import heapq
+from collections.abc import Callable, Iterable, Iterator
+from typing import TypeVar, Union
+
+from dateutil import rrule
+
+T = TypeVar("T")
+
+ItemAdapter = Callable[[Union[datetime.datetime, datetime.date]], T]
+"""An adapter for an object in a sorted container (iterator)."""
+
+
+class RecurIterator(Iterator[T]):
+    """An iterator for a recurrence rule."""
+
+    def __init__(
+        self,
+        item_cb: ItemAdapter[T],
+        recur: Iterator[datetime.datetime | datetime.date],
+    ):
+        """Initialize the RecurIterator."""
+        self._item_cb = item_cb
+        self._recur = recur
+
+    def __iter__(self) -> Iterator[T]:
+        return self
+
+    def __next__(self) -> T:
+        """Return the next event in the recurrence."""
+        dtstart: datetime.datetime | datetime.date = next(self._recur)
+        return self._item_cb(dtstart)
+
+
+class RecurIterable(Iterable[T]):
+    """A series of events from a recurring event."""
+
+    def __init__(
+        self, item_cb: ItemAdapter[T], recur: rrule.rrule | rrule.rruleset
+    ) -> None:
+        """Initialize timeline."""
+        self._item_cb = item_cb
+        self._recur = recur
+
+    def __iter__(self) -> Iterator[T]:
+        """Return an iterator as a traversal over events in chronological order."""
+        return RecurIterator(self._item_cb, iter(self._recur))
+
+
+class PeekingIterator(Iterator[T]):
+    """An iterator with a preview of the next item."""
+
+    def __init__(self, iterator: Iterator[T]):
+        """Initialize PeekingIterator."""
+        self._iterator = iterator
+        self._next = next(self._iterator, None)
+
+    def __iter__(self) -> Iterator[T]:
+        """Return this iterator."""
+        return self
+
+    def peek(self) -> T | None:
+        """Peek at the next item without consuming."""
+        return self._next
+
+    def __next__(self) -> T:
+        """Produce the next item from the merged set."""
+        result = self._next
+        self._next = next(self._iterator, None)
+        if result is None:
+            raise StopIteration()
+        return result
+
+
+class MergedIterator(Iterator[T]):
+    """An iterator with a merged sorted view of the underlying sorted iterators."""
+
+    def __init__(self, iters: list[Iterator[T]]):
+        """Initialize MergedIterator."""
+        self._iters = [PeekingIterator(iterator) for iterator in iters]
+
+    def __iter__(self) -> Iterator[T]:
+        """Return this iterator."""
+        return self
+
+    def __next__(self) -> T:
+        """Produce the next item from the merged set."""
+        heap: list[tuple[T, PeekingIterator[T]]] = []
+        for iterator in self._iters:
+            peekd: T | None = iterator.peek()
+            if peekd:
+                heapq.heappush(heap, (peekd, iterator))
+        if not heap:
+            raise StopIteration()
+        (_, iterator) = heapq.heappop(heap)
+        return next(iterator)
+
+
+class MergedIterable(Iterable[T]):
+    """An iterator that merges results from underlying sorted iterables."""
+
+    def __init__(self, iters: list[Iterable[T]]) -> None:
+        """Initialize MergedIterable."""
+        self._iters = iters
+
+    def __iter__(self) -> Iterator[T]:
+        return MergedIterator([iter(it) for it in self._iters])

--- a/ical/journal.py
+++ b/ical/journal.py
@@ -8,7 +8,7 @@ import datetime
 import logging
 from typing import Any, Optional, Union
 
-from pydantic import Field
+from pydantic import Field, root_validator
 
 from .parsing.property import ParsedProperty
 from .types import (
@@ -19,6 +19,7 @@ from .types import (
     Recur,
     RequestStatus,
     Uri,
+    validate_until_dtstart,
 )
 from .util import dtstamp_factory, normalize_datetime, uid_factory
 
@@ -89,3 +90,5 @@ class Journal(ComponentModel):
     def start_datetime(self) -> datetime.datetime:
         """Return the events start as a datetime."""
         return normalize_datetime(self.start).astimezone(tz=datetime.timezone.utc)
+
+    _validate_until_dtstart = root_validator(allow_reuse=True)(validate_until_dtstart)

--- a/ical/timezone.py
+++ b/ical/timezone.py
@@ -13,11 +13,15 @@ different calendaring systems.
 from __future__ import annotations
 
 import datetime
+import enum
 import logging
-from typing import Any, Optional, Union
+from dataclasses import dataclass
+from typing import Any, Iterable, Optional, Union
 
+from dateutil.rrule import rruleset
 from pydantic import Field, root_validator, validator
 
+from .iter import MergedIterable, RecurIterable
 from .parsing.property import ParsedProperty
 from .types import ComponentModel, Recur, Uri, UtcOffset, parse_recur
 from .tzif import timezoneinfo, tz_rule
@@ -29,10 +33,12 @@ _LOGGER = logging.getLogger(__name__)
 # Assume that all tzif timezone rules start at an arbitrary old date. This library
 # typically only works with "go forward" dates, so we don't need to be completely
 # accurate and use the historical database of times.
-TZ_START = datetime.datetime(2010, 1, 1, 0, 0, 0)
+_TZ_START = datetime.datetime(2010, 1, 1, 0, 0, 0)
+
+_ZERO = datetime.timedelta(0)
 
 
-class TimezoneInfo(ComponentModel):
+class Observance(ComponentModel):
     """A sub-component with properties for a set of timezone observances."""
 
     # Has an alias of 'start'
@@ -68,12 +74,48 @@ class TimezoneInfo(ComponentModel):
             data["dtstart"] = data.pop("start")
         super().__init__(**data)
 
+    @property
+    def start_datetime(self) -> datetime.datetime:
+        """Return the start of the observance."""
+        return self.dtstart
+
+    def as_ruleset(self) -> rruleset:
+        """Represent the occurrence as a rule of repeated dates or datetimes."""
+        ruleset = rruleset()
+        if self.rrule:
+            ruleset.rrule(self.rrule.as_rrule(self.dtstart))
+        for rdate in self.rdate:
+            ruleset.rdate(rdate)  # type: ignore[no-untyped-call]
+        return ruleset
+
     @validator("dtstart")
     def verify_dtstart_local_time(cls, value: datetime.datetime) -> datetime.datetime:
         """Validate that dtstart is specified in a local time."""
         if value.utcoffset() is not None:
             raise ValueError(f"Start time must be in local time format: {value}")
         return value
+
+
+class _ObservanceType(str, enum.Enum):
+    """Type of a timezone observance."""
+
+    STANDARD = "STANDARD"
+    DAYLIGHT = "DAYLIGHT"
+
+
+@dataclass
+class _ObservanceInfo:
+    """Object holding observance information."""
+
+    observance_type: _ObservanceType
+    observance: Observance
+
+    def get(
+        self,
+        value: datetime.datetime | datetime.date,
+    ) -> tuple[datetime.datetime | datetime.date, "_ObservanceInfo"]:
+        """Adapt for an iterator over observances."""
+        return (value, self)
 
 
 class Timezone(ComponentModel):
@@ -91,10 +133,10 @@ class Timezone(ComponentModel):
     tz_id: str = Field(alias="tzid")
     """An identifier for this Timezone, unique within a calendar."""
 
-    standard: list[TimezoneInfo] = Field(default_factory=list)
+    standard: list[Observance] = Field(default_factory=list)
     """Describes the base offset from UTC for the time zone."""
 
-    daylight: list[TimezoneInfo] = Field(default_factory=list)
+    daylight: list[Observance] = Field(default_factory=list)
     """Describes adjustments made to account for changes in daylight hours."""
 
     tz_url: Optional[Uri] = Field(alias="tzurl", default=None)
@@ -109,7 +151,7 @@ class Timezone(ComponentModel):
     extras: list[ParsedProperty] = Field(default_factory=list)
 
     @classmethod
-    def from_tzif(cls, key: str, start: datetime.datetime = TZ_START) -> Timezone:
+    def from_tzif(cls, key: str, start: datetime.datetime = _TZ_START) -> Timezone:
         """Create a new Timezone from a tzif data source."""
         info = timezoneinfo.read(key)
         rule = info.rule
@@ -120,7 +162,7 @@ class Timezone(ComponentModel):
         if rule.dst and rule.dst.offset:
             dst_offset = rule.dst.offset
 
-        std_timezone_info = TimezoneInfo(
+        std_timezone_info = Observance(
             tz_name=[rule.std.name],
             tz_offset_to=UtcOffset(offset=rule.std.offset),
             tz_offset_from=UtcOffset(dst_offset),
@@ -139,7 +181,7 @@ class Timezone(ComponentModel):
             )
             std_timezone_info.dtstart = rule.dst_end.rrule_dtstart(start)
             daylight.append(
-                TimezoneInfo(
+                Observance(
                     tz_name=[rule.dst.name],
                     tz_offset_to=UtcOffset(offset=rule.dst.offset),
                     tz_offset_from=UtcOffset(offset=rule.std.offset),
@@ -149,6 +191,52 @@ class Timezone(ComponentModel):
             )
         return Timezone(tz_id=key, standard=[std_timezone_info], daylight=daylight)
 
+    def _observances(
+        self,
+    ) -> Iterable[tuple[datetime.datetime | datetime.date, _ObservanceInfo]]:
+        return MergedIterable(self._std_observances() + self._dst_observances())
+
+    def _std_observances(
+        self,
+    ) -> list[Iterable[tuple[datetime.datetime | datetime.date, _ObservanceInfo]]]:
+        iters: list[
+            Iterable[tuple[datetime.datetime | datetime.date, _ObservanceInfo]]
+        ] = []
+        for observance in self.standard:
+            iters.append(
+                RecurIterable(
+                    _ObservanceInfo(_ObservanceType.STANDARD, observance).get,
+                    observance.as_ruleset(),
+                )
+            )
+        return iters
+
+    def _dst_observances(
+        self,
+    ) -> list[Iterable[tuple[datetime.datetime | datetime.date, _ObservanceInfo]]]:
+        iters: list[
+            Iterable[tuple[datetime.datetime | datetime.date, _ObservanceInfo]]
+        ] = []
+        for observance in self.daylight:
+            iters.append(
+                RecurIterable(
+                    _ObservanceInfo(_ObservanceType.DAYLIGHT, observance).get,
+                    observance.as_ruleset(),
+                )
+            )
+        return iters
+
+    def get_observance(self, value: datetime.datetime) -> _ObservanceInfo | None:
+        """Return the specified observence for the specified date."""
+        if value.tzinfo is not None:
+            raise ValueError("Start time must be in local time format")
+        last_observance_info: _ObservanceInfo | None = None
+        for dt_start, observance_info in self._observances():
+            if dt_start > value:
+                return last_observance_info
+            last_observance_info = observance_info
+        return last_observance_info
+
     @root_validator
     def parse_required_timezoneinfo(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Require at least one standard or daylight definition."""
@@ -157,3 +245,49 @@ class Timezone(ComponentModel):
         if not standard and not daylight:
             raise ValueError("At least one standard or daylight definition is required")
         return values
+
+
+class IcsTimezoneInfo(datetime.tzinfo):
+    """An implementation of tzinfo based on an ICS Timezone.
+
+    This class is used to provide a tzinfo object for any datetime object
+    used within a calendar. An rfc5545 calendar is an unambiguous definition of
+    a calendar, and as a result, must encode all timezone information used in
+    the calendar, hence this class.
+    """
+
+    def __init__(self, timezone: Timezone) -> None:
+        """Initialize IcsTimezoneInfo."""
+        self._timezone = timezone
+
+    @classmethod
+    def from_timezone(cls, timezone: Timezone) -> IcsTimezoneInfo:
+        """Create a new instance of an IcsTimezoneInfo."""
+        return cls(timezone)
+
+    def utcoffset(self, dt: datetime.datetime | None) -> datetime.timedelta:
+        """Return offset of local time from UTC, as a timedelta object."""
+        if not dt:
+            return _ZERO
+        obs = self._timezone.get_observance(dt.replace(tzinfo=None))
+        if not obs:
+            return _ZERO
+        return obs.observance.tz_offset_to.offset
+
+    def tzname(self, dt: datetime.datetime | None) -> str | None:
+        """Return the time zone name for the datetime as a sorting."""
+        if dt is None:
+            return None
+        obs = self._timezone.get_observance(dt.replace(tzinfo=None))
+        if obs and obs.observance.tz_name:
+            return obs.observance.tz_name[0]
+        return None
+
+    def dst(self, dt: datetime.datetime | None) -> datetime.timedelta | None:
+        """Return the daylight saving time (DST) adjustment, if applicable."""
+        if dt is None:
+            return None
+        obs = self._timezone.get_observance(dt.replace(tzinfo=None))
+        if obs and obs.observance_type == _ObservanceType.DAYLIGHT:
+            return obs.observance.tz_offset_to.offset
+        return _ZERO

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -19,6 +19,7 @@ from .types import (
     RequestStatus,
     TodoStatus,
     Uri,
+    validate_until_dtstart,
 )
 from .util import dtstamp_factory, normalize_datetime, uid_factory
 
@@ -102,3 +103,5 @@ class Todo(ComponentModel):
         if values.get("duration") and not values.get("dtstart"):
             raise ValueError("Duration requires that dtstart is specified")
         return values
+
+    _validate_until_dtstart = root_validator(allow_reuse=True)(validate_until_dtstart)

--- a/ical/types.py
+++ b/ical/types.py
@@ -36,6 +36,7 @@ from collections.abc import Callable
 from typing import Any, Generator, Optional, TypeVar, Union, get_args, get_origin
 from urllib.parse import urlparse
 
+from dateutil import rrule
 from pydantic import BaseModel, Field, root_validator
 from pydantic.dataclasses import dataclass
 from pydantic.fields import SHAPE_LIST, ModelField
@@ -619,7 +620,6 @@ def parse_utc_offset(prop: Any) -> UtcOffset:
     )
     if sign == "-":
         result = -result
-    _LOGGER.info("parse_utc_offset")
     return UtcOffset(result)
 
 
@@ -693,6 +693,23 @@ class Frequency(str, enum.Enum):
     """Repeating events based on an interval of a year or more."""
 
 
+RRULE_FREQ = {
+    Frequency.DAILY: rrule.DAILY,
+    Frequency.WEEKLY: rrule.WEEKLY,
+    Frequency.MONTHLY: rrule.MONTHLY,
+    Frequency.YEARLY: rrule.YEARLY,
+}
+RRULE_WEEKDAY = {
+    Weekday.MONDAY: rrule.MO,
+    Weekday.TUESDAY: rrule.TU,
+    Weekday.WEDNESDAY: rrule.WE,
+    Weekday.THURSDAY: rrule.TH,
+    Weekday.FRIDAY: rrule.FR,
+    Weekday.SATURDAY: rrule.SA,
+    Weekday.SUNDAY: rrule.SU,
+}
+
+
 class Recur(BaseModel):
     """A type used to identify properties that contain a recurrence rule specification.
 
@@ -726,6 +743,31 @@ class Recur(BaseModel):
 
     by_month: list[int] = Field(alias="bymonth", default_factory=list)
     """Month number between 1 and 12."""
+
+    def as_rrule(self, dtstart: datetime.datetime | datetime.date) -> rrule.rrule:
+        """Create a dateutil rrule for the specified event."""
+        if (freq := RRULE_FREQ.get(self.freq)) is None:
+            raise ValueError(f"Unsupported frequency in rrule: {self.freq}")
+
+        byweekday: list[rrule.weekday] | None = None
+        if self.by_weekday:
+            byweekday = [
+                RRULE_WEEKDAY[weekday.weekday](
+                    1 if weekday.occurrence is None else weekday.occurrence
+                )
+                for weekday in self.by_weekday
+            ]
+        return rrule.rrule(
+            freq=freq,
+            dtstart=dtstart,
+            interval=self.interval,
+            count=self.count,
+            until=self.until,
+            byweekday=byweekday,
+            bymonthday=self.by_month_day if self.by_month_day else None,
+            bymonth=self.by_month if self.by_month else None,
+            cache=True,
+        )
 
     class Config:
         """Pydantic model configuration."""
@@ -803,6 +845,29 @@ def encode_recur_ics(data: dict[str, Any]) -> str:
             continue
         result.append(f"{key.upper()}={value}")
     return ";".join(result)
+
+
+def validate_until_dtstart(_cls: BaseModel, values: dict[str, Any]) -> dict[str, Any]:
+    """Verify the until time and dtstart are the same."""
+    if (
+        (rule := values.get("rrule"))
+        and (until := rule.until)
+        and (dtstart := values.get("dtstart"))
+    ):
+        if isinstance(dtstart, datetime.datetime) and isinstance(
+            until, datetime.datetime
+        ):
+            if dtstart.tzinfo is None:
+                if until.tzinfo is not None:
+                    raise ValueError("DTSTART is date local but UNTIL was not")
+            else:
+                if until.utcoffset():
+                    raise ValueError("DTSTART had UTC or local and UNTIL must be UTC")
+        elif not (
+            isinstance(dtstart, datetime.date) and isinstance(dtstart, datetime.date)
+        ):
+            raise ValueError("DTSTART and UNTIL must be the same value type")
+    return values
 
 
 def parse_extra_fields(


### PR DESCRIPTION
Add vtimezone tzinfo implementation with the following changes:
- Evaluate rrules for vtimezones
- centralize rrule creation and iterator libraries for rrule evaluation in multiple contexts beyond timeline
- add dtstart and rrule validation based on rfc5545
