### PR TITLE
Streamline and refactor property encoding logic

### DIFF
--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -8,7 +8,7 @@ from pydantic import Field
 
 from .calendar import Calendar
 from .parsing.component import encode_content, parse_content
-from .types import ICS_ENCODERS, ComponentModel, encode_model
+from .types import ICS_ENCODERS, ComponentModel
 
 
 class CalendarStream(ComponentModel):
@@ -28,7 +28,7 @@ class CalendarStream(ComponentModel):
 
     def ics(self) -> str:
         """Encode the calendar stream as an rfc5545 iCalendar Stream content."""
-        return encode_content(encode_model("stream", self).components)
+        return encode_content(self.__encode_component_root__().components)
 
 
 class IcsCalendarStream(CalendarStream):

--- a/ical/timezone.py
+++ b/ical/timezone.py
@@ -23,7 +23,7 @@ from pydantic import Field, root_validator, validator
 
 from .iter import MergedIterable, RecurIterable
 from .parsing.property import ParsedProperty
-from .types import ComponentModel, Recur, Uri, UtcOffset, parse_recur
+from .types import ComponentModel, Recur, Uri, UtcOffset
 from .tzif import timezoneinfo, tz_rule
 from .util import dtstamp_factory
 
@@ -177,7 +177,7 @@ class Timezone(ComponentModel):
             and isinstance(rule.dst_end, tz_rule.RuleDate)
         ):
             std_timezone_info.rrule = Recur.parse_obj(
-                parse_recur(rule.dst_end.rrule_str)
+                Recur.parse_recur(rule.dst_end.rrule_str)
             )
             std_timezone_info.dtstart = rule.dst_end.rrule_dtstart(start)
             daylight.append(
@@ -185,7 +185,7 @@ class Timezone(ComponentModel):
                     tz_name=[rule.dst.name],
                     tz_offset_to=UtcOffset(offset=rule.dst.offset),
                     tz_offset_from=UtcOffset(offset=rule.std.offset),
-                    rrule=Recur.parse_obj(parse_recur(rule.dst_start.rrule_str)),
+                    rrule=Recur.parse_obj(Recur.parse_recur(rule.dst_start.rrule_str)),
                     dtstart=rule.dst_start.rrule_dtstart(start),
                 )
             )

--- a/ical/types.py
+++ b/ical/types.py
@@ -454,15 +454,8 @@ class DurationEncoder:
         return result
 
     @classmethod
-    def __encode_property_json__(cls, value: Any) -> str:
+    def __encode_property_json__(cls, duration: datetime.timedelta) -> str:
         """Serialize a time delta as a DURATION ICS value."""
-        duration: datetime.timedelta
-        if isinstance(value, datetime.timedelta):
-            duration = value
-        elif isinstance(value, float):
-            duration = datetime.timedelta(seconds=value)
-        else:
-            raise ValueError(f"Unexpected value type: {value}")
         parts = []
         if duration < datetime.timedelta(days=0):
             parts.append("-")
@@ -488,7 +481,6 @@ class DurationEncoder:
                 parts.append(f"{minutes}M")
             if seconds != 0:
                 parts.append(f"{seconds}S")
-        _LOGGER.debug("__encode_property_json__=%s", parts)
         return "".join(parts)
 
 
@@ -706,15 +698,9 @@ class UtcOffset:
         return UtcOffset(result)
 
     @classmethod
-    def __encode_property_json__(cls, value: Any) -> str:
+    def __encode_property_json__(cls, value: UtcOffset) -> str:
         """Serialize a time delta as a UTC-OFFSET ICS value."""
-        if isinstance(value, str):
-            return value  # Already encoded as ics
-        duration: datetime.timedelta
-        if isinstance(value, UtcOffset):
-            duration = value.offset
-        else:
-            raise ValueError(f"Unexpected UTC OFFSET value type: {value}")
+        duration = value.offset
         parts = []
         if duration < datetime.timedelta(days=0):
             parts.append("-")


### PR DESCRIPTION
Streamline property encoding by moving ad-hoc methods into classes of a similar type. This is a step towards spilling apart the large `types.py` and splitting into a separate module.

There is a set of steps for encoding that are more clearly laid out:
- Encoding done by pydantic to get the data model hierarchy ready. Objects are converted to strings or dictionaries of strings
- Additional value encoding
- Additional property parameter encoding as ParsedPropertyParameters
- Assembling into ParsedProperty objects

Issue #72