### PR TITLE
Simplify enum mapping and cleanup older type handling

### DIFF
--- a/ical/_types.py
+++ b/ical/_types.py
@@ -28,7 +28,7 @@ import datetime
 import json
 import logging
 from collections.abc import Callable
-from typing import Any, Generator, TypeVar, Union, get_args, get_origin
+from typing import Any, TypeVar, Union, get_args, get_origin
 
 from pydantic import BaseModel, root_validator
 from pydantic.fields import SHAPE_LIST, ModelField
@@ -40,7 +40,6 @@ from .types.const import Classification, EventStatus, JournalStatus, TodoStatus
 from .types.data_types import DATA_TYPE
 from .types.date_time import DateTimeEncoder
 from .types.duration import DurationEncoder
-from .types.integer import IntEncoder
 from .types.text import TextEncoder
 
 _LOGGER = logging.getLogger(__name__)
@@ -59,22 +58,6 @@ ALLOW_REPEATED_VALUES = {
     "resources",
     "freebusy",
 }
-
-
-class Priority(int):
-    """Defines relative priority for a calendar component."""
-
-    @classmethod
-    def __get_validators__(cls) -> Generator[Callable, None, None]:  # type: ignore[type-arg]
-        yield cls.parse_priority
-
-    @classmethod
-    def parse_priority(cls, value: ParsedProperty) -> int:
-        """Parse a rfc5545 into a text value."""
-        priority = IntEncoder.__parse_property_value__(value)
-        if priority < 0 or priority > 9:
-            raise ValueError("Expected priority between 0-9")
-        return priority
 
 
 def _all_fields(cls: BaseModel) -> dict[str, ModelField]:

--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from ._types import ICS_ENCODERS, ComponentModel
+from ._types import ComponentModel
 from .calendar import Calendar
 from .parsing.component import encode_content, parse_content
+from .types.data_types import DATA_TYPE
 
 
 class CalendarStream(ComponentModel):
@@ -53,6 +54,6 @@ class IcsCalendarStream(CalendarStream):
     class Config:
         """Configuration for IcsCalendarStream pydantic model."""
 
-        json_encoders = ICS_ENCODERS
+        json_encoders = DATA_TYPE.encode_property_json
         validate_assignment = True
         allow_population_by_field_name = True

--- a/ical/event.py
+++ b/ical/event.py
@@ -10,10 +10,10 @@ from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator
 
-from ._types import ComponentModel, Priority, validate_until_dtstart
+from ._types import ComponentModel, validate_until_dtstart
 from .alarm import Alarm
 from .parsing.property import ParsedProperty
-from .types import CalAddress, Geo, Recur, RequestStatus, Uri
+from .types import CalAddress, Geo, Priority, Recur, RequestStatus, Uri
 from .types.const import Classification, EventStatus
 from .util import dtstamp_factory, normalize_datetime, uid_factory
 

--- a/ical/event.py
+++ b/ical/event.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import datetime
+import enum
 import logging
 from typing import Any, Optional, Union
 
@@ -13,11 +14,18 @@ from pydantic import Field, root_validator
 from ._types import ComponentModel, validate_until_dtstart
 from .alarm import Alarm
 from .parsing.property import ParsedProperty
-from .types import CalAddress, Geo, Priority, Recur, RequestStatus, Uri
-from .types.const import Classification, EventStatus
+from .types import CalAddress, Classification, Geo, Priority, Recur, RequestStatus, Uri
 from .util import dtstamp_factory, normalize_datetime, uid_factory
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class EventStatus(str, enum.Enum):
+    """Status or confirmation of the event."""
+
+    CONFIRMED = "CONFIRMED"
+    TENTATIVE = "TENTATIVE"
+    CANCELLED = "CANCELLED"
 
 
 class Event(ComponentModel):

--- a/ical/journal.py
+++ b/ical/journal.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import datetime
+import enum
 import logging
 from typing import Any, Optional, Union
 
@@ -12,11 +13,18 @@ from pydantic import Field, root_validator
 
 from ._types import ComponentModel, validate_until_dtstart
 from .parsing.property import ParsedProperty
-from .types import CalAddress, Recur, RequestStatus, Uri
-from .types.const import Classification, JournalStatus
+from .types import CalAddress, Classification, Recur, RequestStatus, Uri
 from .util import dtstamp_factory, normalize_datetime, uid_factory
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class JournalStatus(str, enum.Enum):
+    """Status or confirmation of the journal entry."""
+
+    DRAFT = "DRAFT"
+    FINAL = "FINAL"
+    CANCELLED = "CANCELLED"
 
 
 class Journal(ComponentModel):

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -7,10 +7,10 @@ from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator
 
-from ._types import ComponentModel, Priority, validate_until_dtstart
+from ._types import ComponentModel, validate_until_dtstart
 from .alarm import Alarm
 from .parsing.property import ParsedProperty
-from .types import CalAddress, Geo, Recur, RequestStatus, Uri
+from .types import CalAddress, Geo, Priority, Recur, RequestStatus, Uri
 from .types.const import Classification, TodoStatus
 from .util import dtstamp_factory, normalize_datetime, uid_factory
 

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime
+import enum
 from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator
@@ -10,9 +11,17 @@ from pydantic import Field, root_validator
 from ._types import ComponentModel, validate_until_dtstart
 from .alarm import Alarm
 from .parsing.property import ParsedProperty
-from .types import CalAddress, Geo, Priority, Recur, RequestStatus, Uri
-from .types.const import Classification, TodoStatus
+from .types import CalAddress, Classification, Geo, Priority, Recur, RequestStatus, Uri
 from .util import dtstamp_factory, normalize_datetime, uid_factory
+
+
+class TodoStatus(str, enum.Enum):
+    """Status or confirmation of the to-do."""
+
+    NEEDS_ACTION = "NEEDS-ACTION"
+    COMPLETED = "COMPLETED"
+    IN_PROCESS = "IN-PROCESS"
+    CANCELLED = "CANCELLED"
 
 
 class Todo(ComponentModel):

--- a/ical/types/__init__.py
+++ b/ical/types/__init__.py
@@ -2,21 +2,23 @@
 
 # Import all types for the registry
 from . import integer  # noqa: F401
-from . import recur  # noqa: F401
 from . import boolean, date, date_time, duration  # noqa: F401
 from . import float as float_pkg  # noqa: F401
 from .cal_address import CalAddress
+from .const import Classification
 from .geo import Geo
-from .period import Period
+from .period import FreeBusyType, Period
 from .priority import Priority
-from .recur import Recur
+from .recur import Frequency, Recur, Weekday, WeekdayValue
 from .request_status import RequestStatus
 from .uri import Uri
 from .utc_offset import UtcOffset
 
 __all__ = [
-    "const",
     "CalAddress",
+    "Classification",
+    "Frequency",
+    "FreeBusyType",
     "Geo",
     "Period",
     "Priority",
@@ -24,4 +26,6 @@ __all__ = [
     "RequestStatus",
     "UtcOffset",
     "Uri",
+    "Weekday",
+    "WeekdayValue",
 ]

--- a/ical/types/__init__.py
+++ b/ical/types/__init__.py
@@ -8,6 +8,7 @@ from . import float as float_pkg  # noqa: F401
 from .cal_address import CalAddress
 from .geo import Geo
 from .period import Period
+from .priority import Priority
 from .recur import Recur
 from .request_status import RequestStatus
 from .uri import Uri
@@ -18,6 +19,7 @@ __all__ = [
     "CalAddress",
     "Geo",
     "Period",
+    "Priority",
     "Recur",
     "RequestStatus",
     "UtcOffset",

--- a/ical/types/cal_address.py
+++ b/ical/types/cal_address.py
@@ -3,18 +3,51 @@
 from __future__ import annotations
 
 import dataclasses
+import enum
 import logging
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field, root_validator
 
-from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
+from ical.parsing.property import ParsedPropertyParameter
 
 from .data_types import DATA_TYPE, encode_model_property_params
 from .parsing import parse_parameter_values
 from .uri import Uri
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class CalendarUserType(str, enum.Enum):
+    """The type of calendar user."""
+
+    INDIVIDUAL = "INDIVIDUAL"
+    GROUP = "GROUP"
+    RESOURCE = "GROUP"
+    ROOM = "ROOM"
+    UNKNOWN = "UNKNOWN"
+
+
+class ParticipationStatus(str, enum.Enum):
+    """Participation status for a calendar user."""
+
+    NEEDS_ACTION = "NEEDS-ACTION"
+    ACCEPTED = "ACCEPTED"
+    DECLINED = "DECLINED"
+    # Additional statuses for Events and Todos
+    TENTATIVE = "TENTATIVE"
+    DELEGATED = "DELEGATED"
+    # Additional status for TODOs
+    COMPLETED = "COMPLETED"
+
+
+class Role(str, enum.Enum):
+    """Role for the calendar user."""
+
+    CHAIR = "CHAIR"
+    REQUIRED = "REQ-PARTICIPANT"
+    OPTIONAL = "OPT-PARTICIPANT"
+    NON_PARTICIPANT = "NON-PARTICIPANT"
 
 
 @DATA_TYPE.register("CAL-ADDRESS")
@@ -66,11 +99,7 @@ class CalAddress(BaseModel):
         parse_parameter_values
     )
 
-    @classmethod
-    def __parse_property_value__(cls, prop: ParsedProperty) -> dict[str, str]:
-        """Convert the property into a dictionary for pydantic model."""
-        # XXX???
-        return dataclasses.asdict(prop)
+    __parse_property_value__ = dataclasses.asdict
 
     @classmethod
     def __encode_property_value__(cls, model_data: dict[str, str]) -> str | None:

--- a/ical/types/const.py
+++ b/ical/types/const.py
@@ -3,82 +3,9 @@
 import enum
 
 
-class EventStatus(str, enum.Enum):
-    """Status or confirmation of the event."""
-
-    CONFIRMED = "CONFIRMED"
-    TENTATIVE = "TENTATIVE"
-    CANCELLED = "CANCELLED"
-
-
-class TodoStatus(str, enum.Enum):
-    """Status or confirmation of the to-do."""
-
-    NEEDS_ACTION = "NEEDS-ACTION"
-    COMPLETED = "COMPLETED"
-    IN_PROCESS = "IN-PROCESS"
-    CANCELLED = "CANCELLED"
-
-
-class JournalStatus(str, enum.Enum):
-    """Status or confirmation of the journal entry."""
-
-    DRAFT = "DRAFT"
-    FINAL = "FINAL"
-    CANCELLED = "CANCELLED"
-
-
 class Classification(str, enum.Enum):
     """Defines the access classification for a calendar component."""
 
     PUBLIC = "PUBLIC"
     PRIVATE = "PRIVATE"
     CONFIDENTIAL = "CONFIDENTIAL"
-
-
-class CalendarUserType(str, enum.Enum):
-    """The type of calendar user."""
-
-    INDIVIDUAL = "INDIVIDUAL"
-    GROUP = "GROUP"
-    RESOURCE = "GROUP"
-    ROOM = "ROOM"
-    UNKNOWN = "UNKNOWN"
-
-
-class ParticipationStatus(str, enum.Enum):
-    """Participation status for a calendar user."""
-
-    NEEDS_ACTION = "NEEDS-ACTION"
-    ACCEPTED = "ACCEPTED"
-    DECLINED = "DECLINED"
-    # Additional statuses for Events and Todos
-    TENTATIVE = "TENTATIVE"
-    DELEGATED = "DELEGATED"
-    # Additional status for TODOs
-    COMPLETED = "COMPLETED"
-
-
-class Role(str, enum.Enum):
-    """Role for the calendar user."""
-
-    CHAIR = "CHAIR"
-    REQUIRED = "REQ-PARTICIPANT"
-    OPTIONAL = "OPT-PARTICIPANT"
-    NON_PARTICIPANT = "NON-PARTICIPANT"
-
-
-class FreeBusyType(str, enum.Enum):
-    """Specifies the free/busy time type."""
-
-    FREE = "FREE"
-    """The time interval is free for scheduling."""
-
-    BUSY = "BUSY"
-    """One or more events have been scheduled for the interval."""
-
-    BUSY_UNAVAILABLE = "BUSY-UNAVAILABLE"
-    """The interval can not be scheduled."""
-
-    BUSY_TENTATIVE = "BUSY-TENTATIVE"
-    """One or more events have been tentatively scheduled for the interval."""

--- a/ical/types/period.py
+++ b/ical/types/period.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import datetime
+import enum
 import logging
 from typing import Any, Optional
 
@@ -9,13 +10,28 @@ from pydantic import BaseModel, Field, root_validator
 
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 
-from .const import FreeBusyType
 from .data_types import DATA_TYPE, encode_model_property_params
 from .date_time import DateTimeEncoder
 from .duration import DurationEncoder
 from .parsing import parse_parameter_values
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class FreeBusyType(str, enum.Enum):
+    """Specifies the free/busy time type."""
+
+    FREE = "FREE"
+    """The time interval is free for scheduling."""
+
+    BUSY = "BUSY"
+    """One or more events have been scheduled for the interval."""
+
+    BUSY_UNAVAILABLE = "BUSY-UNAVAILABLE"
+    """The interval can not be scheduled."""
+
+    BUSY_TENTATIVE = "BUSY-TENTATIVE"
+    """One or more events have been tentatively scheduled for the interval."""
 
 
 @DATA_TYPE.register("PERIOD")

--- a/ical/types/priority.py
+++ b/ical/types/priority.py
@@ -1,0 +1,24 @@
+"""Parser for the the PRIORITY type."""
+
+from collections.abc import Callable
+from typing import Generator
+
+from ical.parsing.property import ParsedProperty
+
+from .integer import IntEncoder
+
+
+class Priority(int):
+    """Defines relative priority for a calendar component."""
+
+    @classmethod
+    def __get_validators__(cls) -> Generator[Callable, None, None]:  # type: ignore[type-arg]
+        yield cls.parse_priority
+
+    @classmethod
+    def parse_priority(cls, value: ParsedProperty) -> int:
+        """Parse a rfc5545 into a text value."""
+        priority = IntEncoder.__parse_property_value__(value)
+        if priority < 0 or priority > 9:
+            raise ValueError("Expected priority between 0-9")
+        return priority

--- a/tests/test_freebusy.py
+++ b/tests/test_freebusy.py
@@ -11,8 +11,7 @@ import pytest
 from pydantic import ValidationError
 
 from ical.freebusy import FreeBusy
-from ical.types import Period
-from ical.types.const import FreeBusyType
+from ical.types import FreeBusyType, Period
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -9,8 +9,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import ValidationError
 
-from ical.journal import Journal
-from ical.types.const import JournalStatus
+from ical.journal import Journal, JournalStatus
 
 
 def test_empty() -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,9 +3,10 @@
 import datetime
 from typing import Optional, Union
 
-from ical._types import ICS_ENCODERS, ComponentModel
+from ical._types import ComponentModel
 from ical.parsing.component import ParsedComponent
 from ical.parsing.property import ParsedProperty
+from ical.types.data_types import DATA_TYPE
 
 
 def test_encode_component() -> None:
@@ -29,7 +30,7 @@ def test_encode_component() -> None:
         class Config:
             """Pydantic model configuration."""
 
-            json_encoders = ICS_ENCODERS
+            json_encoders = DATA_TYPE.encode_property_json
 
     model = TestModel.parse_obj(
         {

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,10 +3,7 @@
 import datetime
 from typing import Optional, Union
 
-import pytest
-from pydantic import ValidationError
-
-from ical._types import ICS_ENCODERS, ComponentModel, Priority
+from ical._types import ICS_ENCODERS, ComponentModel
 from ical.parsing.component import ParsedComponent
 from ical.parsing.property import ParsedProperty
 
@@ -136,24 +133,3 @@ def test_optional_field_parser() -> None:
         {"dt": [ParsedProperty(name="dt", value="20220724T120000")]}
     )
     assert model.dt == datetime.datetime(2022, 7, 24, 12, 0, 0)
-
-
-def test_priority() -> None:
-    """Test for priority fields."""
-
-    class TestModel(ComponentModel):
-        """Model under test."""
-
-        pri: Priority
-
-    model = TestModel.parse_obj({"pri": [ParsedProperty(name="dt", value="1")]})
-    assert model.pri == 1
-
-    model = TestModel.parse_obj({"pri": [ParsedProperty(name="dt", value="9")]})
-    assert model.pri == 9
-
-    with pytest.raises(ValidationError):
-        TestModel.parse_obj({"pri": [ParsedProperty(name="dt", value="-1")]})
-
-    with pytest.raises(ValidationError):
-        TestModel.parse_obj({"pri": [ParsedProperty(name="dt", value="10")]})

--- a/tests/types/test_date_time.py
+++ b/tests/types/test_date_time.py
@@ -6,9 +6,10 @@ from typing import Union
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ICS_ENCODERS, ComponentModel
+from ical._types import ComponentModel
 from ical.parsing.component import ParsedComponent
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
+from ical.types.data_types import DATA_TYPE
 from ical.tzif import timezoneinfo
 
 
@@ -111,7 +112,7 @@ def test_datedatime_parameter_encoder() -> None:
         class Config:
             """Pydantic model configuration."""
 
-            json_encoders = ICS_ENCODERS
+            json_encoders = DATA_TYPE.encode_property_json
 
     model = TestModel.parse_obj(
         {

--- a/tests/types/test_duration.py
+++ b/tests/types/test_duration.py
@@ -4,8 +4,9 @@ import datetime
 
 import pytest
 
-from ical._types import ICS_ENCODERS, ComponentModel
+from ical._types import ComponentModel
 from ical.parsing.property import ParsedProperty
+from ical.types.data_types import DATA_TYPE
 
 
 class FakeModel(ComponentModel):
@@ -16,7 +17,7 @@ class FakeModel(ComponentModel):
     class Config:
         """Pydantic model configuration."""
 
-        json_encoders = ICS_ENCODERS
+        json_encoders = DATA_TYPE.encode_property_json
 
 
 @pytest.mark.parametrize(

--- a/tests/types/test_period.py
+++ b/tests/types/test_period.py
@@ -5,10 +5,11 @@ import datetime
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ICS_ENCODERS, ComponentModel
+from ical._types import ComponentModel
 from ical.parsing.component import ParsedComponent
 from ical.parsing.property import ParsedProperty
 from ical.types import Period
+from ical.types.data_types import DATA_TYPE
 
 
 class FakeModel(ComponentModel):
@@ -19,7 +20,7 @@ class FakeModel(ComponentModel):
     class Config:
         """Pydantic model configuration."""
 
-        json_encoders = ICS_ENCODERS
+        json_encoders = DATA_TYPE.encode_property_json
 
 
 def test_period() -> None:

--- a/tests/types/test_priority.py
+++ b/tests/types/test_priority.py
@@ -1,0 +1,30 @@
+"""Tests for PRIORITY types."""
+
+import pytest
+from pydantic import ValidationError
+
+from ical._types import ComponentModel
+from ical.parsing.property import ParsedProperty
+from ical.types import Priority
+
+
+class FakeModel(ComponentModel):
+    """Model under test."""
+
+    pri: Priority
+
+
+def test_priority() -> None:
+    """Test for priority fields."""
+
+    model = FakeModel.parse_obj({"pri": [ParsedProperty(name="dt", value="1")]})
+    assert model.pri == 1
+
+    model = FakeModel.parse_obj({"pri": [ParsedProperty(name="dt", value="9")]})
+    assert model.pri == 9
+
+    with pytest.raises(ValidationError):
+        FakeModel.parse_obj({"pri": [ParsedProperty(name="dt", value="-1")]})
+
+    with pytest.raises(ValidationError):
+        FakeModel.parse_obj({"pri": [ParsedProperty(name="dt", value="10")]})


### PR DESCRIPTION
Simplify enum mapping to use native pydantic support for enum parsing, and relocate enums next to where they are used.