### PR TITLE
Rename `_types.py` to `component.py`

### DIFF
--- a/ical/alarm.py
+++ b/ical/alarm.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator
 
-from ._types import ComponentModel
+from .component import ComponentModel
 from .parsing.property import ParsedProperty
 from .types import CalAddress
 

--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from pydantic import Field
 
-from ._types import ComponentModel
+from .component import ComponentModel
 from .event import Event
 from .freebusy import FreeBusy
 from .journal import Journal

--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 
 from pydantic import Field
 
-from ._types import ComponentModel
 from .calendar import Calendar
+from .component import ComponentModel
 from .parsing.component import encode_content, parse_content
 from .types.data_types import DATA_TYPE
 

--- a/ical/component.py
+++ b/ical/component.py
@@ -1,4 +1,4 @@
-"""Libraries for translating between rfc5545 parsed objects and pydantic data.
+"""Library for parsing and encoding rfc5545 components with pydantic.
 
 The data model returned by the contentlines parsing is a bag of ParsedProperty
 objects that support all the flexibility of the rfc5545 spec. However in the
@@ -10,11 +10,8 @@ into the simpler pydantic data model, and handles custom field types and
 validators.
 
 Just as the pydantic model provides syntax glue for parsing data and
-associating necessary validators, this is the same for the opposite
-direction.
-
-A custom class with the method `__encode_component__` is used to serialize
-the object as a ParsedComponent.
+associating necessary validators, this is also doing the same thing
+in the opposite direction to encode back to ICS.
 """
 
 from __future__ import annotations

--- a/ical/event.py
+++ b/ical/event.py
@@ -11,8 +11,8 @@ from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator
 
-from ._types import ComponentModel, validate_until_dtstart
 from .alarm import Alarm
+from .component import ComponentModel, validate_until_dtstart
 from .parsing.property import ParsedProperty
 from .types import CalAddress, Classification, Geo, Priority, Recur, RequestStatus, Uri
 from .util import dtstamp_factory, normalize_datetime, uid_factory

--- a/ical/freebusy.py
+++ b/ical/freebusy.py
@@ -10,7 +10,7 @@ from typing import Any, Optional, Union
 
 from pydantic import Field, validator
 
-from ._types import ComponentModel
+from .component import ComponentModel
 from .parsing.property import ParsedProperty
 from .types import CalAddress, Period, RequestStatus, Uri
 from .util import dtstamp_factory, normalize_datetime, uid_factory

--- a/ical/journal.py
+++ b/ical/journal.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator
 
-from ._types import ComponentModel, validate_until_dtstart
+from .component import ComponentModel, validate_until_dtstart
 from .parsing.property import ParsedProperty
 from .types import CalAddress, Classification, Recur, RequestStatus, Uri
 from .util import dtstamp_factory, normalize_datetime, uid_factory

--- a/ical/timezone.py
+++ b/ical/timezone.py
@@ -21,7 +21,7 @@ from typing import Any, Iterable, Optional, Union
 from dateutil.rrule import rruleset
 from pydantic import Field, root_validator, validator
 
-from ._types import ComponentModel
+from .component import ComponentModel
 from .iter import MergedIterable, RecurIterable
 from .parsing.property import ParsedProperty
 from .types import Recur, Uri, UtcOffset

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -8,8 +8,8 @@ from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator
 
-from ._types import ComponentModel, validate_until_dtstart
 from .alarm import Alarm
+from .component import ComponentModel, validate_until_dtstart
 from .parsing.property import ParsedProperty
 from .types import CalAddress, Classification, Geo, Priority, Recur, RequestStatus, Uri
 from .util import dtstamp_factory, normalize_datetime, uid_factory

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,9 +1,9 @@
-"""Tests for property values."""
+"""Tests for component encoding and decoding."""
 
 import datetime
 from typing import Optional, Union
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.component import ParsedComponent
 from ical.parsing.property import ParsedProperty
 from ical.types.data_types import DATA_TYPE

--- a/tests/types/test_boolean.py
+++ b/tests/types/test_boolean.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.property import ParsedProperty
 
 

--- a/tests/types/test_date.py
+++ b/tests/types/test_date.py
@@ -6,7 +6,7 @@ from typing import Union
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.property import ParsedProperty
 
 

--- a/tests/types/test_date_time.py
+++ b/tests/types/test_date_time.py
@@ -6,7 +6,7 @@ from typing import Union
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.component import ParsedComponent
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 from ical.types.data_types import DATA_TYPE

--- a/tests/types/test_duration.py
+++ b/tests/types/test_duration.py
@@ -4,7 +4,7 @@ import datetime
 
 import pytest
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.property import ParsedProperty
 from ical.types.data_types import DATA_TYPE
 

--- a/tests/types/test_float.py
+++ b/tests/types/test_float.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.property import ParsedProperty
 
 

--- a/tests/types/test_geo.py
+++ b/tests/types/test_geo.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.property import ParsedProperty
 from ical.types.geo import Geo
 

--- a/tests/types/test_integer.py
+++ b/tests/types/test_integer.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.property import ParsedProperty
 
 

--- a/tests/types/test_period.py
+++ b/tests/types/test_period.py
@@ -5,7 +5,7 @@ import datetime
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.component import ParsedComponent
 from ical.parsing.property import ParsedProperty
 from ical.types import Period

--- a/tests/types/test_priority.py
+++ b/tests/types/test_priority.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.property import ParsedProperty
 from ical.types import Priority
 

--- a/tests/types/test_text.py
+++ b/tests/types/test_text.py
@@ -1,6 +1,6 @@
 """Tests for property values."""
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.component import ParsedComponent
 from ical.parsing.property import ParsedProperty
 

--- a/tests/types/test_utc_offset.py
+++ b/tests/types/test_utc_offset.py
@@ -5,7 +5,7 @@ import datetime
 import pytest
 from pydantic import ValidationError
 
-from ical._types import ComponentModel
+from ical.component import ComponentModel
 from ical.parsing.property import ParsedProperty
 from ical.types import UtcOffset
 


### PR DESCRIPTION
Rename the component parsing code file now that everything else has been moved into the `types` subdirectory.

Issue #72 