### PR TITLE
Fix types for **kwargs

### DIFF
--- a/ical/event.py
+++ b/ical/event.py
@@ -233,7 +233,7 @@ class Event(ComponentModel):
     alarm: list[Alarm] = Field(alias="valarm", default_factory=list)
     """A grouping of reminder alarms for the event."""
 
-    def __init__(self, **data: dict[str, Any]) -> None:
+    def __init__(self, **data: Any) -> None:
         """Initialize a Calendar Event.
 
         This method accepts keyword args with field names on the Calendar such as `summary`,

--- a/ical/freebusy.py
+++ b/ical/freebusy.py
@@ -68,7 +68,7 @@ class FreeBusy(ComponentModel):
     # Unknown or unsupported properties
     extras: list[ParsedProperty] = Field(default_factory=list)
 
-    def __init__(self, **data: dict[str, Any]) -> None:
+    def __init__(self, **data: Any) -> None:
         """Initialize Event."""
         if "start" in data:
             data["dtstart"] = data.pop("start")

--- a/ical/journal.py
+++ b/ical/journal.py
@@ -74,7 +74,7 @@ class Journal(ComponentModel):
     # Unknown or unsupported properties
     extras: list[ParsedProperty] = Field(default_factory=list)
 
-    def __init__(self, **data: dict[str, Any]) -> None:
+    def __init__(self, **data: Any) -> None:
         """Initialize Event."""
         if "start" in data:
             data["dtstart"] = data.pop("start")

--- a/ical/timezone.py
+++ b/ical/timezone.py
@@ -69,7 +69,7 @@ class Observance(ComponentModel):
 
     extras: list[ParsedProperty] = Field(default_factory=list)
 
-    def __init__(self, **data: dict[str, Any]) -> None:
+    def __init__(self, **data: Any) -> None:
         """Initialize Timezone."""
         if "start" in data:
             data["dtstart"] = data.pop("start")

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -79,7 +79,7 @@ class Todo(ComponentModel):
 
     extras: list[ParsedProperty] = Field(default_factory=list)
 
-    def __init__(self, **data: dict[str, Any]) -> None:
+    def __init__(self, **data: Any) -> None:
         """Initialize Todo."""
         if "start" in data:
             data["dtstart"] = data.pop("start")


### PR DESCRIPTION
`**kwargs` arguments should be typed according to their values (i.e. a *single* argument), not `kwargs` as a whole - see e.g. the [mypy docs](https://mypy.readthedocs.io/en/stable/getting_started.html?highlight=kwargs#more-function-signatures) (last snippet).

This fixes typing issues such as this one:

![image](https://user-images.githubusercontent.com/625793/188929472-d076fe6f-f081-4315-b1b7-dec7a36a0076.png)

Weirdly enough, the Pydantic mypy plugin seems to hide this issue in this repository. If I comment out `plugins = pydantic.mypy` in `mypy.ini`, this is flagged in the tests and such... That seems like an issue in that plugin perhaps, but I have no idea of Pydantic, so I won't look at that in detail I'm afraid.