### PR TITLE
Fix small doc issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ $ pip3 install -r requirements_dev.txt
 From within your virtual environment:
 
 ```
-$ py.tests
+$ pytest
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ calendar.events.append(
     Event(summary="Event summary", start=date(2022, 7, 3), end=date(2022, 7, 4)),
 )
 for event in calendar.timeline:
-    print(e.summary)
+    print(event.summary)
 ```
 
 # Reading ics files


### PR DESCRIPTION
- `py.tests` should be `py.test`, but the dot isn't usually used anymore nowadays
- The quickstart example uses `e`, but only `event` is defined