### PR TITLE
Simplify merged iterator based on PR feedback

### DIFF
--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -5,51 +5,11 @@ from typing import Iterable, Iterator
 
 import pytest
 
-from ical.iter import MergedIterable, MergedIterator, PeekingIterator, RecurIterable
+from ical.iter import MergedIterable, MergedIterator, RecurIterable
 
 EMPTY_LIST: list[bool] = []
 EMPTY_ITERATOR_LIST: list[Iterator[bool]] = []
 EMPTY_ITERABLE_LIST: list[Iterable[bool]] = []
-
-
-def test_peek_empty() -> None:
-    """Test the peeking iterator on an empty input."""
-    peek_it = PeekingIterator(iter(EMPTY_LIST))
-    assert not peek_it.peek()
-
-    with pytest.raises(StopIteration):
-        next(peek_it)
-
-    with pytest.raises(StopIteration):
-        next(iter(peek_it))
-
-
-def test_peek_first() -> None:
-    """Test peeking before consuming anything."""
-    peek_it = PeekingIterator(iter([1, 2, 3, 4]))
-    assert peek_it.peek() == 1
-    assert list(peek_it) == [1, 2, 3, 4]
-    assert not peek_it.peek()
-
-
-def test_peek_middle() -> None:
-    """Test peeking in the middle."""
-    peek_it = PeekingIterator(iter([1, 2, 3, 4]))
-    assert next(peek_it) == 1
-    assert peek_it.peek() == 2
-    assert list(peek_it) == [2, 3, 4]
-    assert not peek_it.peek()
-
-
-def test_peek_last() -> None:
-    """Test peeking at the last item."""
-    peek_it = PeekingIterator(iter([1, 2, 3, 4]))
-    assert next(peek_it) == 1
-    assert next(peek_it) == 2
-    assert next(peek_it) == 3
-    assert peek_it.peek() == 4
-    assert list(peek_it) == [4]
-    assert not peek_it.peek()
 
 
 def test_merged_empty() -> None:

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -54,7 +54,7 @@ def test_recur_empty() -> None:
 
 
 def test_merge_false_values() -> None:
-    """Test the merged iterator can handle Falsy values."""
+    """Test the merged iterator can handle values evaluating to False."""
     merged_it: Iterable[float | int] = MergedIterable([[0, 1], [-2, 0, 0.5, 2]])
     assert list(merged_it) == [-2, 0, 0, 0.5, 1, 2]
 

--- a/tests/test_iter.py
+++ b/tests/test_iter.py
@@ -1,5 +1,7 @@
 """Tests for the iter library."""
 
+from __future__ import annotations
+
 import datetime
 from typing import Iterable, Iterator
 
@@ -24,6 +26,9 @@ def test_merged_empty() -> None:
     with pytest.raises(StopIteration):
         next(MergedIterator(EMPTY_ITERATOR_LIST))
 
+    with pytest.raises(StopIteration):
+        next(MergedIterator([iter(EMPTY_LIST), iter(EMPTY_LIST)]))
+
 
 def test_merge_is_sorted() -> None:
     """Test that the merge result of two sorted inputs is sorted."""
@@ -46,3 +51,15 @@ def test_recur_empty() -> None:
     assert list(recur_it) == [True, False, True]
     # an iterator is an iterable
     assert list(iter(iter(recur_it))) == [True, False, True]
+
+
+def test_merge_false_values() -> None:
+    """Test the merged iterator can handle Falsy values."""
+    merged_it: Iterable[float | int] = MergedIterable([[0, 1], [-2, 0, 0.5, 2]])
+    assert list(merged_it) == [-2, 0, 0, 0.5, 1, 2]
+
+
+def test_merge_none_values() -> None:
+    """Test the merged iterator can handle None values."""
+    merged_it = MergedIterable([[None, None], [None]])
+    assert list(merged_it) == [None, None, None]


### PR DESCRIPTION
Simplify merged iterator based on PR feedback by removing the peeking iterator and instead using the heap as the place to store the next item. This only reads what is strictly necessary from input iterators in `MergedIterator`
