### PR TITLE
Rename cancel method to delete

### DIFF
--- a/ical/store.py
+++ b/ical/store.py
@@ -69,8 +69,8 @@ class EventStore:
 
     You may also delete an event, or a specific instance of a recurring event:
     ```python
-    # Cancel a single instance of the recurring event
-    store.cancel(uid=event.uid, recurrence_id="20220710")
+    # Delete a single instance of the recurring event
+    store.delete(uid=event.uid, recurrence_id="20220710")
     ```
 
     Then viewing the store using the `print` example removes the individual
@@ -118,7 +118,7 @@ class EventStore:
         self._ensure_timezone(event)
         return new_event
 
-    def cancel(
+    def delete(
         self,
         uid: str,
         recurrence_id: str | None = None,
@@ -126,15 +126,15 @@ class EventStore:
     ) -> None:
         """Delete the event from the calendar.
 
-        This method is used to cancel an existing event. For a recurring event
-        either the whole event or instances of an event may be cancelled. To
-        cancel the complete range of a recurring event, the `uid` property
+        This method is used to delete an existing event. For a recurring event
+        either the whole event or instances of an event may be deleted. To
+        delete the complete range of a recurring event, the `uid` property
         for the event must be specified and the `recurrence_id` should not
-        be specified. To cancel an individual instances of the event the
+        be specified. To delete an individual instances of the event the
         `recurrence_id` must be specified.
 
         When deleting individual instances, the range property may specify
-        if cancellation of just a specific instance, or a range of instances.
+        if deletion of just a specific instance, or a range of instances.
         """
         if not (store_event := self._lookup_event(uid)):
             raise ValueError(f"No existing event with uid: {uid}")
@@ -155,7 +155,7 @@ class EventStore:
             store_event.exdate.append(exdate)
             return
 
-        # Assumes any recurrence cancellation is valid, and that overwriting
+        # Assumes any recurrence deletion is valid, and that overwriting
         # the "until" value will not produce more instances.
         store_event.rrule.count = None
         store_event.rrule.until = exdate - datetime.timedelta(seconds=1)
@@ -235,7 +235,7 @@ class EventStore:
                 if store_event.dtend:
                     update["dtend"] = dtstart + store_event.computed_duration
 
-        # Make a deep copy since cancellation may update this objects recurrence rules
+        # Make a deep copy since deletion may update this objects recurrence rules
         new_event = store_event.copy(update=update, deep=True)
         if recurrence_id and new_event.rrule and new_event.rrule.count:
             # The recurring event count needs to skip any events that
@@ -245,10 +245,10 @@ class EventStore:
                     break
                 new_event.rrule.count = new_event.rrule.count - 1
 
-        # Editing a single instance of a recurring event is like canceling that instance
+        # Editing a single instance of a recurring event is like deleting that instance
         # then adding a new instance on the specified date. If recurrence id is not
         # specified then the entire event is replaced.
-        self.cancel(uid, recurrence_id=recurrence_id, recurrence_range=recurrence_range)
+        self.delete(uid, recurrence_id=recurrence_id, recurrence_range=recurrence_range)
         if recurrence_id:
             self.add(new_event)
         else:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -82,7 +82,7 @@ def test_empty_store(fetch_events: Callable[..., list[dict[str, Any]]]) -> None:
     assert fetch_events() == []
 
 
-def test_add_and_cancel_event(
+def test_add_and_delete_event(
     store: EventStore, fetch_events: Callable[..., list[dict[str, Any]]]
 ) -> None:
     """Test adding an event to the store and retrieval."""
@@ -104,7 +104,7 @@ def test_add_and_cancel_event(
             "sequence": 0,
         },
     ]
-    store.cancel("mock-uid-1")
+    store.delete("mock-uid-1")
     assert fetch_events() == []
 
 
@@ -172,7 +172,7 @@ def test_recurring_event(
     fetch_events: Callable[..., list[dict[str, Any]]],
     recur: Recur,
 ) -> None:
-    """Test adding a recurring event and canceling the entire series."""
+    """Test adding a recurring event and deleting the entire series."""
     store.add(
         Event(
             summary="Monday meeting",
@@ -213,7 +213,7 @@ def test_recurring_event(
             "summary": "Monday meeting",
         },
     ]
-    store.cancel("mock-uid-1")
+    store.delete("mock-uid-1")
     assert fetch_events(None) == []
 
 
@@ -224,12 +224,12 @@ def test_recurring_event(
         Recur.from_rrule("FREQ=WEEKLY;COUNT=5"),
     ],
 )
-def test_cancel_partial_recurring_event(
+def test_deletel_partial_recurring_event(
     store: EventStore,
     fetch_events: Callable[..., list[dict[str, Any]]],
     recur: Recur,
 ) -> None:
-    """Test adding a recurring event and cancelling part of the series."""
+    """Test adding a recurring event and deleting part of the series."""
     store.add(
         Event(
             summary="Monday meeting",
@@ -238,8 +238,8 @@ def test_cancel_partial_recurring_event(
             rrule=recur,
         )
     )
-    store.cancel(uid="mock-uid-1", recurrence_id="20220905T090000")
-    store.cancel(uid="mock-uid-1", recurrence_id="20220919T090000")
+    store.delete(uid="mock-uid-1", recurrence_id="20220905T090000")
+    store.delete(uid="mock-uid-1", recurrence_id="20220919T090000")
     assert fetch_events({"uid", "recurrence_id", "dtstart", "summary"}) == [
         {
             "uid": "mock-uid-1",
@@ -269,12 +269,12 @@ def test_cancel_partial_recurring_event(
         Recur.from_rrule("FREQ=WEEKLY;COUNT=5"),
     ],
 )
-def test_cancel_this_and_future_event(
+def test_delete_this_and_future_event(
     store: EventStore,
     fetch_events: Callable[..., list[dict[str, Any]]],
     recur: Recur,
 ) -> None:
-    """Test adding a recurring event and cancelling events after one event."""
+    """Test adding a recurring event and deleting events after one event."""
     store.add(
         Event(
             summary="Monday meeting",
@@ -283,7 +283,7 @@ def test_cancel_this_and_future_event(
             rrule=recur,
         )
     )
-    store.cancel(
+    store.delete(
         uid="mock-uid-1",
         recurrence_id="20220919T090000",
         recurrence_range=Range.THIS_AND_FUTURE,
@@ -459,7 +459,7 @@ def test_edit_recurring_event_this_and_future(
     ]
 
 
-def test_add_and_cancel_event_date(
+def test_add_and_delete_event_date(
     store: EventStore, fetch_events: Callable[..., list[dict[str, Any]]]
 ) -> None:
     """Test adding an event to the store and retrieval."""
@@ -481,11 +481,11 @@ def test_add_and_cancel_event_date(
             "sequence": 0,
         },
     ]
-    store.cancel("mock-uid-1")
+    store.delete("mock-uid-1")
     assert fetch_events() == []
 
 
-def test_cancel_event_date_recurring(
+def test_delete_event_date_recurring(
     store: EventStore, fetch_events: Callable[..., list[dict[str, Any]]]
 ) -> None:
     """Test adding an event to the store and retrieval."""
@@ -518,7 +518,7 @@ def test_cancel_event_date_recurring(
         },
     ]
 
-    store.cancel("mock-uid-1", recurrence_id="20220905")
+    store.delete("mock-uid-1", recurrence_id="20220905")
     assert fetch_events({"uid", "recurrence_id", "dtstart", "summary"}) == [
         {
             "uid": "mock-uid-1",
@@ -543,7 +543,7 @@ def test_invalid_uid(
         store.edit("invalid", Event(summary="example summary"))
 
     with pytest.raises(ValueError, match=r"No existing event with uid"):
-        store.cancel("invalid")
+        store.delete("invalid")
 
 
 def test_invalid_recurrence_id(
@@ -559,7 +559,7 @@ def test_invalid_recurrence_id(
     )
 
     with pytest.raises(ValueError, match=r"event is not recurring"):
-        store.cancel("mock-uid-1", recurrence_id="invalid")
+        store.delete("mock-uid-1", recurrence_id="invalid")
 
     with pytest.raises(ValueError, match=r"event is not recurring"):
         store.edit(


### PR DESCRIPTION
Rename cancel method to delete based on discussion: Cancellation implies it may still exist with a different status, vs deletion which entirely removes the event.