### PR TITLE
Add APIs for overriding the local timezone

### DIFF
--- a/ical/util.py
+++ b/ical/util.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 
 __all__ = [
-    "set_local_timezone",
+    "use_local_timezone",
     "dtstamp_factory",
     "uid_factory",
 ]
@@ -30,11 +30,12 @@ def uid_factory() -> str:
 
 
 @contextmanager
-def set_local_timezone(local_tz: datetime.tzinfo) -> Generator[None, None, None]:
+def use_local_timezone(local_tz: datetime.tzinfo) -> Generator[None, None, None]:
     """Set the local timezone to use when converting a date to datetime.
 
     This is expected to be used as a context manager when the default timezone
-    used by python is not the timezone to be used for calendar operations.
+    used by python is not the timezone to be used for calendar operations (the
+    attendees local timezone).
 
     Example:
     ```
@@ -42,7 +43,7 @@ def set_local_timezone(local_tz: datetime.tzinfo) -> Generator[None, None, None]
     import zoneinfo
     from ical.calendar import Calendar
     from ical.event import Event
-    from ical.util import set_local_timezone
+    from ical.util import use_local_timezone
 
     cal = Calendar()
     cal.events.append(
@@ -52,8 +53,8 @@ def set_local_timezone(local_tz: datetime.tzinfo) -> Generator[None, None, None]
             end=datetime.date(2022, 2, 2)
         )
     )
-    # Use UTC-8 as timezone
-    with set_local_timezone(zoneinfo.ZoneInfo("America/Los_Angeles")):
+    # Use UTC-8 as local timezone
+    with use_local_timezone(zoneinfo.ZoneInfo("America/Los_Angeles")):
         # Returns event above
         events = cal.timeline.start_after(
             datetime.datetime(2022, 2, 1, 7, 59, 59, tzinfo=datetime.timezone.utc))

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -14,7 +14,7 @@ from freezegun import freeze_time
 from ical.calendar import Calendar
 from ical.calendar_stream import IcsCalendarStream
 from ical.event import Event
-from ical.util import set_local_timezone
+from ical.util import use_local_timezone
 
 
 @pytest.fixture(name="calendar")
@@ -318,6 +318,6 @@ def test_all_day_with_local_timezone(
         nonlocal cal
         return [e.summary for e in cal.timeline.start_after(dtstart)]
 
-    with set_local_timezone(zoneinfo.ZoneInfo(tzname)):
+    with use_local_timezone(zoneinfo.ZoneInfo(tzname)):
         assert start_after(dt_before) == ["event"]
         assert not start_after(dt_after)


### PR DESCRIPTION
Allow using a timezone different than the python system timezone. This is needed where a user may set an application level timezone not matching the system timezone (e.g. like HomeAssistant)

The default timezones are currently awkward to pass through the pydantic data model or normalization APIs, so this uses a context manager, allowing flexible use at calendar operation time. There may be a better way in the future to set this at a calendar level, but this is the least intrusive for now.

The `util.local_timezone` method is no longer exposed by the API, since it was previously exposed for mocking and no longer needed.