### PR TITLE
Remove timezone context manager with improved timespan/timeline APIs

### DIFF
--- a/ical/__init__.py
+++ b/ical/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "journal",
     "store",
     "timeline",
+    "timespan",
     "timezone",
     "todo",
     "types",

--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -63,7 +63,7 @@ class Calendar(ComponentModel):
         """Return a timeline view of events on the calendar.
 
         All events are returned as if the attendee is viewing from the
-        specified timezone. For examlpe, this affects the order that All Day
+        specified timezone. For example, this affects the order that All Day
         events are returned.
         """
         return calendar_timeline(self.events, tzinfo=tzinfo)

--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 from importlib import metadata
 from typing import Optional
 
@@ -52,5 +53,17 @@ class Calendar(ComponentModel):
 
     @property
     def timeline(self) -> Timeline:
-        """Return a timeline view of events on the calendar."""
-        return calendar_timeline(self.events)
+        """Return a timeline view of events on the calendar.
+
+        All day events are returned as if the attendee is viewing from UTC time.
+        """
+        return self.timeline_tz()
+
+    def timeline_tz(self, tzinfo: datetime.tzinfo = datetime.timezone.utc) -> Timeline:
+        """Return a timeline view of events on the calendar.
+
+        All events are returned as if the attendee is viewing from the
+        specified timezone. For examlpe, this affects the order that All Day
+        events are returned.
+        """
+        return calendar_timeline(self.events, tzinfo=tzinfo)

--- a/ical/timespan.py
+++ b/ical/timespan.py
@@ -16,6 +16,8 @@ from typing import Any
 
 from .util import normalize_datetime
 
+__all__ = ["Timespan"]
+
 
 class Timespan:
     """An unambiguous definition of a start and end time.

--- a/ical/timespan.py
+++ b/ical/timespan.py
@@ -1,0 +1,112 @@
+"""A timespan is defined by a start and end time and used for comparisons.
+
+A common way to compare events is by comparing their start and end time. Often
+there are corner cases such as an all day event which does not specify a
+specific time, but instead needs to be interpreted in the timezone of the
+attendee. A timespan is unambiguous in that it is created with that timezone.
+
+A `Timespan` is not instantiated directly, but created by a calendar component
+such as an `Event`.
+"""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any
+
+from .util import normalize_datetime
+
+
+class Timespan:
+    """An unambiguous definition of a start and end time.
+
+    A timespan is not ambiguous in that it can never be a "floating" time range
+    and instead is always aligned to some kind of timezone or utc.
+    """
+
+    def __init__(self, start: datetime.datetime, end: datetime.datetime) -> None:
+        """..."""
+        self._start = start
+        self._end = end
+        if not self._start.tzinfo:
+            raise ValueError(f"Start time did not have a timezone: {self._start}")
+        self._tzinfo = self._start.tzinfo
+
+    @classmethod
+    def of(  # pylint: disable=invalid-name]
+        cls,
+        start: datetime.date | datetime.datetime,
+        end: datetime.date | datetime.datetime,
+    ) -> "Timespan":
+        """Create a Timestapn for the specified date range."""
+        return Timespan(normalize_datetime(start), normalize_datetime(end))
+
+    @property
+    def start(self) -> datetime.datetime:
+        """Return the timespan start as a datetime."""
+        return self._start
+
+    @property
+    def end(self) -> datetime.datetime:
+        """Return the timespan end as a datetime."""
+        return self._end
+
+    @property
+    def tzinfo(self) -> datetime.tzinfo:
+        """Return the timespan timezone."""
+        return self._tzinfo
+
+    @property
+    def duration(self) -> datetime.timedelta:
+        """Return the timespan duration."""
+        return self.end - self.start
+
+    def starts_within(self, other: "Timespan") -> bool:
+        """Return True if this timespan starts while the other timespan is active."""
+        return other.start <= self.start < other.end
+
+    def ends_within(self, other: "Timespan") -> bool:
+        """Return True if this timespan ends while the other event is active."""
+        return other.start <= self.end < other.end
+
+    def intersects(self, other: "Timespan") -> bool:
+        """Return True if this timespan overlaps with the other event."""
+        return (
+            other.start <= self.start < other.end
+            or other.start < self.end <= other.end
+            or self.start <= other.start < self.end
+            or self.start < other.end <= self.end
+        )
+
+    def includes(self, other: "Timespan") -> bool:
+        """Return True if the other timespan starts and ends within this event."""
+        return (
+            self.start <= other.start < self.end and self.start <= other.end < self.end
+        )
+
+    def is_included_in(self, other: "Timespan") -> bool:
+        """Return True if this timespan starts and ends within the other event."""
+        return other.start <= self.start and self.end < other.end
+
+    def _tuple(self) -> tuple[datetime.datetime, datetime.datetime]:
+        return (self.start, self.end)
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, Timespan):
+            return NotImplemented
+        return self._tuple() < other._tuple()
+
+    def __gt__(self, other: Any) -> bool:
+        if not isinstance(other, Timespan):
+            return NotImplemented
+        return self._tuple() > other._tuple()
+
+    def __le__(self, other: Any) -> bool:
+        if not isinstance(other, Timespan):
+            return NotImplemented
+        return self._tuple() <= other._tuple()
+
+    def __ge__(self, other: Any) -> bool:
+        if not isinstance(other, Timespan):
+            return NotImplemented
+        return self._tuple() >= other._tuple()

--- a/ical/util.py
+++ b/ical/util.py
@@ -4,19 +4,14 @@ from __future__ import annotations
 
 import datetime
 import uuid
-from collections.abc import Generator
-from contextlib import contextmanager
-from contextvars import ContextVar
 
 __all__ = [
-    "use_local_timezone",
     "dtstamp_factory",
     "uid_factory",
 ]
 
 
 MIDNIGHT = datetime.time()
-LOCAL_TZ = ContextVar[datetime.tzinfo]("_local_tz")
 
 
 def dtstamp_factory() -> datetime.datetime:
@@ -29,61 +24,19 @@ def uid_factory() -> str:
     return str(uuid.uuid1())
 
 
-@contextmanager
-def use_local_timezone(local_tz: datetime.tzinfo) -> Generator[None, None, None]:
-    """Set the local timezone to use when converting a date to datetime.
-
-    This is expected to be used as a context manager when the default timezone
-    used by python is not the timezone to be used for calendar operations (the
-    attendees local timezone).
-
-    Example:
-    ```
-    import datetime
-    import zoneinfo
-    from ical.calendar import Calendar
-    from ical.event import Event
-    from ical.util import use_local_timezone
-
-    cal = Calendar()
-    cal.events.append(
-        Event(
-            summary="Example",
-            start=datetime.date(2022, 2, 1),
-            end=datetime.date(2022, 2, 2)
-        )
-    )
-    # Use UTC-8 as local timezone
-    with use_local_timezone(zoneinfo.ZoneInfo("America/Los_Angeles")):
-        # Returns event above
-        events = cal.timeline.start_after(
-            datetime.datetime(2022, 2, 1, 7, 59, 59, tzinfo=datetime.timezone.utc))
-
-        # Does not return event above
-        events = cal.timeline.start_after(
-            datetime.datetime(2022, 2, 1, 8, 00, 00, tzinfo=datetime.timezone.utc))
-    ```
-    """
-    orig_tz = LOCAL_TZ.set(local_tz)
-    try:
-        yield
-    finally:
-        LOCAL_TZ.reset(orig_tz)
-
-
 def local_timezone() -> datetime.tzinfo:
     """Get the local timezone to use when converting date to datetime."""
-    if local_tz := LOCAL_TZ.get(None):
-        return local_tz
     if local_tz := datetime.datetime.now().astimezone().tzinfo:
         return local_tz
     return datetime.timezone.utc
 
 
-def normalize_datetime(value: datetime.date | datetime.datetime) -> datetime.datetime:
+def normalize_datetime(
+    value: datetime.date | datetime.datetime, tzinfo: datetime.tzinfo | None = None
+) -> datetime.datetime:
     """Convert date or datetime to a value that can be used for comparison."""
     if not isinstance(value, datetime.datetime):
         value = datetime.datetime.combine(value, MIDNIGHT)
     if value.tzinfo is None:
-        value = value.replace(tzinfo=local_timezone())
+        value = value.replace(tzinfo=tzinfo if tzinfo else local_timezone())
     return value

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -356,7 +356,7 @@ def test_parse_event_timezones(
     assert event.end == end
 
 
-def test_all_day_timezones() -> None:
+def test_all_day_timezones_default() -> None:
     """Test behavior of all day events interacting with timezones."""
     with patch(
         "ical.util.local_timezone", return_value=zoneinfo.ZoneInfo("America/Regina")
@@ -366,6 +366,32 @@ def test_all_day_timezones() -> None:
             2022, 8, 1, 6, 0, 0, tzinfo=timezone.utc
         )
         assert event.end_datetime == datetime(2022, 8, 2, 6, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "dtstart,dtend",
+    [
+        (
+            datetime(2022, 8, 1, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Regina")),
+            datetime(2022, 8, 2, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Regina")),
+        ),
+        (
+            datetime(
+                2022, 8, 1, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Los_Angeles")
+            ),
+            datetime(
+                2022, 8, 2, 0, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Los_Angeles")
+            ),
+        ),
+    ],
+)
+def test_all_day_timespan_timezone_explicit(dtstart: datetime, dtend: datetime) -> None:
+    """Test behavior of all day events interacting with timezones specified explicitly."""
+    event = Event(summary=SUMMARY, start=date(2022, 8, 1), end=date(2022, 8, 2))
+    assert dtstart.tzinfo
+    timespan = event.timespan_of(dtstart.tzinfo)
+    assert timespan.start == dtstart
+    assert timespan.end == dtend
 
 
 def test_validate_assignment() -> None:


### PR DESCRIPTION
Introduces a `Timespan` that is a holder of start/end time information. The Timespan is defined as a duration that is unambiguous with respect to the timezone information such that it can be compared to other timespans, such as an all day
event, with clarity.   This PR removes timezone context manager with improved timespan/timeline API.

This is meant to be a more explicit way to set the attendee timezone when using the timespan/timeline and event comparisons.