### PR TITLE
Improve timeline performance

### DIFF
--- a/.github/workflows/python-benchmark.yaml
+++ b/.github/workflows/python-benchmark.yaml
@@ -1,0 +1,33 @@
+name: Python benchmarks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
+    - name: Run benchmarks with pytest
+      run: |
+        pytest --benchmark-only

--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -16,6 +16,7 @@ from .parsing.property import ParsedProperty
 from .timeline import Timeline, calendar_timeline
 from .timezone import Timezone
 from .todo import Todo
+from .util import local_timezone
 
 _VERSION = metadata.version("ical")
 _PRODID = metadata.metadata("ical")["prodid"]
@@ -59,11 +60,11 @@ class Calendar(ComponentModel):
         """
         return self.timeline_tz()
 
-    def timeline_tz(self, tzinfo: datetime.tzinfo = datetime.timezone.utc) -> Timeline:
+    def timeline_tz(self, tzinfo: datetime.tzinfo | None = None) -> Timeline:
         """Return a timeline view of events on the calendar.
 
         All events are returned as if the attendee is viewing from the
         specified timezone. For example, this affects the order that All Day
         events are returned.
         """
-        return calendar_timeline(self.events, tzinfo=tzinfo)
+        return calendar_timeline(self.events, tzinfo=tzinfo or local_timezone())

--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -15,7 +15,13 @@ from collections.abc import Iterable, Iterator
 from dateutil import rrule
 
 from .event import Event
-from .iter import MergedIterable, RecurIterable
+from .iter import (
+    LazySortableItem,
+    MergedIterable,
+    RecurIterable,
+    SortableItem,
+    SortableItemValue,
+)
 from .timespan import Timespan
 from .types.recur import RecurrenceId
 from .util import normalize_datetime
@@ -32,12 +38,13 @@ class Timeline(Iterable[Event]):
     typically not instantiated directly.
     """
 
-    def __init__(self, iterable: Iterable[Event]) -> None:
+    def __init__(self, iterable: Iterable[SortableItem[Timespan, Event]]) -> None:
         self._iterable = iterable
 
     def __iter__(self) -> Iterator[Event]:
         """Return an iterator as a traversal over events in chronological order."""
-        return iter(self._iterable)
+        for item in self._iterable:
+            yield item.item
 
     def included(
         self,
@@ -49,11 +56,10 @@ class Timeline(Iterable[Event]):
         The end date is exclusive.
         """
         timespan = Timespan.of(start, end)
-        for event in self:
-            timesp = event.timespan_of(timespan.tzinfo)
-            if timesp.is_included_in(timespan):
-                yield event
-            elif timesp > timespan:
+        for item in self._iterable:
+            if item.key.is_included_in(timespan):
+                yield item.item
+            elif item.key > timespan:
                 break
 
     def overlapping(
@@ -66,11 +72,10 @@ class Timeline(Iterable[Event]):
         The end date is exclusive.
         """
         timespan = Timespan.of(start, end)
-        for event in self:
-            timesp = event.timespan_of(timespan.tzinfo)
-            if timesp.intersects(timespan):
-                yield event
-            elif timesp > timespan:
+        for item in self._iterable:
+            if item.key.intersects(timespan):
+                yield item.item
+            elif item.key > timespan:
                 break
 
     def start_after(
@@ -81,9 +86,9 @@ class Timeline(Iterable[Event]):
         instant_value = normalize_datetime(instant)
         if not instant_value.tzinfo:
             raise ValueError("Expected tzinfo to be set on normalized datetime")
-        for event in self:
-            if event.timespan_of(instant_value.tzinfo).start > instant_value:
-                yield event
+        for item in self._iterable:
+            if item.key.start > instant_value:
+                yield item.item
 
     def active_after(
         self,
@@ -93,10 +98,9 @@ class Timeline(Iterable[Event]):
         instant_value = normalize_datetime(instant)
         if not instant_value.tzinfo:
             raise ValueError("Expected tzinfo to be set on normalized datetime")
-        for event in self:
-            timesp = event.timespan_of(instant_value.tzinfo)
-            if timesp.start > instant_value or timesp.end > instant_value:
-                yield event
+        for item in self._iterable:
+            if item.key.start > instant_value or item.key.end > instant_value:
+                yield item.item
 
     def at_instant(
         self,
@@ -104,11 +108,12 @@ class Timeline(Iterable[Event]):
     ) -> Iterator[Event]:  # pylint: disable
         """Return an iterator containing events starting after the specified time."""
         timespan = Timespan.of(instant, instant)
-        for event in self:
-            timesp = event.timespan_of(timespan.tzinfo)
-            if timesp.includes(timespan):
-                yield event
-            elif timesp > timespan:
+        for item in self._iterable:
+            _LOGGER.debug("Checking item: s=%s, %s", item.key.start, timespan.start)
+            _LOGGER.debug("Checking item: e=%s, %s", item.key.end, timespan.end)
+            if item.key.includes(timespan):
+                yield item.item
+            elif item.key > timespan:
                 break
 
     def on_date(self, day: datetime.date) -> Iterator[Event]:  # pylint: disable
@@ -124,7 +129,7 @@ class Timeline(Iterable[Event]):
         return self.at_instant(datetime.datetime.now())
 
 
-class EventIterable(Iterable[Event]):
+class EventIterable(Iterable[SortableItem[Timespan, Event]]):
     """Iterable that returns events in sorted order.
 
     This iterable will ignore recurring events entirely.
@@ -135,19 +140,20 @@ class EventIterable(Iterable[Event]):
         self._iterable = iterable
         self._tzinfo = tzinfo
 
-    def __iter__(self) -> Iterator[Event]:
+    def __iter__(self) -> Iterator[SortableItem[Timespan, Event]]:
         """Return an iterator as a traversal over events in chronological order."""
         # Using a heap is faster than sorting if the number of events (n) is
         # much bigger than the number of events we extract from the iterator (k).
         # Complexity: O(n + k log n).
-        heap: list[tuple[datetime.date | datetime.datetime, Event]] = []
+        heap: list[SortableItem[Timespan, Event]] = []
         for event in iter(self._iterable):
             if event.rrule or event.rdate:
                 continue
-            heapq.heappush(heap, (event.timespan_of(self._tzinfo).start, event))
+            heapq.heappush(
+                heap, SortableItemValue(event.timespan_of(self._tzinfo), event)
+            )
         while heap:
-            (_, event) = heapq.heappop(heap)
-            yield event
+            yield heapq.heappop(heap)
 
 
 class RecurAdapter:
@@ -164,24 +170,33 @@ class RecurAdapter:
         self._event_duration = event.computed_duration
         self._is_all_day = not isinstance(self._event.dtstart, datetime.datetime)
 
-    def get(self, dtstart: datetime.datetime | datetime.date) -> Event:
-        """Return the next event in the recurrence."""
+    def get(
+        self, dtstart: datetime.datetime | datetime.date
+    ) -> SortableItem[Timespan, Event]:
+        """Return a lazy sortable item."""
         if self._is_all_day and isinstance(dtstart, datetime.datetime):
             # Convert back to datetime.date if needed for the original event
             dtstart = datetime.date.fromordinal(dtstart.toordinal())
-        return self._event.copy(
-            deep=True,
-            update={
-                "dtstart": dtstart,
-                "dtend": dtstart + self._event_duration,
-                "recurrence_id": RecurrenceId.__parse_property_value__(dtstart),
-            },
+
+        def build() -> Event:
+            return self._event.copy(
+                update={
+                    "dtstart": dtstart,
+                    "dtend": dtstart + self._event_duration,
+                    "recurrence_id": RecurrenceId.__parse_property_value__(dtstart),
+                },
+            )
+
+        return LazySortableItem(
+            Timespan.of(dtstart, dtstart + self._event_duration), build
         )
 
 
 def calendar_timeline(events: list[Event], tzinfo: datetime.tzinfo) -> Timeline:
     """Create a timeline for events on a calendar, including recurrence."""
-    iters: list[Iterable[Event]] = [EventIterable(events, tzinfo=tzinfo)]
+    iters: list[Iterable[SortableItem[Timespan, Event]]] = [
+        EventIterable(events, tzinfo=tzinfo)
+    ]
     for event in events:
         if not event.rrule and not event.rdate:
             continue

--- a/ical/timespan.py
+++ b/ical/timespan.py
@@ -90,25 +90,22 @@ class Timespan:
         """Return True if this timespan starts and ends within the other event."""
         return other.start <= self.start and self.end < other.end
 
-    def _tuple(self) -> tuple[datetime.datetime, datetime.datetime]:
-        return (self.start, self.end)
-
     def __lt__(self, other: Any) -> bool:
         if not isinstance(other, Timespan):
             return NotImplemented
-        return self._tuple() < other._tuple()
+        return (self._start, self._end) < (other.start, other.end)
 
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, Timespan):
             return NotImplemented
-        return self._tuple() > other._tuple()
+        return (self._start, self._end) > (other.start, other.end)
 
     def __le__(self, other: Any) -> bool:
         if not isinstance(other, Timespan):
             return NotImplemented
-        return self._tuple() <= other._tuple()
+        return (self._start, self._end) <= (other.start, other.end)
 
     def __ge__(self, other: Any) -> bool:
         if not isinstance(other, Timespan):
             return NotImplemented
-        return self._tuple() >= other._tuple()
+        return (self._start, self._end) >= (other.start, other.end)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,4 @@
 [pytest]
 log_level = DEBUG
+# Can be run manually with --benchmark-only
+addopts = --benchmark-skip

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ pdoc==12.1.0
 pip==22.1.2
 pylint==2.14.4
 pytest==7.1.2
+pytest-benchmark==3.4.1
 pytest-cov==3.0.0
 pytest-golden==0.2.2
 types-python-dateutil==2.8.19

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -355,7 +355,7 @@ def test_mixed_iteration_order(calendar_mixed: Calendar) -> None:
     """Test iteration order of all day events based on the attendee timezone."""
 
     # UTC order
-    assert [e.summary for e in calendar_mixed.timeline] == [
+    assert [e.summary for e in calendar_mixed.timeline_tz(datetime.timezone.utc)] == [
         "All Day",
         "Event @ 5UTC",
         "Event @ 7 UTC",
@@ -409,11 +409,11 @@ def test_all_day_with_local_timezone(
         ]
     )
 
-    def start_after(dtstart: datetime.datetime) -> list[str]:
-        nonlocal cal
-        return [e.summary for e in cal.timeline.start_after(dtstart)]
-
     local_tz = zoneinfo.ZoneInfo(tzname)
+
+    def start_after(dtstart: datetime.datetime) -> list[str]:
+        nonlocal cal, local_tz
+        return [e.summary for e in cal.timeline_tz(local_tz).start_after(dtstart)]
 
     local_before = dt_before.astimezone(local_tz)
     assert start_after(local_before) == ["event"]

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -1,0 +1,55 @@
+"""Tests for the timeline library."""
+
+import datetime
+import random
+import zoneinfo
+from typing import Any
+
+import pytest
+
+from ical.calendar import Calendar
+from ical.event import Event
+from ical.types.recur import Recur
+
+TZ = zoneinfo.ZoneInfo("America/Regina")
+
+
+@pytest.fixture(name="calendar")
+def fake_calendar(num_events: int, num_instances: int) -> Calendar:
+    """Fixture for creating a fake calendar of items."""
+    cal = Calendar()
+    for i in range(num_events):
+        delta = datetime.timedelta(days=int(365 * random.random()))
+        cal.events.append(
+            Event(
+                summary=f"Event {i}",
+                start=datetime.date(2022, 2, 1) + delta,
+                end=datetime.date(2000, 2, 2) + delta,
+                rrule=Recur.from_rrule(f"FREQ=DAILY;COUNT={num_instances}"),
+            )
+        )
+    return cal
+
+
+@pytest.mark.parametrize(
+    "num_events,num_instances",
+    [
+        (10, 10),
+        (10, 100),
+        (10, 1000),
+        (100, 10),
+        (100, 100),
+    ],
+)
+@pytest.mark.benchmark(min_rounds=1, cprofile=True, warmup=False)
+def test_benchmark_merged_iter(
+    calendar: Calendar, num_events: int, num_instances: int, benchmark: Any
+) -> None:
+    """Add a benchmark for the merged iterator."""
+
+    def exhaust() -> int:
+        nonlocal calendar
+        return sum(1 for _ in calendar.timeline_tz(TZ))
+
+    result = benchmark(exhaust)
+    assert result == num_events * num_instances


### PR DESCRIPTION
Improve timeline performance by avoiding unnecessary copying of event objects into the heap during iteration. The approach is to introduce an additional object that is put onto the heap called a `SortableItem`. This object holds a key that is used for sorting (see `__lt__`) while on the heap and has another property to return the actual item.  The `Timeline`, merged iterators for recurrence rules, and original event iterator have been updated to build this instead, and performance is much faster.

Adds a benchmark that is run as part of a new github workflow or can be run manually.

Some additional parts of the timeline abstractions have now been made generic so they can be shared with other libraries implementing recurring events in a performant way.