### PR TITLE
Fix broken test that fails in STD time

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -26,7 +26,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
         if [ -f requirements_dev.txt ]; then pip install -r requirements_dev.txt; fi
     - name: Lint with flake8
       run: |

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,5 +12,6 @@ pytest-cov==3.0.0
 pytest-golden==0.2.2
 types-python-dateutil==2.8.19
 flake8==5.0.4
-flake8-black==0.3.3
+flake8-black==0.3.5
+black==22.10.0
 wheel==0.37.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,4 +11,6 @@ pytest-benchmark==3.4.1
 pytest-cov==3.0.0
 pytest-golden==0.2.2
 types-python-dateutil==2.8.19
+flake8==5.0.4
+flake8-black==0.3.3
 wheel==0.37.1

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -81,7 +81,7 @@ def test_start_end_duration(
         (
             date(2022, 9, 6),
             date(2022, 9, 7),
-            datetime(2022, 9, 6, 8, 0, 0, tzinfo=timezone.utc),
+            datetime(2022, 9, 6, 8, 0, 1, tzinfo=timezone.utc),
             datetime(2022, 9, 6, 8, 30, 0, tzinfo=timezone.utc),
         ),
     ],


### PR DESCRIPTION
Fix broken test that fails in STD time because the generated start date is equal, not strictly less than the other start date.