### PR TITLE
Improve debugging of recurrence errors and fix rdate handling

### DIFF
--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -122,15 +122,11 @@ class RecurAdapter:
         """Initialize the RecurAdapter."""
         self._event = event
         self._event_duration = event.computed_duration
-        self._is_all_day = not isinstance(self._event.dtstart, datetime.datetime)
 
     def get(
         self, dtstart: datetime.datetime | datetime.date
     ) -> SortableItem[Timespan, Event]:
         """Return a lazy sortable item."""
-        if self._is_all_day and isinstance(dtstart, datetime.datetime):
-            # Convert back to datetime.date if needed for the original event
-            dtstart = datetime.date.fromordinal(dtstart.toordinal())
 
         def build() -> Event:
             return self._event.copy(

--- a/tests/types/test_recur.py
+++ b/tests/types/test_recur.py
@@ -684,3 +684,33 @@ def test_recur_until_as_string() -> None:
     )
     assert event.rrule
     assert event.rrule.as_rrule_str() == "FREQ=DAILY;UNTIL=20220810T060000;INTERVAL=1"
+
+
+def test_rdate_all_day() -> None:
+    """Test how all day events are handled with RDATE."""
+
+    calendar = Calendar()
+    calendar.events.extend(
+        [
+            Event(
+                summary="Monthly Event",
+                start=datetime.date(2022, 8, 2),
+                end=datetime.date(2022, 8, 2),
+                rdate=[
+                    datetime.date(2022, 8, 3),
+                    datetime.date(2022, 8, 4),
+                    datetime.date(2022, 10, 3),
+                ],
+                rrule=Recur.from_rrule("FREQ=MONTHLY;COUNT=3"),
+            ),
+        ]
+    )
+    events = list(calendar.timeline)
+    assert [(event.start, event.summary) for event in events] == [
+        (datetime.date(2022, 8, 2), "Monthly Event"),
+        (datetime.date(2022, 8, 3), "Monthly Event"),
+        (datetime.date(2022, 8, 4), "Monthly Event"),
+        (datetime.date(2022, 9, 2), "Monthly Event"),
+        (datetime.date(2022, 10, 2), "Monthly Event"),
+        (datetime.date(2022, 10, 3), "Monthly Event"),
+    ]


### PR DESCRIPTION
Move the logic for `dateutile.rrule` wrapping into a separate `Iterable` that can (1) Have a common shared place for working around `dateutil.rrule` limitations and (2) improve debugging with a common exception handler for issues like 

https://github.com/home-assistant/core/issues/83040

```
  File "/usr/local/lib/python3.10/site-packages/ical/iter.py", line 113, in __iter__
    for dtvalue in self._recur:
  File "/usr/local/lib/python3.10/site-packages/dateutil/rrule.py", line 1396, in _iter
    heapq.heapify(rlist)
  File "/usr/local/lib/python3.10/site-packages/dateutil/rrule.py", line 1338, in __lt__
    return self.dt < other.dt
TypeError: can't compare datetime.datetime to datetime.date
```

This also imports an improvement for `RDATE` handling that was corrected in `gcal_sync`, so now it is also included in the common library.