### PR TITLE
Improve multi-language support and improve performance

### DIFF
--- a/ical/parsing/parser.py
+++ b/ical/parsing/parser.py
@@ -25,6 +25,7 @@ Note: This specific example may be a bit confusing because one of the property p
 """
 
 import logging
+from functools import cache
 from typing import cast
 
 from pyparsing import (
@@ -53,6 +54,7 @@ from .unicode import SAFE_CHAR, VALUE_CHAR
 _LOGGER = logging.getLogger(__name__)
 
 
+@cache
 def _create_parser() -> ParserElement:
     """Create rfc5545 parser."""
     iana_token = Word(alphanums + "-")

--- a/ical/parsing/parser.py
+++ b/ical/parsing/parser.py
@@ -25,6 +25,7 @@ Note: This specific example may be a bit confusing because one of the property p
 """
 
 import logging
+import threading
 from functools import cache
 from typing import cast
 
@@ -91,12 +92,19 @@ def _create_parser() -> ParserElement:
         + Word(VALUE_CHAR)[0, 1].set_results_name(PARSE_VALUE)
     )
     contentline.set_whitespace_chars("")
+    if _LOGGER.isEnabledFor(logging.DEBUG):
+        contentline.set_debug(flag=True)
     return cast(ParserElement, contentline)
 
 
+_parser_lock = threading.Lock()
+
+
 def parse_contentlines(lines: list[str]) -> list[ParseResults]:
-    """Parse a set of unfolded lines into parse results."""
-    parser = _create_parser()
-    if _LOGGER.isEnabledFor(logging.DEBUG):
-        parser.set_debug(flag=True)
-    return [parser.parse_string(line, parse_all=True) for line in lines if line]
+    """Parse a set of unfolded lines into parse results.
+
+    Note, this method is not threadsafe and may be called from only one method at a time.
+    """
+    with _parser_lock:
+        parser = _create_parser()
+        return [parser.parse_string(line, parse_all=True) for line in lines if line]

--- a/ical/parsing/unicode.py
+++ b/ical/parsing/unicode.py
@@ -100,4 +100,6 @@ class ValueChar(CharRange):
     ]
 
 
-VALUE_CHAR = "".join(WSP + ValueChar.all() + NON_US_ASCII)
+VALUE_CHAR = "".join(
+    WSP + ValueChar.all() + NON_US_ASCII + BasicMultilingualPlane.all()
+)

--- a/tests/parsing/test_component.py
+++ b/tests/parsing/test_component.py
@@ -1,6 +1,7 @@
 """Tests for parsing raw components."""
 
 import json
+from typing import Any
 
 import pytest
 from pytest_golden.plugin import GoldenTestFixture
@@ -24,3 +25,17 @@ def test_encode_contentlines(golden: GoldenTestFixture) -> None:
     values = parse_content(golden["input"])
     ics = encode_content(values)
     assert ics == golden.get("encoded", golden["input"])
+
+
+@pytest.mark.golden_test("testdata/*.yaml")
+def test_parse_contentlines_benchmark(
+    golden: GoldenTestFixture, json_encoder: json.JSONEncoder, benchmark: Any
+) -> None:
+    """Benchmark to measure the speed of parsing."""
+
+    def parse() -> None:
+        values = parse_content(golden["input"])
+        values = json.loads(json_encoder.encode(values))
+        assert values == golden["output"]
+
+    benchmark(parse)

--- a/tests/parsing/test_unicode.py
+++ b/tests/parsing/test_unicode.py
@@ -1,5 +1,7 @@
 """Tests for unicode specific handling."""
 
+import pytest
+
 from ical.parsing.unicode import SAFE_CHAR, VALUE_CHAR
 
 
@@ -27,3 +29,23 @@ def test_value_char() -> None:
     assert ";" in VALUE_CHAR
     assert "," in VALUE_CHAR
     assert "🎄" in VALUE_CHAR
+
+
+@pytest.mark.parametrize(
+    "word",
+    [
+        "žmogus",
+        "中文",
+        "кириллица",
+        "Ελληνικά",
+        "עִברִית",
+        "日本語",
+        "한국어",
+        "ไทย",
+        "देवनागरी",
+    ],
+)
+def test_languages(word: str) -> None:
+    """Test basic values in non-english character sets are valid."""
+    for char in word:
+        assert char in VALUE_CHAR


### PR DESCRIPTION
Improve multi-language support and improve performance by adding caching of parser creation.

Addresses https://github.com/home-assistant/core/issues/83503

This adds a benchmark that shows that the timing when from ms to us for the parsing tests. The pyparsing parser is reused which is how the speedup is achieved. Add a lock on the pyparsing parser created which is reused for extra safety given its not threadsafe. In most contexts this is probably not necessarily, but given the huge speedup it seems acceptable to add the lock overhead for extra safety in case this is reused in multiple contexts (e.g. gcal and ical in the same system)