### PR TITLE
Allow edits of events to change the recurrence rule going forward

### DIFF
--- a/ical/store.py
+++ b/ical/store.py
@@ -198,6 +198,15 @@ class EventStore:
         update = self._prepare_update(
             store_event, event, recurrence_id, recurrence_range
         )
+        if recurrence_range == Range.NONE:
+            if event.rrule and (
+                not store_event.rrule
+                or event.rrule.as_rrule_str() != store_event.rrule.as_rrule_str()
+            ):
+                raise ValueError(
+                    f"Can't update single instance with rrule (rrule={event.rrule})"
+                )
+            event.rrule = None
 
         # Make a deep copy since deletion may update this objects recurrence rules
         new_event = store_event.copy(update=update, deep=True)
@@ -248,7 +257,6 @@ class EventStore:
                 # The new event copied from the original is a single instance,
                 # not recurrin
                 update["rrule"] = None
-                update["rdate"] = []
             else:
                 # Overwriting with a new recurring event
                 update.update(

--- a/ical/store.py
+++ b/ical/store.py
@@ -236,7 +236,7 @@ class EventStore:
         recurrence_id: str | None = None,
         recurrence_range: Range = Range.NONE,
     ) -> dict[str, Any]:
-        """Prepare an update to an existin gevent."""
+        """Prepare an update to an existing event."""
         partial_update = event.dict(exclude_unset=True)
         _LOGGER.debug("EV update=%s", event)
         update = {

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -408,6 +408,33 @@ def test_edit_recurring_event_instance(
     ]
 
 
+def test_cant_change_recurrence_for_event_instance(
+    store: EventStore,
+    frozen_time: FrozenDateTimeFactory,
+) -> None:
+    """Test editing all instances of a recurring event."""
+    store.add(
+        Event(
+            summary="Monday meeting",
+            start="2022-08-29T09:00:00",
+            end="2022-08-29T09:30:00",
+            rrule=Recur.from_rrule("FREQ=WEEKLY;COUNT=3"),
+        )
+    )
+
+    frozen_time.tick(delta=datetime.timedelta(seconds=10))
+    with pytest.raises(ValueError, match="single instance with rrule"):
+        store.edit(
+            "mock-uid-1",
+            Event(
+                start="2022-09-06T09:00:00",
+                summary="Tuesday meeting",
+                rrule=Recur.from_rrule("FREQ=DAILY;COUNT=3"),
+            ),
+            recurrence_id="20220905T090000",
+        )
+
+
 @pytest.mark.parametrize(
     "recur",
     [

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -535,6 +535,52 @@ def test_delete_event_date_recurring(
     ]
 
 
+def test_edit_recurrence_rule_this_and_future(
+    store: EventStore,
+    fetch_events: Callable[..., list[dict[str, Any]]],
+    frozen_time: FrozenDateTimeFactory,
+) -> None:
+    """Test editing all instances of a recurring event."""
+    store.add(
+        Event(
+            summary="Monday meeting",
+            start="2022-08-29T09:00:00",
+            end="2022-08-29T09:30:00",
+            rrule=Recur.from_rrule("FREQ=WEEKLY;COUNT=3"),
+        )
+    )
+    frozen_time.tick(delta=datetime.timedelta(seconds=10))
+    store.edit(
+        "mock-uid-1",
+        Event(
+            summary="Team meeting",
+            rrule=Recur.from_rrule("FREQ=WEEKLY;COUNT=3;INTERVAL=2"),
+        ),
+        recurrence_id="20220905T090000",
+        recurrence_range=Range.THIS_AND_FUTURE,
+    )
+    assert fetch_events({"uid", "recurrence_id", "dtstart", "summary"}) == [
+        {
+            "uid": "mock-uid-1",
+            "recurrence_id": "20220829T090000",
+            "dtstart": "2022-08-29T09:00:00",
+            "summary": "Monday meeting",
+        },
+        {
+            "uid": "mock-uid-2",
+            "dtstart": "2022-09-05T09:00:00",
+            "recurrence_id": "20220905T090000",
+            "summary": "Team meeting",
+        },
+        {
+            "uid": "mock-uid-2",
+            "recurrence_id": "20220919T090000",
+            "dtstart": "2022-09-19T09:00:00",
+            "summary": "Team meeting",
+        },
+    ]
+
+
 def test_invalid_uid(
     store: EventStore,
 ) -> None:


### PR DESCRIPTION
Allow edits of recurring events to modify the recurrence rule going forward. The existing update logic would break a `Recur` object by converting it to a dictionary first.