### PR TITLE
Replace unidiomatic type check with isinstance checks

### DIFF
--- a/ical/event.py
+++ b/ical/event.py
@@ -366,12 +366,23 @@ class Event(ComponentModel):
     @root_validator(allow_reuse=True)
     def _validate_date_types(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate that start and end values are the same date or datetime type."""
-        if (
-            (dtstart := values.get("dtstart"))
-            and (dtend := values.get("dtend"))
-            and type(dtstart) != type(dtend)  # pylint: disable=unidiomatic-typecheck
-        ):
-            raise ValueError("Expected end value type to match start")
+        dtstart = values.get("dtstart")
+        dtend = values.get("dtend")
+
+        if not dtstart or not dtend:
+            return values
+        if isinstance(dtstart, datetime.datetime):
+            if not isinstance(dtend, datetime.datetime):
+                raise ValueError(
+                    f"Unexpected dtstart value '{dtstart}' was datetime but "
+                    f"dtend value '{dtend}' was not datetime"
+                )
+        elif isinstance(dtstart, datetime.date):
+            if isinstance(dtend, datetime.datetime):
+                raise ValueError(
+                    f"Unexpected dtstart value '{dtstart}' was date but "
+                    f"dtend value '{dtend}' was datetime"
+                )
         return values
 
     @root_validator(allow_reuse=True)


### PR DESCRIPTION
Replace unidiomatic type check with isinstance checks in the hopes that it fixes a validation error:

```
File "/usr/local/lib/python3.10/site-packages/ical/calendar_stream.py", line 69, in calendar_from_ics
stream = cls.from_ics(content)
File "/usr/local/lib/python3.10/site-packages/ical/calendar_stream.py", line 56, in from_ics
return cls.parse_obj(result)
File "pydantic/main.py", line 526, in pydantic.main.BaseModel.parse_obj
File "pydantic/main.py", line 342, in pydantic.main.BaseModel.init
pydantic.error_wrappers.ValidationError: 1 validation error for IcsCalendarStream
vcalendar -> 0 -> vevent -> 0 -> root
Expected end value type to match start (type=value_error)
```