### PR TITLE
Fix bugs and undeterministic behavior due to type caching

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,3 @@
 [MASTER]
 extension-pkg-whitelist=pydantic
-disable = no-self-argument
+disable = no-self-argument, too-many-instance-attributes

--- a/ical/types/data_types.py
+++ b/ical/types/data_types.py
@@ -60,9 +60,13 @@ class Registry:
             type, Callable[[dict[str, Any]], list[ParsedPropertyParameter]]
         ] = {}
         self._disable_value_param: set[type] = set()
+        self._parse_order: dict[type, int] = {}
 
     def register(
-        self, name: str | None = None, disable_value_param: bool = False
+        self,
+        name: str | None = None,
+        disable_value_param: bool = False,
+        parse_order: int | None = None,
     ) -> Callable[[type], type]:
         """Return decorator to register a type.
 
@@ -92,6 +96,8 @@ class Registry:
                 self._encode_property_params[data_type] = encode_property_params
             if disable_value_param:
                 self._disable_value_param |= set({data_type})
+            if parse_order:
+                self._parse_order[data_type] = parse_order
             return func
 
         return decorator
@@ -127,6 +133,11 @@ class Registry:
     def disable_value_param(self) -> set[type]:
         """Return set of types that do not allow VALUE overrides by component parsing."""
         return self._disable_value_param
+
+    @property
+    def parse_order(self) -> dict[type, int]:
+        """Return the parse ordering of the specified type."""
+        return self._parse_order
 
 
 DATA_TYPE: Registry = Registry()

--- a/ical/types/date.py
+++ b/ical/types/date.py
@@ -12,7 +12,7 @@ from .data_types import DATA_TYPE
 DATE_REGEX = re.compile(r"^([0-9]{8})$")
 
 
-@DATA_TYPE.register("DATE")
+@DATA_TYPE.register("DATE", parse_order=1)
 class DateEncoder:
     """Encode and decode an rfc5545 DATE and datetime.date."""
 

--- a/ical/types/date_time.py
+++ b/ical/types/date_time.py
@@ -20,7 +20,7 @@ TZID = "TZID"
 ATTR_VALUE = "VALUE"
 
 
-@DATA_TYPE.register("DATE-TIME")
+@DATA_TYPE.register("DATE-TIME", parse_order=2)
 class DateTimeEncoder:
     """Class to handle encoding for a datetime.datetime."""
 


### PR DESCRIPTION
Fix a bug where date/time vlaues were parsed with the incorrect type. The issue was related to the fact that `get_args` can return `Union[datetime.datetime, datetime.date, None]` values in an arbitrary order, not necessarily the order specified in the union. The way to reproduce this was to randomly shuffle the return values of `get_args` showing that it caused the bug.  This introduces two changes
- Stop trying to parse `NoneType` and just let that happen naturally
- Introduce a strict ordering on the types so that we try to parse a datetime before a date

The original error message would look something like this:
```
Unexpected dtstart value '2022-12-15 07:45:00' was datetime but dtend value '2022-12-15' was not datetime (type=value_error)
```
Though this issue was actually the same as the root cause in https://github.com/allenporter/ical/pull/139

```
File "/usr/local/lib/python3.10/site-packages/ical/calendar_stream.py", line 69, in calendar_from_ics
stream = cls.from_ics(content)
File "/usr/local/lib/python3.10/site-packages/ical/calendar_stream.py", line 56, in from_ics
return cls.parse_obj(result)
File "pydantic/main.py", line 526, in pydantic.main.BaseModel.parse_obj
File "pydantic/main.py", line 342, in pydantic.main.BaseModel.init
pydantic.error_wrappers.ValidationError: 1 validation error for IcsCalendarStream
vcalendar -> 0 -> vevent -> 0 -> root
Expected end value type to match start (type=value_error)
```

Related issues:
- https://github.com/home-assistant/core/issues/84171
- https://github.com/home-assistant/core/issues/83401