### PR TITLE
Remove specific python version from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
     name: mypy
     entry: "./run-mypy"
     language: python
-    language_version: python3.9
     additional_dependencies: ["mypy==0.930"]
     types: [python]
     # use require_serial so that script


### PR DESCRIPTION
Remove specific python version from pre-commit to avoid looking for the wrong version after upgrading to python3.10

```
An unexpected error has occurred: CalledProcessError: command: ('/home/linuxbrew/.linuxbrew/opt/python@3.10/bin/python3.10', '-mvirtualenv', '/home/allen/.cache/pre-commit/repotv1arf27/py_env-python3.9', '-p', 'python3.9')
return code: 1
expected return code: 0
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.9'

```