### PR TITLE
Fix debugging strings for invalid recurrence rules

### DIFF
--- a/ical/iter.py
+++ b/ical/iter.py
@@ -196,8 +196,8 @@ class RulesetIterable(Iterable[Union[datetime.datetime, datetime.date]]):
 
     def __repr__(self) -> str:
         return (
-            f"RulesetIterable(dtstart={self._dtstart}, rrule={self._rrule}, "
-            "rdate={self._rdate}, exdate={self._exdate})"
+            f"RulesetIterable(dtstart={self._dtstart}, rrule={[ str(r) for r in self._rrule ]}, "
+            f"rdate={self._rdate}, exdate={self._exdate})"
         )
 
 


### PR DESCRIPTION
Fix debugging strings for invalid recurrence rules

When there are bugs building the recurrence rules that are unsupported by `dateutil.rrule` the debugging is currently broken:
```
  File "/usr/local/lib/python3.10/site-packages/ical/iter.py", line 369, in active_after
    for item in self._iterable:
  File "/usr/local/lib/python3.10/site-packages/ical/iter.py", line 252, in __next__
    self._make_heap()
  File "/usr/local/lib/python3.10/site-packages/ical/iter.py", line 242, in _make_heap
    next_item = next(iterator)
  File "/usr/local/lib/python3.10/site-packages/ical/iter.py", line 222, in __iter__
    for dtvalue in self._recur:
  File "/usr/local/lib/python3.10/site-packages/gcal_sync/timeline.py", line 92, in __iter__
    for value in self._func:
  File "/usr/local/lib/python3.10/site-packages/ical/iter.py", line 193, in __iter__
    raise RecurrenceError(
ical.iter.RecurrenceError: Error evaluating recurrence rule (RulesetIterable(dtstart=2021-01-16 05:30:00+01:00, rrule=[<dateutil.rrule.rrule object at 0x7fd1a1ef5480>], rdate={self._rdate}, exdate={self._exdate})): can't compare datetime.datetime to datetime.date
```

This fixes two bugs:
- Each rrule is converted to a string rather than converting the list to a string
- The fstrings for the rdate and exdate are now evaluated properly

The debug string itself is now tested explicitly to ensure the logic is correct.

Downstream issue: https://github.com/home-assistant/core/issues/83040