### PR TITLE
Fix THIS_AND_FUTURE bugs for delete and edit

### DIFF
--- a/ical/store.py
+++ b/ical/store.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from .calendar import Calendar
 from .event import Event
+from .iter import RulesetIterable
 from .timezone import Timezone
 from .types import Range, Recur, RecurrenceId
 from .tzif.timezoneinfo import TimezoneInfoError
@@ -139,6 +140,15 @@ class EventStore:
         if not (store_event := self._lookup_event(uid)):
             raise ValueError(f"No existing event with uid: {uid}")
 
+        if (
+            recurrence_id
+            and recurrence_range == Range.THIS_AND_FUTURE
+            and RecurrenceId.to_value(recurrence_id) == store_event.dtstart
+        ):
+            # Editing the first instance and all forward is the same as editing the
+            # entire series so don't bother forking a new event
+            recurrence_id = None
+
         # Deleting all instances in the series
         if not recurrence_id:
             self._calendar.events.remove(store_event)
@@ -153,12 +163,6 @@ class EventStore:
             # A single recurrence instance is removed. Add an exclusion to
             # to the event.
             store_event.exdate.append(exdate)
-            return
-
-        # Deleting forward from the first instance is the same as deleting
-        # the entire series. This avoids iterating over empty events unnecessarily.
-        if exdate == store_event.dtstart:
-            self._calendar.events.remove(store_event)
             return
 
         # Assumes any recurrence deletion is valid, and that overwriting
@@ -191,7 +195,7 @@ class EventStore:
         store.edit("event-uid-1", Event(summary="New Summary"))
         ```
 
-        For a recurring event, either the whol eevent or individual instances
+        For a recurring event, either the whole event or individual instances
         of the event may be edited. To edit the complete range of a recurring
         event the `uid` property must be specified and the `recurrence_id` should
         not be specified. To edit an individual instances of the event the
@@ -204,6 +208,16 @@ class EventStore:
         """
         if not (store_event := self._lookup_event(uid)):
             raise ValueError(f"No existing event with uid: {uid}")
+
+        if (
+            recurrence_id
+            and recurrence_range == Range.THIS_AND_FUTURE
+            and RecurrenceId.to_value(recurrence_id) == store_event.dtstart
+        ):
+            # Editing the first instance and all forward is the same as editing the
+            # entire series so don't bother forking a new event
+            recurrence_id = None
+
         update = self._prepare_update(
             store_event, event, recurrence_id, recurrence_range
         )
@@ -221,9 +235,16 @@ class EventStore:
         new_event = store_event.copy(update=update, deep=True)
         if recurrence_id and new_event.rrule and new_event.rrule.count:
             # The recurring event count needs to skip any events that
-            # come before the start of the new event.
+            # come before the start of the new event. Use a RulesetIterable
+            # to handle workarounds for dateutil.rrule limitations.
             dtstart: datetime.date | datetime.datetime = update["dtstart"]
-            for dtvalue in iter(new_event.rrule.as_rrule(store_event.dtstart)):
+            ruleset = RulesetIterable(
+                store_event.dtstart,
+                [new_event.rrule.as_rrule(store_event.dtstart)],
+                [],
+                [],
+            )
+            for dtvalue in ruleset:
                 if dtvalue >= dtstart:
                     break
                 new_event.rrule.count = new_event.rrule.count - 1

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -598,6 +598,57 @@ def test_edit_recurring_event_this_and_future(
     ]
 
 
+@pytest.mark.parametrize(
+    "recur",
+    [
+        Recur.from_rrule("FREQ=WEEKLY;UNTIL=20220912"),
+        Recur.from_rrule("FREQ=WEEKLY;COUNT=3"),
+    ],
+)
+def test_edit_recurring_all_day_event_this_and_future(
+    store: EventStore,
+    fetch_events: Callable[..., list[dict[str, Any]]],
+    frozen_time: FrozenDateTimeFactory,
+    recur: Recur,
+) -> None:
+    """Test editing future instance of a recurring event."""
+    store.add(
+        Event(
+            summary="Monday",
+            start="2022-08-29",
+            end="2022-08-30",
+            rrule=recur,
+        )
+    )
+    frozen_time.tick(delta=datetime.timedelta(seconds=10))
+    store.edit(
+        "mock-uid-1",
+        Event(summary="Mondays [edit]"),
+        recurrence_id="20220905",
+        recurrence_range=Range.THIS_AND_FUTURE,
+    )
+    assert fetch_events({"uid", "recurrence_id", "dtstart", "summary"}) == [
+        {
+            "uid": "mock-uid-1",
+            "recurrence_id": "20220829",
+            "dtstart": "2022-08-29",
+            "summary": "Monday",
+        },
+        {
+            "uid": "mock-uid-2",
+            "dtstart": "2022-09-05",
+            "recurrence_id": "20220905",
+            "summary": "Mondays [edit]",
+        },
+        {
+            "uid": "mock-uid-2",
+            "recurrence_id": "20220912",
+            "dtstart": "2022-09-12",
+            "summary": "Mondays [edit]",
+        },
+    ]
+
+
 def test_add_and_delete_event_date(
     store: EventStore, fetch_events: Callable[..., list[dict[str, Any]]]
 ) -> None:
@@ -715,6 +766,98 @@ def test_edit_recurrence_rule_this_and_future(
             "uid": "mock-uid-2",
             "recurrence_id": "20220919T090000",
             "dtstart": "2022-09-19T09:00:00",
+            "summary": "Team meeting",
+        },
+    ]
+
+
+def test_edit_recurrence_rule_this_and_future_all_day_first_instance(
+    store: EventStore,
+    fetch_events: Callable[..., list[dict[str, Any]]],
+    frozen_time: FrozenDateTimeFactory,
+) -> None:
+    """Test editing future instances starting at the first instance."""
+    store.add(
+        Event(
+            summary="Monday",
+            start="2022-08-29",
+            end="2022-08-30",
+            rrule=Recur.from_rrule("FREQ=WEEKLY;COUNT=3"),
+        )
+    )
+    frozen_time.tick(delta=datetime.timedelta(seconds=10))
+    store.edit(
+        "mock-uid-1",
+        Event(
+            summary="Mondays [edit]",
+            rrule=Recur.from_rrule("FREQ=WEEKLY;COUNT=3;INTERVAL=2"),
+        ),
+        recurrence_id="20220829",
+        recurrence_range=Range.THIS_AND_FUTURE,
+    )
+    assert fetch_events({"uid", "recurrence_id", "dtstart", "summary"}) == [
+        {
+            "uid": "mock-uid-1",
+            "dtstart": "2022-08-29",
+            "recurrence_id": "20220829",
+            "summary": "Mondays [edit]",
+        },
+        {
+            "uid": "mock-uid-1",
+            "dtstart": "2022-09-12",
+            "recurrence_id": "20220912",
+            "summary": "Mondays [edit]",
+        },
+        {
+            "uid": "mock-uid-1",
+            "recurrence_id": "20220926",
+            "dtstart": "2022-09-26",
+            "summary": "Mondays [edit]",
+        },
+    ]
+
+
+def test_edit_recurrence_rule_this_and_future_first_instance(
+    store: EventStore,
+    fetch_events: Callable[..., list[dict[str, Any]]],
+    frozen_time: FrozenDateTimeFactory,
+) -> None:
+    """Test editing future instances starting at the first instance."""
+    store.add(
+        Event(
+            summary="Monday meeting",
+            start="2022-08-29T09:00:00",
+            end="2022-08-29T09:30:00",
+            rrule=Recur.from_rrule("FREQ=WEEKLY;COUNT=3"),
+        )
+    )
+    frozen_time.tick(delta=datetime.timedelta(seconds=10))
+    store.edit(
+        "mock-uid-1",
+        Event(
+            summary="Team meeting",
+            rrule=Recur.from_rrule("FREQ=WEEKLY;COUNT=3;INTERVAL=2"),
+        ),
+        recurrence_id="20220829T090000",
+        recurrence_range=Range.THIS_AND_FUTURE,
+    )
+    assert fetch_events({"uid", "recurrence_id", "dtstart", "summary"}) == [
+        {
+            "uid": "mock-uid-1",
+            "dtstart": "2022-08-29T09:00:00",
+            "recurrence_id": "20220829T090000",
+            "summary": "Team meeting",
+        },
+        {
+            "uid": "mock-uid-1",
+            "dtstart": "2022-09-12T09:00:00",
+            "recurrence_id": "20220912T090000",
+            "summary": "Team meeting",
+        },
+        {
+            "uid": "mock-uid-1",
+            "recurrence_id": "20220926T090000",
+            "dtstart": "2022-09-26T09:00:00",
             "summary": "Team meeting",
         },
     ]


### PR DESCRIPTION
There were some bugs with events:
- deleting this and future for the first instance now deletes the entire series
- deleting this and future with an all day event was still including the event for the recurrence id
- Fix a `dateulil.rrule` limitation bug
- Similar bugs with edits

Issue #138