### PR TITLE
Add additional event date/datetime parsing debug logging

### DIFF
--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -28,12 +28,16 @@ with filename.open(mode="w") as ics_file:
 
 from __future__ import annotations
 
+import logging
+
 from pydantic import Field
 
 from .calendar import Calendar
 from .component import ComponentModel
 from .parsing.component import encode_content, parse_content
 from .types.data_types import DATA_TYPE
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class CalendarStream(ComponentModel):
@@ -53,6 +57,7 @@ class CalendarStream(ComponentModel):
         for component in components:
             result.setdefault(component.name, [])
             result[component.name].append(component.as_dict())
+        _LOGGER.debug("Parsing object %s", result)
         return cls.parse_obj(result)
 
     def ics(self) -> str:

--- a/ical/component.py
+++ b/ical/component.py
@@ -117,6 +117,8 @@ class ComponentModel(BaseModel):
             validated = [cls._parse_property(field_types, prop) for prop in value]
             values[field.alias] = validated if allow_repeated else validated[0]
 
+        _LOGGER.debug("Completed parsing value data %s", values)
+
         return values
 
     @classmethod


### PR DESCRIPTION
Add additional debug logging in the date/datetime parsing code, as well as calendar stream.

Meant to aide in tracking down https://github.com/home-assistant/core/issues/8417 root cause.