### PR TITLE
Use pydantic smart union to better match exact type

### DIFF
--- a/ical/component.py
+++ b/ical/component.py
@@ -273,3 +273,4 @@ class ComponentModel(BaseModel):
 
         validate_assignment = True
         allow_population_by_field_name = True
+        smart_union = True


### PR DESCRIPTION
Use pydantic [smart union](https://docs.pydantic.dev/usage/model_config/#smart-union) to better match exact type.

Pydantic documentation says to order types from most specific to least specific, however that assumption is not upheld when `get_arg` on the `Union` type is returned in a different order than declared. To workaround `datetime.datetime` to `datetime.date` coercion, using `smart_union` to check for an exact type match.

See discussion in https://github.com/home-assistant/core/issues/84171