### PR TITLE
Make EventStore have a hard failure when adding event with unknown timezone

### DIFF
--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -16,7 +16,7 @@ from freezegun.api import FrozenDateTimeFactory
 
 from ical.calendar import Calendar
 from ical.event import Event
-from ical.store import EventStore
+from ical.store import EventStore, EventStoreError
 from ical.types.recur import Range, Recur
 
 
@@ -158,7 +158,7 @@ def test_edit_event(
 
 def test_edit_event_invalid_uid(store: EventStore) -> None:
     """Edit an event that does not exist."""
-    with pytest.raises(ValueError, match="No existing"):
+    with pytest.raises(EventStoreError, match="No existing"):
         store.edit("mock-uid-1", Event(start="2022-08-29T09:05:00", summary="Delayed"))
 
 
@@ -537,7 +537,7 @@ def test_cant_change_recurrence_for_event_instance(
     )
 
     frozen_time.tick(delta=datetime.timedelta(seconds=10))
-    with pytest.raises(ValueError, match="single instance with rrule"):
+    with pytest.raises(EventStoreError, match="single instance with rrule"):
         store.edit(
             "mock-uid-1",
             Event(
@@ -923,10 +923,10 @@ def test_invalid_uid(
     store: EventStore,
 ) -> None:
     """Test iteration over an empty calendar."""
-    with pytest.raises(ValueError, match=r"No existing event with uid"):
+    with pytest.raises(EventStoreError, match=r"No existing event with uid"):
         store.edit("invalid", Event(summary="example summary"))
 
-    with pytest.raises(ValueError, match=r"No existing event with uid"):
+    with pytest.raises(EventStoreError, match=r"No existing event with uid"):
         store.delete("invalid")
 
 
@@ -942,10 +942,10 @@ def test_invalid_recurrence_id(
         )
     )
 
-    with pytest.raises(ValueError, match=r"event is not recurring"):
+    with pytest.raises(EventStoreError, match=r"event is not recurring"):
         store.delete("mock-uid-1", recurrence_id="invalid")
 
-    with pytest.raises(ValueError, match=r"event is not recurring"):
+    with pytest.raises(EventStoreError, match=r"event is not recurring"):
         store.edit(
             "mock-uid-1", recurrence_id="invalid", event=Event(summary="invalid")
         )
@@ -1031,3 +1031,21 @@ def test_timezone_for_datetime(
     assert len(calendar.timezones) == 2
     assert calendar.timezones[0].tz_id == "America/Los_Angeles"
     assert calendar.timezones[1].tz_id == "America/New_York"
+
+
+def test_timezone_offset_not_supported(
+    calendar: Calendar,
+    store: EventStore,
+) -> None:
+    """Test adding a datetime for a timestamp that does not have a valid timezone."""
+    offset = datetime.timedelta(hours=-8)
+    tzinfo = datetime.timezone(offset=offset)
+    event = Event(
+        summary="Monday meeting",
+        start=datetime.datetime(2022, 8, 29, 9, 0, 0, tzinfo=tzinfo),
+        end=datetime.datetime(2022, 8, 29, 9, 30, 0, tzinfo=tzinfo),
+    )
+    with pytest.raises(EventStoreError, match=r"No timezone information"):
+        store.add(event)
+    assert not calendar.events
+    assert not calendar.timezones


### PR DESCRIPTION
Add an exception type that is thrown for all EventStore events due to bad input.