### PR TITLE
Fix bug in recurrence rules for events with explicit timezone

### DIFF
--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -128,12 +128,20 @@ class RecurAdapter:
     ) -> SortableItem[Timespan, Event]:
         """Return a lazy sortable item."""
 
+        recur_id_dt = dtstart
+        # Make recurrence_id floating time to avoid dealing with serializing
+        # TZID. This value will still be unique within the series and is in
+        # the context of dtstart which may have a timezone.
+        if isinstance(recur_id_dt, datetime.datetime) and recur_id_dt.tzinfo:
+            recur_id_dt = recur_id_dt.replace(tzinfo=None)
+        recurrence_id = RecurrenceId.__parse_property_value__(recur_id_dt)
+
         def build() -> Event:
             return self._event.copy(
                 update={
                     "dtstart": dtstart,
                     "dtend": dtstart + self._event_duration,
-                    "recurrence_id": RecurrenceId.__parse_property_value__(dtstart),
+                    "recurrence_id": recurrence_id,
                 },
             )
 


### PR DESCRIPTION
Fix bug in recurrence rules for events with explicit timezone. The RECURRENCE-ID would be returned as a dictionary with the datetime and a TZID value.

As a workaround, the recurrence-id itself will no longer contain timezone information. This should be fine since it is unique within a series and dtstart already contains timezone information.