### PR TITLE
Add APIs for redacting ICS contents

### DIFF
--- a/ical/__init__.py
+++ b/ical/__init__.py
@@ -17,4 +17,5 @@ __all__ = [
     "types",
     "tzif",
     "util",
+    "diagnostics",
 ]

--- a/ical/diagnostics.py
+++ b/ical/diagnostics.py
@@ -35,19 +35,25 @@ def component_sep(contentline: str) -> int:
     return semi
 
 
-def redact_contentline(contentline: str) -> str:
+def redact_contentline(contentline: str, component_allowlist: set[str]) -> str:
     """Return a redacted version of an ics content line."""
     if (i := component_sep(contentline)) and i > -1:
         component = contentline[0:i]
-        if component in COMPONENT_ALLOWLIST:
+        if component in component_allowlist:
             return contentline
         return f"{component}:{REDACT}"
     return REDACT
 
 
-def redact_ics(ics: str) -> Generator[str, None, None]:
+def redact_ics(
+    ics: str,
+    max_contentlines: int = MAX_CONTENTLINES,
+    component_allowlist: set[str] | None = None,
+) -> Generator[str, None, None]:
     """Generate redacted ics file contents one line at a time."""
     contentlines = ics.split("\n")
-    for contentline in itertools.islice(contentlines, MAX_CONTENTLINES):
+    for contentline in itertools.islice(contentlines, max_contentlines):
         if contentline:
-            yield redact_contentline(contentline)
+            yield redact_contentline(
+                contentline, component_allowlist or COMPONENT_ALLOWLIST
+            )

--- a/ical/diagnostics.py
+++ b/ical/diagnostics.py
@@ -1,0 +1,53 @@
+"""Library for diagnostics or debugging information about calendars."""
+
+from collections.abc import Generator
+import itertools
+
+
+__all__ = [
+    "redact_ics",
+]
+
+
+COMPONENT_ALLOWLIST = {
+    "BEGIN",
+    "END",
+    "DTSTAMP",
+    "CREATED",
+    "LAST-MODIFIED",
+    "DTSTART",
+    "DTEND",
+    "RRULE",
+    "PRODID",
+}
+REDACT = "***"
+MAX_CONTENTLINES = 5000
+
+
+def component_sep(contentline: str) -> int:
+    """Return the component prefix index in the string."""
+    colon = contentline.find(":")
+    semi = contentline.find(";")
+    if colon > -1 and semi > -1:
+        return min(colon, semi)
+    if colon > -1:
+        return colon
+    return semi
+
+
+def redact_contentline(contentline: str) -> str:
+    """Return a redacted version of an ics content line."""
+    if (i := component_sep(contentline)) and i > -1:
+        component = contentline[0:i]
+        if component in COMPONENT_ALLOWLIST:
+            return contentline
+        return f"{component}:{REDACT}"
+    return REDACT
+
+
+def redact_ics(ics: str) -> Generator[str, None, None]:
+    """Generate redacted ics file contents one line at a time."""
+    contentlines = ics.split("\n")
+    for contentline in itertools.islice(contentlines, MAX_CONTENTLINES):
+        if contentline:
+            yield redact_contentline(contentline)

--- a/ical/diagnostics.py
+++ b/ical/diagnostics.py
@@ -1,5 +1,7 @@
 """Library for diagnostics or debugging information about calendars."""
 
+from __future__ import annotations
+
 from collections.abc import Generator
 import itertools
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -17,3 +17,5 @@ flake8-black==0.3.5
 ruff==0.0.253
 black==22.10.0
 wheel==0.37.1
+PyYAML==6.0
+types-PyYAML==6.0.12.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,5 +38,5 @@ ical = py.typed
 [flake8]
 max-line-length = 88
 ignore =
-    E501,  # black: Line too long
-    W503   # black: Line break before binary operator
+    E501,
+    W503

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,56 @@
+"""Tests for diagnostics."""
+
+import yaml
+import pytest
+
+from ical.diagnostics import redact_ics
+
+
+DATETIME_TIMEZONE = """BEGIN:VCALENDAR
+PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+VERSION:***
+BEGIN:VEVENT
+DTSTAMP:19970610T172345Z
+UID:***
+DTSTART;TZID=America/New_York:19970714T133000
+DTEND;TZID=America/New_York:19970714T140000
+SUMMARY:***
+END:VEVENT
+END:VCALENDAR"""
+
+DESCRIPTION_ALTREP = """BEGIN:VCALENDAR
+PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+VERSION:***
+BEGIN:VEVENT
+DTSTAMP:19970610T172345Z
+UID:***
+DTSTART:19970714T170000Z
+DTEND:19970715T040000Z
+SUMMARY:***
+DESCRIPTION:***
+***
+END:VEVENT
+END:VCALENDAR"""
+
+
+def test_empty() -> None:
+    """Test redaction of an empty ics file."""
+    assert list(redact_ics("")) == []
+    assert list(redact_ics("\n")) == []
+
+
+@pytest.mark.parametrize(
+    ("filename", "output"),
+    [
+        ("tests/testdata/datetime_timezone.yaml", DATETIME_TIMEZONE),
+        ("tests/testdata/description_altrep.yaml", DESCRIPTION_ALTREP),
+    ],
+    ids=("datetime_timezone", "description_altrep"),
+)
+def test_redact_date_timezone(filename: str, output: str) -> None:
+    """Test redaction of an empty ics file."""
+
+    with open(filename) as f:
+        doc = yaml.load(f, Loader=yaml.CLoader)
+    ics = doc["input"]
+    assert "\n".join(list(redact_ics(ics))) == output


### PR DESCRIPTION
Add an API that can scrub an ICS file to remove sensitive fields, leaving just the data needed for debugging. This allows specifying a set of components, or use a default, as well as the maximum number of total lines in the output.