### PR TITLE
Fix timezone parser when mutating values

### DIFF
--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -92,6 +92,9 @@ class Calendar(ComponentModel):
         DATE-TIME parser will use this instead of the TZID string. We prefer
         to use any python timezones when present.
         """
+        # Run only when initially parsing a VTIMEZONE
+        if "vtimezone" not in values:
+            return values
 
         # First parse the timezones out of the calendar, ignoring everything else
         timezone_model = TimezoneModel.parse_obj(values)

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -21,6 +21,16 @@ VERSION:2.0
 END:VCALENDAR"""
     )
 
+    calendar.prodid = "-//example//1.2.4"
+    ics = IcsCalendarStream.calendar_to_ics(calendar)
+    assert (
+        ics
+        == """BEGIN:VCALENDAR
+PRODID:-//example//1.2.4
+VERSION:2.0
+END:VCALENDAR"""
+    )
+
 
 @pytest.mark.golden_test("testdata/*.yaml")
 def test_parse(golden: GoldenTestFixture, json_encoder: json.JSONEncoder) -> None:


### PR DESCRIPTION
Fix timezone parser when mutating Calendar objects. When editing a field on `Calendar` It currently raises:
```
pydantic.error_wrappers.ValidationError: 1 validation error for Calendar
__root__ -> __root__
  'NoneType' object is not iterable (type=type_error)
```