### PR TITLE
Allow invalid UNTIL DATE-TIME rules for Google Calendar ics

### DIFF
--- a/tests/testdata/rrule-until-mismatch.yaml
+++ b/tests/testdata/rrule-until-mismatch.yaml
@@ -1,0 +1,60 @@
+input: |-
+  BEGIN:VCALENDAR
+  PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+  VERSION:2.0
+  BEGIN:VEVENT
+  DTSTART:20220802
+  DTEND:20220803
+  DTSTAMP:20220731T190408Z
+  UID:5gog4qp8rohrj69q63ddvbnbt5@google.com
+  RRULE:FREQ=DAILY;UNTIL=20220904T070000Z
+  CREATED:20220731T190207Z
+  DESCRIPTION:
+  LAST-MODIFIED:20220731T190207Z
+  LOCATION:
+  SEQUENCE:0
+  STATUS:CONFIRMED
+  SUMMARY:Daily Event
+  TRANSP:OPAQUE
+  END:VEVENT
+  END:VCALENDAR
+output:
+  calendars:
+  - prodid: -//hacksw/handcal//NONSGML v1.0//EN
+    version: '2.0'
+    events:
+    - dtstamp: '2022-07-31T19:04:08+00:00'
+      uid: 5gog4qp8rohrj69q63ddvbnbt5@google.com
+      dtstart: '2022-08-02'
+      dtend: '2022-08-03'
+      summary: Daily Event
+      created: '2022-07-31T19:02:07+00:00'
+      description: ''
+      last_modified: '2022-07-31T19:02:07+00:00'
+      location: ''
+      rrule:
+        freq: DAILY
+        until: '2022-09-04'
+      sequence: 0
+      status: CONFIRMED
+      transparency: OPAQUE
+encoded: |-
+  BEGIN:VCALENDAR
+  PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+  VERSION:2.0
+  BEGIN:VEVENT
+  DTSTAMP:20220731T190408Z
+  UID:5gog4qp8rohrj69q63ddvbnbt5@google.com
+  DTSTART:20220802
+  DTEND:20220803
+  SUMMARY:Daily Event
+  CREATED:20220731T190207Z
+  DESCRIPTION:
+  LAST-MODIFIED:20220731T190207Z
+  LOCATION:
+  RRULE:FREQ=DAILY;UNTIL=20220904
+  SEQUENCE:0
+  STATUS:CONFIRMED
+  TRANSP:OPAQUE
+  END:VEVENT
+  END:VCALENDAR

--- a/tests/types/test_recur.py
+++ b/tests/types/test_recur.py
@@ -647,16 +647,6 @@ def test_until_time_mismatch() -> None:
             ),
         )
 
-    with pytest.raises(
-        ValidationError, match="DTSTART and UNTIL must be the same value type"
-    ):
-        Event(
-            summary="Bi-annual meeting",
-            start=datetime.datetime(2022, 1, 2, 6, 0, 0),
-            end=datetime.datetime(2022, 1, 2, 7, 0, 0),
-            rrule=Recur(freq=Frequency.DAILY, until=datetime.date(2022, 8, 4)),
-        )
-
 
 @pytest.mark.parametrize(
     "recur",

--- a/tests/types/test_recur.py
+++ b/tests/types/test_recur.py
@@ -597,8 +597,36 @@ def test_year_iteration() -> None:
     ]
 
 
+def test_until_time_valid() -> None:
+    """Test success cases where until has a valid date or time compared to dtstart."""
+
+    Event(
+        summary="Bi-annual meeting",
+        start=datetime.datetime(2022, 1, 2, 6, 0, 0),
+        end=datetime.datetime(2022, 1, 2, 7, 0, 0),
+        rrule=Recur(
+            freq=Frequency.DAILY,
+            until=datetime.datetime(2022, 8, 4, 6, 0, 0),
+        ),
+    )
+
+
 def test_until_time_mismatch() -> None:
     """Test failure case where until has a different timezone than start."""
+
+    with pytest.raises(
+        ValidationError,
+        match="DTSTART was DATE-TIME but UNTIL was DATE",
+    ):
+        Event(
+            summary="Bi-annual meeting",
+            start=datetime.datetime(2022, 1, 2, 6, 0, 0),
+            end=datetime.datetime(2022, 1, 2, 7, 0, 0),
+            rrule=Recur(
+                freq=Frequency.DAILY,
+                until=datetime.date(2022, 8, 4),
+            ),
+        )
 
     with pytest.raises(
         ValidationError, match="DTSTART is date local but UNTIL was not"

--- a/tests/types/test_recur.py
+++ b/tests/types/test_recur.py
@@ -597,16 +597,25 @@ def test_year_iteration() -> None:
     ]
 
 
-def test_until_time_valid() -> None:
+@pytest.mark.parametrize(
+    ("tzinfo", "until_tzinfo"),
+    [
+        (None, None),
+        (zoneinfo.ZoneInfo("America/New_York"), datetime.timezone.utc),
+    ],
+)
+def test_until_time_valid(
+    tzinfo: zoneinfo.ZoneInfo | None, until_tzinfo: zoneinfo.ZoneInfo | None
+) -> None:
     """Test success cases where until has a valid date or time compared to dtstart."""
 
     Event(
         summary="Bi-annual meeting",
-        start=datetime.datetime(2022, 1, 2, 6, 0, 0),
-        end=datetime.datetime(2022, 1, 2, 7, 0, 0),
+        start=datetime.datetime(2022, 1, 2, 6, 0, 0, tzinfo=tzinfo),
+        end=datetime.datetime(2022, 1, 2, 7, 0, 0, tzinfo=tzinfo),
         rrule=Recur(
             freq=Frequency.DAILY,
-            until=datetime.datetime(2022, 8, 4, 6, 0, 0),
+            until=datetime.datetime(2022, 8, 4, 6, 0, 0, tzinfo=until_tzinfo),
         ),
     )
 


### PR DESCRIPTION
Allow invalid UNTIL DATE-TIME rules for Google Calendar ics files.

Google calendar may export .ics files like this:
```
BEGIN:VEVENT
DTSTART;VALUE=DATE:20110806
DTEND;VALUE=DATE:20110807
RRULE:FREQ=WEEKLY;UNTIL=20110812T070000Z;BYDAY=SA
...
END:VEVENT
```

The specific validation rule this is implementing comes from https://www.rfc-editor.org/rfc/rfc5545#section-3.3.10

```
The UNTIL rule part defines a DATE or DATE-TIME value that bounds
the recurrence rule in an inclusive manner.  ... 
... The value of the UNTIL rule part MUST have the same
value type as the "DTSTART" property.  Furthermore, if the
"DTSTART" property is specified as a date with local time, then
the UNTIL rule part MUST also be specified as a date with local
time.  If the "DTSTART" property is specified as a date with UTC
time or a date with local time and time zone reference, then the
UNTIL rule part MUST be specified as a date with UTC time.
```

The existing interpretation of the RFC is correct, but we'll instead prefer to be compatible and just coerce the data to be valid in the validation layer.

Issue #176