### PR TITLE
Prevent dependencies on newer versions of pydantic

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ical
-version = 4.5.3
+version = 4.5.2
 description = Python iCalendar implementation (rfc 2445)
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ical
-version = 4.5.2
+version = 4.5.3
 description = Python iCalendar implementation (rfc 2445)
 long_description = file: README.md
 long_description_content_type = text/markdown
@@ -18,7 +18,7 @@ python_requires = >= 3.9
 install_requires =
   python-dateutil>=2.8.2
   tzdata>=2022.1
-  pydantic>=1.9.1
+  pydantic>=1.9.1,<2.0a1
   pyparsing>=3.0.9
   emoji>=2.2.0
 include_package_data = True


### PR DESCRIPTION
Prevent dependencies on newer versions of pydantic since it requires a large overhaul.
https://docs.pydantic.dev/blog/pydantic-v2-alpha/