### PR TITLE
Coerce invalid exdate date values to a datetime

### DIFF
--- a/ical/component.py
+++ b/ical/component.py
@@ -96,14 +96,22 @@ def _as_datetime(
     return date_value
 
 
-def validate_recurrence_dates(_cls: BaseModel, values: dict[str, Any]) -> dict[str, Any]:
+def validate_recurrence_dates(
+    _cls: BaseModel, values: dict[str, Any]
+) -> dict[str, Any]:
     """Verify the recurrence dates have the correct types."""
-    if not (rule := values.get("rrule")) or not (dtstart := values.get("dtstart")) or not isinstance(dtstart, datetime.datetime):
+    if (
+        not values.get("rrule")
+        or not (dtstart := values.get("dtstart"))
+        or not isinstance(dtstart, datetime.datetime)
+    ):
         return values
     for field in ("exdate", "rdate"):
         if not (date_values := values.get(field)):
             continue
-        values[field] = [ _as_datetime(date_value, dtstart) for date_value in date_values ]
+        values[field] = [
+            _as_datetime(date_value, dtstart) for date_value in date_values
+        ]
     return values
 
 

--- a/ical/component.py
+++ b/ical/component.py
@@ -87,6 +87,26 @@ def validate_until_dtstart(_cls: BaseModel, values: dict[str, Any]) -> dict[str,
     return values
 
 
+def _as_datetime(
+    date_value: datetime.datetime | datetime.date,
+    dtstart: datetime.datetime,
+) -> datetime.datetime:
+    if not isinstance(date_value, datetime.datetime):
+        return datetime.datetime.combine(date_value, dtstart.time())
+    return date_value
+
+
+def validate_recurrence_dates(_cls: BaseModel, values: dict[str, Any]) -> dict[str, Any]:
+    """Verify the recurrence dates have the correct types."""
+    if not (rule := values.get("rrule")) or not (dtstart := values.get("dtstart")) or not isinstance(dtstart, datetime.datetime):
+        return values
+    for field in ("exdate", "rdate"):
+        if not (date_values := values.get(field)):
+            continue
+        values[field] = [ _as_datetime(date_value, dtstart) for date_value in date_values ]
+    return values
+
+
 class ComponentModel(BaseModel):
     """Abstract class for rfc5545 component model."""
 

--- a/ical/journal.py
+++ b/ical/journal.py
@@ -11,7 +11,7 @@ from typing import Any, Optional, Union
 
 from pydantic import Field, root_validator
 
-from .component import ComponentModel, validate_until_dtstart
+from .component import ComponentModel, validate_until_dtstart, validate_recurrence_dates
 from .parsing.property import ParsedProperty
 from .types import CalAddress, Classification, Recur, RecurrenceId, RequestStatus, Uri
 from .util import dtstamp_factory, normalize_datetime, uid_factory
@@ -91,3 +91,4 @@ class Journal(ComponentModel):
         return normalize_datetime(self.start).astimezone(tz=datetime.timezone.utc)
 
     _validate_until_dtstart = root_validator(allow_reuse=True)(validate_until_dtstart)
+    _validate_recurrence_dates = root_validator(allow_reuse=True)(validate_recurrence_dates)

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -9,7 +9,7 @@ from typing import Any, Optional, Union
 from pydantic import Field, root_validator
 
 from .alarm import Alarm
-from .component import ComponentModel, validate_until_dtstart
+from .component import ComponentModel, validate_until_dtstart, validate_recurrence_dates
 from .parsing.property import ParsedProperty
 from .types import (
     CalAddress,
@@ -112,3 +112,4 @@ class Todo(ComponentModel):
         return values
 
     _validate_until_dtstart = root_validator(allow_reuse=True)(validate_until_dtstart)
+    _validate_recurrence_dates = root_validator(allow_reuse=True)(validate_recurrence_dates)

--- a/tests/types/test_recur.py
+++ b/tests/types/test_recur.py
@@ -776,7 +776,7 @@ def test_recur_by_monthday_as_string(recur: Recur) -> None:
     ],
 )
 def test_recur_by_last_day_as_string(recur: Recur) -> None:
-    """Test converting a recurrence rule with a weekday reepat into a string."""
+    """Test converting a recurrence rule with a weekday repeat into a string."""
     event = Event(
         summary="summary",
         start=datetime.date(2022, 9, 6),
@@ -814,4 +814,31 @@ def test_rdate_all_day() -> None:
         (datetime.date(2022, 9, 2), "Monthly Event"),
         (datetime.date(2022, 10, 2), "Monthly Event"),
         (datetime.date(2022, 10, 3), "Monthly Event"),
+    ]
+
+
+def test_rrule_exdate_mismatch() -> None:
+    """Test a recurrence rule with mixed datetime and exdate values."""
+    calendar = Calendar()
+    calendar.events.extend(
+        [
+            Event(
+                summary="Morning exercise",
+                start=datetime.datetime(2022, 8, 2, 6, 0, 0),
+                end=datetime.datetime(2022, 8, 2, 7, 0, 0),
+                rrule=Recur(
+                    freq=Frequency.WEEKLY, until=datetime.datetime(2022, 8, 10, 6, 0, 0)
+                ),
+                exdate=[
+                    datetime.date(2022, 8, 3),
+                    datetime.date(2022, 8, 4),
+                    datetime.date(2022, 8, 5),
+                ],
+            ),
+        ]
+    )
+    events = list(calendar.timeline)
+    assert [(event.start, event.summary) for event in events] == [
+        (datetime.datetime(2022, 8, 2, 6, 0, 0), "Morning exercise"),
+        (datetime.datetime(2022, 8, 9, 6, 0, 0), "Morning exercise"),
     ]


### PR DESCRIPTION
Coerce invalid exdate date values to a datetime to avoid issues like:

```
ical.iter.RecurrenceError: Error evaluating recurrence rule (RulesetIterable(dtstart=2023-06-13 00:00:00, rrule=['DTSTART:20230613T000000\nRRULE:FREQ=WEEKLY;BYDAY=TU'], rdate=[], exdate=[datetime.date(2023, 7, 4), datetime.date(2023, 9, 5), datetime.date(2023, 12, 26), datetime.date(2024, 1, 2)])): can't compare datetime.datetime to datetime.date
```
