### PR TITLE
Replace datetime.utcnow

### DIFF
--- a/ical/util.py
+++ b/ical/util.py
@@ -19,7 +19,7 @@ PRODID = "github.com/allenporter/ical"
 
 def dtstamp_factory() -> datetime.datetime:
     """Factory method for new event timestamps to facilitate mocking."""
-    return datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
+    return datetime.datetime.now(tz=datetime.timezone.utc)
 
 
 def uid_factory() -> str:

--- a/ical/util.py
+++ b/ical/util.py
@@ -19,7 +19,7 @@ PRODID = "github.com/allenporter/ical"
 
 def dtstamp_factory() -> datetime.datetime:
     """Factory method for new event timestamps to facilitate mocking."""
-    return datetime.datetime.utcnow()
+    return datetime.datetime.now(tz=datetime.timezone.utc).replace(tzinfo=None)
 
 
 def uid_factory() -> str:

--- a/tests/test_calendar.py
+++ b/tests/test_calendar.py
@@ -344,7 +344,7 @@ def test_create_and_serialize_calendar(
         "PRODID:-//example//1.2.3",
         "VERSION:2.0",
         "BEGIN:VEVENT",
-        "DTSTAMP:20000101T123000",
+        "DTSTAMP:20000101T123000Z",
         "UID:68e9e07c-7557-36e2-91c1-8febe7527841",
         "DTSTART:20000201",
         "DTEND:20000202",

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -97,7 +97,7 @@ def test_from_tzif_timezoneinfo_with_dst(
        PRODID:-//example//1.2.3
        VERSION:2.0
        BEGIN:VTIMEZONE
-       DTSTAMP:20220822T123000
+       DTSTAMP:20220822T123000Z
        TZID:America/New_York
        BEGIN:STANDARD
        DTSTART:20101107T020000
@@ -159,7 +159,7 @@ def test_from_tzif_timezoneinfo_fixed_offset(
        PRODID:-//example//1.2.3
        VERSION:2.0
        BEGIN:VTIMEZONE
-       DTSTAMP:20220822T123000
+       DTSTAMP:20220822T123000Z
        TZID:Asia/Tokyo
        BEGIN:STANDARD
        DTSTART:20100101T000000


### PR DESCRIPTION
Starting with Python 3.12 `datetime.utcnow` will be deprecated.
https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcnow