### PR TITLE
Update timeline/timespan call to propagate timezone

### DIFF
--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -118,10 +118,11 @@ class RecurAdapter:
     necessary updated fields to act as a flattened instance of the event.
     """
 
-    def __init__(self, event: Event):
+    def __init__(self, event: Event, tzinfo: datetime.tzinfo | None = None):
         """Initialize the RecurAdapter."""
         self._event = event
         self._event_duration = event.computed_duration
+        self._tzinfo = tzinfo
 
     def get(
         self, dtstart: datetime.datetime | datetime.date
@@ -146,7 +147,7 @@ class RecurAdapter:
             )
 
         return LazySortableItem(
-            Timespan.of(dtstart, dtstart + self._event_duration), build
+            Timespan.of(dtstart, dtstart + self._event_duration, self._tzinfo), build
         )
 
 
@@ -158,5 +159,5 @@ def calendar_timeline(events: list[Event], tzinfo: datetime.tzinfo) -> Timeline:
     for event in events:
         if not (recur := event.as_rrule()):
             continue
-        iters.append(RecurIterable(RecurAdapter(event).get, recur))
+        iters.append(RecurIterable(RecurAdapter(event, tzinfo=tzinfo).get, recur))
     return Timeline(MergedIterable(iters))

--- a/ical/timespan.py
+++ b/ical/timespan.py
@@ -39,9 +39,12 @@ class Timespan:
         cls,
         start: datetime.date | datetime.datetime,
         end: datetime.date | datetime.datetime,
+        tzinfo: datetime.tzinfo | None = None,
     ) -> "Timespan":
         """Create a Timestapn for the specified date range."""
-        return Timespan(normalize_datetime(start), normalize_datetime(end))
+        return Timespan(
+            normalize_datetime(start, tzinfo), normalize_datetime(end, tzinfo)
+        )
 
     @property
     def start(self) -> datetime.datetime:

--- a/ical/util.py
+++ b/ical/util.py
@@ -46,5 +46,7 @@ def normalize_datetime(
     if not isinstance(value, datetime.datetime):
         value = datetime.datetime.combine(value, MIDNIGHT)
     if value.tzinfo is None:
-        value = value.replace(tzinfo=tzinfo if tzinfo else local_timezone())
+        if tzinfo is None:
+            tzinfo = local_timezone()
+        value = value.replace(tzinfo=tzinfo)
     return value


### PR DESCRIPTION
Update timeline/timespan call to propagate timezone to handle the case where the system timezone is different than the timezone of the viewer that was passed in.