### PR TITLE
Update python-package.yaml to test python 3.12

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Attempt to confirm if https://github.com/home-assistant/core/pull/103483 is reproducible here.