### PR TITLE
Fix bug handling case where exdate and dtstart are different  date types

### DIFF
--- a/ical/iter.py
+++ b/ical/iter.py
@@ -177,9 +177,9 @@ class RulesetIterable(Iterable[Union[datetime.datetime, datetime.date]]):
         ruleset = rrule.rruleset()
         for rule in self._rrule:
             ruleset.rrule(self._converter(rule))  # type: ignore[arg-type]
-        for rdate in self._converter(self._rdate):
+        for rdate in self._rdate:
             ruleset.rdate(rdate)  # type: ignore[no-untyped-call]
-        for exdate in self._converter(self._exdate):
+        for exdate in self._exdate:
             ruleset.exdate(exdate)  # type: ignore[no-untyped-call]
         return ruleset
 

--- a/ical/iter.py
+++ b/ical/iter.py
@@ -163,24 +163,23 @@ class RulesetIterable(Iterable[Union[datetime.datetime, datetime.date]]):
         self._rrule = recur
         self._rdate = rdate
         self._exdate = exdate
+        # dateutil.rrule will convert all input values to datetime even if the
+        # input value is a date. If needed, convert back to a date so that
+        # comparisons between exdate/rdate as a date in the rruleset will
+        # be in the right format.
+        if not isinstance(dtstart, datetime.datetime):
+            self._converter = AllDayConverter
+        else:
+            self._converter = lambda x: x
 
     def _ruleset(self) -> Iterable[datetime.datetime | datetime.date]:
         """Create a dateutil.rruleset."""
-        is_date: bool = not isinstance(self._dtstart, datetime.datetime)
-
         ruleset = rrule.rruleset()
         for rule in self._rrule:
-            # dateutil.rrule will convert all input values to datetime even if the
-            # input value is a date. If needed, convert back to a date so that
-            # comparisons between exdate/rdate as a date in the rruleset will
-            # be in the right format.
-            value_iter: Iterable[datetime.date | datetime.datetime] = rule
-            if is_date:
-                value_iter = AllDayConverter(value_iter)
-            ruleset.rrule(value_iter)  # type: ignore[arg-type]
-        for rdate in self._rdate:
+            ruleset.rrule(self._converter(rule))  # type: ignore[arg-type]
+        for rdate in self._converter(self._rdate):
             ruleset.rdate(rdate)  # type: ignore[no-untyped-call]
-        for exdate in self._exdate:
+        for exdate in self._converter(self._exdate):
             ruleset.exdate(exdate)  # type: ignore[no-untyped-call]
         return ruleset
 

--- a/tests/testdata/rrule-exdate-mismatch.yaml
+++ b/tests/testdata/rrule-exdate-mismatch.yaml
@@ -29,8 +29,8 @@ output:
         - weekday: SU
         - weekday: SA
       exdate:
-      - '2023-12-23T08:00:00'
-      - '2023-12-17T08:00:00'
+      - '2023-12-23'
+      - '2023-12-17'
 encoded: |-
   BEGIN:VCALENDAR
   PRODID:-//hacksw/handcal//NONSGML v1.0//EN
@@ -42,7 +42,7 @@ encoded: |-
   DTEND:20231224
   SUMMARY:Example date
   RRULE:FREQ=WEEKLY;BYDAY=SU,SA
-  EXDATE:20231223T080000
-  EXDATE:20231217T080000
+  EXDATE:20231223
+  EXDATE:20231217
   END:VEVENT
   END:VCALENDAR

--- a/tests/testdata/rrule-exdate-mismatch.yaml
+++ b/tests/testdata/rrule-exdate-mismatch.yaml
@@ -1,0 +1,48 @@
+input: |-
+  BEGIN:VCALENDAR
+  PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+  VERSION:2.0
+  BEGIN:VEVENT
+  DTSTAMP:20231210T163427
+  UID:fc7a9b1e-9779-11ee-8e0d-6045bda9e0cd
+  DTSTART:20231224
+  DTEND:20231224
+  SUMMARY:Example date
+  RRULE:FREQ=WEEKLY;BYDAY=SU,SA
+  EXDATE:20231223T080000
+  EXDATE:20231217T080000
+  END:VEVENT
+  END:VCALENDAR
+output:
+  calendars:
+  - prodid: -//hacksw/handcal//NONSGML v1.0//EN
+    version: '2.0'
+    events:
+    - dtstamp: '2023-12-10T16:34:27'
+      uid: fc7a9b1e-9779-11ee-8e0d-6045bda9e0cd
+      dtstart: '2023-12-24'
+      dtend: '2023-12-24'
+      summary: Example date
+      rrule:
+        freq: WEEKLY
+        by_weekday:
+        - weekday: SU
+        - weekday: SA
+      exdate:
+      - '2023-12-23T08:00:00'
+      - '2023-12-17T08:00:00'
+encoded: |-
+  BEGIN:VCALENDAR
+  PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+  VERSION:2.0
+  BEGIN:VEVENT
+  DTSTAMP:20231210T163427
+  UID:fc7a9b1e-9779-11ee-8e0d-6045bda9e0cd
+  DTSTART:20231224
+  DTEND:20231224
+  SUMMARY:Example date
+  RRULE:FREQ=WEEKLY;BYDAY=SU,SA
+  EXDATE:20231223T080000
+  EXDATE:20231217T080000
+  END:VEVENT
+  END:VCALENDAR


### PR DESCRIPTION
This extends the case that is already handled for other rrule types to also handle exdate and rdate.

Fixes https://github.com/home-assistant/core/issues/105262