### PR TITLE
Update CI documentation deployment permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,6 +12,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
+  actions: read
   contents: read
   pages: write
   id-token: write


### PR DESCRIPTION
From https://github.com/actions/deploy-pages/releases/tag/v4.0.0
>This version requires the permission `actions: read` in the workflows which use it.
