### PR TITLE
Preserve uid when editing recurring events

### DIFF
--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 import datetime
 import itertools
 import logging
@@ -22,7 +21,6 @@ from .types.date_time import TZID
 from .parsing.property import ParsedProperty
 from .timeline import Timeline, calendar_timeline
 from .timezone import Timezone, TimezoneModel, IcsTimezoneInfo
-from .list import todo_list_view
 from .todo import Todo
 from .util import local_timezone, prodid_factory
 
@@ -81,13 +79,6 @@ class Calendar(ComponentModel):
         events are returned.
         """
         return calendar_timeline(self.events, tzinfo=tzinfo or local_timezone())
-
-    def todo_list(self, tzinfo: datetime.tzinfo | None = None) -> Iterable[Todo]:
-        """Return a list of all todos on the calendar.
-
-        This view accounts for recurring todos.
-        """
-        return todo_list_view(self.todos, tzinfo=tzinfo or local_timezone())
 
     @root_validator(pre=True)
     def _propagate_timezones(cls, values: dict[str, Any]) -> dict[str, Any]:

--- a/ical/iter.py
+++ b/ical/iter.py
@@ -95,6 +95,10 @@ class SortableItem(Generic[K, T], ABC):
         return cast(bool, self._key < other.key)
 
 
+SpanOrderedItem = SortableItem[Timespan, T]
+"""A sortable item with a timespan as the key."""
+
+
 class SortableItemValue(SortableItem[K, T]):
     """Concrete value implementation of SortableItem."""
 
@@ -151,7 +155,10 @@ class RulesetIterable(Iterable[Union[datetime.datetime, datetime.date]]):
     debug. This wrapper is meant to assist with that.
     """
 
-    _converter: Callable[[Iterable[Union[datetime.date, datetime.datetime]]], Iterable[Union[datetime.date, datetime.datetime]]]
+    _converter: Callable[
+        [Iterable[Union[datetime.date, datetime.datetime]]],
+        Iterable[Union[datetime.date, datetime.datetime]],
+    ]
 
     def __init__(
         self,
@@ -307,7 +314,7 @@ class SortedItemIterable(Iterable[SortableItem[K, T]]):
 class SortableItemTimeline(Iterable[T]):
     """A set of components on a calendar."""
 
-    def __init__(self, iterable: Iterable[SortableItem[Timespan, T]]) -> None:
+    def __init__(self, iterable: Iterable[SpanOrderedItem[T]]) -> None:
         self._iterable = iterable
 
     def __iter__(self) -> Iterator[T]:
@@ -391,6 +398,6 @@ class SortableItemTimeline(Iterable[T]):
         """Return an iterator containing all events active on the specified day."""
         return self.on_date(datetime.date.today())
 
-    def now(self) -> Iterator[T]:
+    def now(self, tz: datetime.tzinfo | None = None) -> Iterator[T]:
         """Return an iterator containing all events active on the specified day."""
-        return self.at_instant(datetime.datetime.now())
+        return self.at_instant(datetime.datetime.now(tz=tz))

--- a/ical/list.py
+++ b/ical/list.py
@@ -7,73 +7,20 @@ forever.
 """
 
 import datetime
-from collections.abc import Generator, Iterable
+from collections.abc import Generator
 import logging
 
 from .todo import Todo
-from .iter import (
-    LazySortableItem,
-    MergedIterable,
-    RecurIterable,
-    SortableItem,
-    SortableItemValue,
-)
-from .types.recur import RecurrenceId
+from .recur_adapter import items_by_uid, merge_and_expand_items
+from .util import local_timezone
 
+# Not part of the public API
+__all__: list[str] = []
 
 _LOGGER = logging.getLogger(__name__)
-_SortableTodoItem = SortableItem[datetime.datetime | datetime.date | None, Todo]
 
 
-class RecurAdapter:
-    """An adapter that expands an Todo instance for a recurrence rule.
-
-    This adapter is given an todo, then invoked with a specific date/time instance
-    that the todo is due from a recurrence rule. The todo is copied with
-    necessary updated fields to act as a flattened instance of the todo item.
-    """
-
-    def __init__(self, todo: Todo, tzinfo: datetime.tzinfo | None = None):
-        """Initialize the RecurAdapter."""
-        self._todo = todo
-        self._duration = todo.computed_duration
-        self._tzinfo = tzinfo
-
-    def get(self, dtstart: datetime.datetime | datetime.date) -> _SortableTodoItem:
-        """Return a lazy sortable item."""
-
-        recur_id_dt = dtstart
-        # Make recurrence_id floating time to avoid dealing with serializing
-        # TZID. This value will still be unique within the series and is in
-        # the context of dtstart which may have a timezone.
-        if isinstance(recur_id_dt, datetime.datetime) and recur_id_dt.tzinfo:
-            recur_id_dt = recur_id_dt.replace(tzinfo=None)
-        recurrence_id = RecurrenceId.__parse_property_value__(recur_id_dt)
-
-        def build() -> Todo:
-            updates = {
-                "dtstart": dtstart,
-                "recurrence_id": recurrence_id,
-            }
-            if self._todo.due and self._duration:
-                updates["due"] = dtstart + self._duration
-            return self._todo.copy(update=updates)
-
-        return LazySortableItem(dtstart, build)
-
-
-def _todos_by_uid(todos: list[Todo]) -> dict[str, list[Todo]]:
-    todos_by_uid: dict[str, list[Todo]] = {}
-    for todo in todos:
-        if todo.uid is None:
-            raise ValueError("Todo must have a UID")
-        if todo.uid not in todos_by_uid:
-            todos_by_uid[todo.uid] = []
-        todos_by_uid[todo.uid].append(todo)
-    return todos_by_uid
-
-
-def _pick_todo(todos: list[Todo], tzinfo: datetime.tzinfo) -> Todo:
+def _pick_todo(todos: list[Todo], dtstart: datetime.datetime) -> Todo:
     """Pick a todo to return in a list from a list of recurring todos.
 
     The items passed in must all be for the same original todo (either a
@@ -84,30 +31,28 @@ def _pick_todo(todos: list[Todo], tzinfo: datetime.tzinfo) -> Todo:
     """
     # For a recurring todo, the dtstart is after the last due date. Therefore
     # we can stort items by dtstart and pick the last one that hasn't happened
-    iters: list[Iterable[_SortableTodoItem]] = []
-    for todo in todos:
-        if not (recur := todo.as_rrule()):
-            iters.append([SortableItemValue(todo.dtstart, todo)])
-            continue
-        iters.append(RecurIterable(RecurAdapter(todo, tzinfo=tzinfo).get, recur))
+    root_iter = merge_and_expand_items(todos, dtstart.tzinfo or local_timezone())
 
-    root_iter = MergedIterable(iters)
-
-    # Pick the first todo that hasn't started yet based on its dtstart
-    now = datetime.datetime.now(tzinfo)
     it = iter(root_iter)
     last = next(it)
     while cur := next(it, None):
-        if cur.item.start_datetime is None or cur.item.start_datetime > now:
+        if cur.item.start_datetime is None or cur.item.start_datetime > dtstart:
             break
         last = cur
     return last.item
 
 
 def todo_list_view(
-    todos: list[Todo], tzinfo: datetime.tzinfo
+    todos: list[Todo],
+    dtstart: datetime.datetime | None = None,
 ) -> Generator[Todo, None, None]:
-    """Create a list view for todos on a calendar, including recurrence."""
-    todos_by_uid = _todos_by_uid(todos)
+    """Create a list view for todos on a calendar, including recurrence.
+
+    The dtstart value is used to determine the current time for the list and
+    for deciding which instance of a recurring todo to return.
+    """
+    if dtstart is None:
+        dtstart = datetime.datetime.now(tz=local_timezone())
+    todos_by_uid = items_by_uid(todos)
     for todos in todos_by_uid.values():
-        yield _pick_todo(todos, tzinfo=tzinfo)
+        yield _pick_todo(todos, dtstart)

--- a/ical/recur_adapter.py
+++ b/ical/recur_adapter.py
@@ -93,16 +93,10 @@ def merge_and_expand_items(
     iters: list[Iterable[SpanOrderedItem[ItemType]]] = []
     for item in items:
         if not (recur := item.as_rrule()):
-            dtstart = item.dtstart or datetime.datetime.now(tz=tzinfo)
-            dtend = dtstart
-            if isinstance(item, Todo) and item.due:
-                dtend = item.due
-            elif isinstance(item, Event) and item.dtend:
-                dtend = item.dtend
             iters.append(
                 [
                     SortableItemValue(
-                        Timespan.of(dtstart, dtend, tzinfo),
+                        item.timespan_of(tzinfo),
                         item,
                     )
                 ]

--- a/ical/recur_adapter.py
+++ b/ical/recur_adapter.py
@@ -1,0 +1,112 @@
+"""Component specific iterable functions.
+
+This module contains functions that are helpful for iterating over components
+in a calendar. This includes expanding recurring components or other functions
+for managing components from a list (e.g. grouping by uid).
+"""
+
+import datetime
+from collections.abc import Iterable
+from typing import Generic, TypeVar, cast
+
+from .iter import (
+    MergedIterable,
+    RecurIterable,
+    SortableItemValue,
+    SpanOrderedItem,
+    LazySortableItem,
+    SortableItem,
+)
+from .types.recur import RecurrenceId
+from .event import Event
+from .todo import Todo
+from .timespan import Timespan
+
+
+ItemType = TypeVar("ItemType", bound="Event | Todo")
+_DateOrDatetime = datetime.datetime | datetime.date
+
+
+class RecurAdapter(Generic[ItemType]):
+    """An adapter that expands an Event instance for a recurrence rule.
+
+    This adapter is given an event, then invoked with a specific date/time instance
+    that the event occurs on due to a recurrence rule. The event is copied with
+    necessary updated fields to act as a flattened instance of the event.
+    """
+
+    def __init__(
+        self,
+        item: ItemType,
+        tzinfo: datetime.tzinfo | None = None,
+    ) -> None:
+        """Initialize the RecurAdapter."""
+        self._item = item
+        self._duration = item.computed_duration
+        self._tzinfo = tzinfo
+
+    def get(
+        self, dtstart: datetime.datetime | datetime.date
+    ) -> SortableItem[Timespan, ItemType]:
+        """Return a lazy sortable item."""
+
+        recur_id_dt = dtstart
+        dtend = dtstart + self._duration if self._duration else dtstart
+        # Make recurrence_id floating time to avoid dealing with serializing
+        # TZID. This value will still be unique within the series and is in
+        # the context of dtstart which may have a timezone.
+        if isinstance(recur_id_dt, datetime.datetime) and recur_id_dt.tzinfo:
+            recur_id_dt = recur_id_dt.replace(tzinfo=None)
+        recurrence_id = RecurrenceId.__parse_property_value__(recur_id_dt)
+
+        def build() -> ItemType:
+            updates = {
+                "dtstart": dtstart,
+                "recurrence_id": recurrence_id,
+            }
+            if isinstance(self._item, Event) and self._item.dtend and dtend:
+                updates["dtend"] = dtend
+            if isinstance(self._item, Todo) and self._item.due and dtend:
+                updates["due"] = dtend
+            return cast(ItemType, self._item.copy(update=updates))
+
+        ts = Timespan.of(dtstart, dtend, self._tzinfo)
+        return LazySortableItem(ts, build)
+
+
+def items_by_uid(items: list[ItemType]) -> dict[str, list[ItemType]]:
+    items_by_uid: dict[str, list[ItemType]] = {}
+    for item in items:
+        if item.uid is None:
+            raise ValueError("Todo must have a UID")
+        if (values := items_by_uid.get(item.uid)) is None:
+            values = []
+            items_by_uid[item.uid] = values
+        values.append(item)
+    return items_by_uid
+
+
+def merge_and_expand_items(
+    items: list[ItemType], tzinfo: datetime.tzinfo
+) -> Iterable[SpanOrderedItem[ItemType]]:
+    """Merge and expand items that are recurring."""
+    iters: list[Iterable[SpanOrderedItem[ItemType]]] = []
+    for item in items:
+        if not (recur := item.as_rrule()):
+            dtstart = item.dtstart or datetime.datetime.now(tz=tzinfo)
+            dtend = dtstart
+            if isinstance(item, Todo) and item.due:
+                dtend = item.due
+            elif isinstance(item, Event) and item.dtend:
+                dtend = item.dtend
+            iters.append(
+                [
+                    SortableItemValue(
+                        Timespan.of(dtstart, dtend, tzinfo),
+                        item,
+                    )
+                ]
+            )
+            continue
+        iters.append(RecurIterable(RecurAdapter(item, tzinfo=tzinfo).get, recur))
+    return MergedIterable(iters)

--- a/ical/store.py
+++ b/ical/store.py
@@ -186,6 +186,11 @@ class GenericStore(Generic[_T]):
             update["created"] = item.dtstamp
         if item.sequence is None:
             update["sequence"] = 0
+        if isinstance(item, Todo) and not item.dtstart:
+            if item.due:
+                update["dtstart"] = item.due - datetime.timedelta(days=1)
+            else:
+                update["dtstart"] = datetime.datetime.now(tz=local_timezone())
         new_item = cast(_T, item.copy(update=update))
 
         # The store can only manage cascading deletes for some relationship types

--- a/ical/store.py
+++ b/ical/store.py
@@ -41,17 +41,6 @@ __all__ = [
 _T = TypeVar("_T", bound="Event | Todo")
 
 
-def _lookup_by_uid(
-    items: Iterable[_T], uid: str, recurrence_id: str | None = None
-) -> tuple[int | None, _T | None]:
-    """Find the specified item by id."""
-    for i, item in enumerate(items):
-        if item.uid != uid:
-            continue
-        return i, item
-    return None, None
-
-
 def _ensure_timezone(
     dtstart: datetime.datetime | datetime.date | None, timezones: list[Timezone]
 ) -> Timezone | None:

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -17,6 +17,7 @@ from .component import ComponentModel, validate_until_dtstart, validate_recurren
 from .exceptions import CalendarParseError
 from .iter import RulesetIterable
 from .parsing.property import ParsedProperty
+from .timespan import Timespan
 from .types import (
     CalAddress,
     Classification,
@@ -207,6 +208,22 @@ class Todo(ComponentModel):
         if self.due is None or self.dtstart is None:
             return None
         return self.due - self.dtstart
+
+
+    @property
+    def timespan(self) -> Timespan:
+        """Return a timespan representing the item start and due date."""
+        if not self.start:
+            raise ValueError("Event must have a start and due date to calculate timespan")
+        return Timespan.of(self.start, self.due or self.start)
+
+    def timespan_of(self, tzinfo: datetime.tzinfo) -> Timespan:
+        """Return a timespan representing the item start and due date."""
+        if not self.start:
+            raise ValueError("Event must have a start and due date to calculate timespan")
+        return Timespan.of(
+            normalize_datetime(self.start, tzinfo), normalize_datetime(self.due or self.start, tzinfo)
+        )
 
     @property
     def recurring(self) -> bool:

--- a/tests/__snapshots__/test_store.ambr
+++ b/tests/__snapshots__/test_store.ambr
@@ -721,6 +721,83 @@
     }),
   ])
 # ---
+# name: test_modify_todo_rrule_for_this_and_future[2024-01-05]
+  list([
+    dict({
+      'due': '2024-01-07',
+      'recurrence_id': '20240106',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Wash car (Sa)',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_modify_todo_rrule_for_this_and_future[2024-01-12]
+  list([
+    dict({
+      'due': '2024-01-07',
+      'recurrence_id': '20240106',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Wash car (Sa)',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_modify_todo_rrule_for_this_and_future[2024-01-19]
+  list([
+    dict({
+      'due': '2024-01-14',
+      'recurrence_id': '20240113',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Wash car (Sa)',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_modify_todo_rrule_for_this_and_future[2024-01-26]
+  list([
+    dict({
+      'due': '2024-01-22',
+      'recurrence_id': '20240121',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Wash car (Su)',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_modify_todo_rrule_for_this_and_future[ics]
+  '''
+  BEGIN:VCALENDAR
+  PRODID:-//github.com/allenporter/ical//6.1.1//EN
+  VERSION:2.0
+  BEGIN:VTODO
+  DTSTAMP:20220903T093805
+  UID:mock-uid-1
+  CREATED:20220903T093805
+  DTSTART:20240121
+  DUE:20240122
+  LAST-MODIFIED:20220903T093805
+  RECURRENCE-ID:20240120
+  RRULE:FREQ=WEEKLY;COUNT=8;BYDAY=SU
+  SEQUENCE:1
+  STATUS:NEEDS-ACTION
+  SUMMARY:Wash car (Su)
+  END:VTODO
+  BEGIN:VTODO
+  DTSTAMP:20220903T093805
+  UID:mock-uid-1
+  CREATED:20220903T093805
+  DTSTART:20240106
+  DUE:20240107
+  LAST-MODIFIED:20220903T093805
+  RRULE:FREQ=WEEKLY;UNTIL=20240119;BYDAY=SA
+  SEQUENCE:0
+  STATUS:NEEDS-ACTION
+  SUMMARY:Wash car (Sa)
+  END:VTODO
+  END:VCALENDAR
+  '''
+# ---
 # name: test_recurring_event[start0-end0-recur0]
   list([
     dict({

--- a/tests/__snapshots__/test_store.ambr
+++ b/tests/__snapshots__/test_store.ambr
@@ -823,18 +823,27 @@
     }),
   ])
 # ---
-# name: test_recurring_todo_item_edit_series
-  list([
-    dict({
-      'due': '2024-01-10',
-      'recurrence_id': '20240109',
-      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
-      'summary': 'Walk dog',
-      'uid': 'mock-uid-1',
-    }),
-  ])
+# name: test_recurring_todo_item_edit_series.3
+  '''
+  BEGIN:VCALENDAR
+  PRODID:-//github.com/allenporter/ical//6.1.1//EN
+  VERSION:2.0
+  BEGIN:VTODO
+  DTSTAMP:20240109T100005
+  UID:mock-uid-1
+  CREATED:20240109T100005
+  DTSTART:20240109
+  DUE:20240110
+  LAST-MODIFIED:20240109T100005
+  RRULE:FREQ=DAILY;COUNT=10
+  SEQUENCE:1
+  STATUS:COMPLETED
+  SUMMARY:Walk dog
+  END:VTODO
+  END:VCALENDAR
+  '''
 # ---
-# name: test_recurring_todo_item_edit_series.1
+# name: test_recurring_todo_item_edit_series[completed]
   list([
     dict({
       'due': '2024-01-10',
@@ -845,7 +854,18 @@
     }),
   ])
 # ---
-# name: test_recurring_todo_item_edit_series.2
+# name: test_recurring_todo_item_edit_series[initial]
+  list([
+    dict({
+      'due': '2024-01-10',
+      'recurrence_id': '20240109',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_recurring_todo_item_edit_series[next_instance]
   list([
     dict({
       'due': '2024-01-11',
@@ -856,18 +876,7 @@
     }),
   ])
 # ---
-# name: test_recurring_todo_item_edit_single
-  list([
-    dict({
-      'due': '2024-01-10',
-      'recurrence_id': '20240109',
-      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
-      'summary': 'Walk dog',
-      'uid': 'mock-uid-1',
-    }),
-  ])
-# ---
-# name: test_recurring_todo_item_edit_single.1
+# name: test_recurring_todo_item_edit_single[completed]
   list([
     dict({
       'due': '2024-01-10',
@@ -878,7 +887,26 @@
     }),
   ])
 # ---
-# name: test_recurring_todo_item_edit_single.2
+# name: test_recurring_todo_item_edit_single[deleted_series_ics]
+  '''
+  BEGIN:VCALENDAR
+  PRODID:-//github.com/allenporter/ical//6.1.1//EN
+  VERSION:2.0
+  END:VCALENDAR
+  '''
+# ---
+# name: test_recurring_todo_item_edit_single[initial]
+  list([
+    dict({
+      'due': '2024-01-10',
+      'recurrence_id': '20240109',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_recurring_todo_item_edit_single[next_instance]
   list([
     dict({
       'due': '2024-01-11',
@@ -889,38 +917,7 @@
     }),
   ])
 # ---
-# name: test_recurring_todo_item_edit_single.3
-  list([
-    tuple(
-      '2024-01-09',
-      '2024-01-10',
-      '20240109',
-      None,
-      list([
-      ]),
-    ),
-    tuple(
-      '2024-01-09',
-      '2024-01-10',
-      '20240110',
-      None,
-      list([
-        FakeDate(2024, 1, 9),
-      ]),
-    ),
-    tuple(
-      '2024-01-09',
-      '2024-01-10',
-      None,
-      Recur(freq=<Frequency.DAILY: 'DAILY'>, until=None, count=10, interval=1, by_weekday=[], by_month_day=[], by_month=[], by_setpos=[]),
-      list([
-        FakeDate(2024, 1, 9),
-        FakeDate(2024, 1, 10),
-      ]),
-    ),
-  ])
-# ---
-# name: test_recurring_todo_item_edit_single.4
+# name: test_recurring_todo_item_edit_single[next_instance_completed]
   list([
     dict({
       'due': '2024-01-10',
@@ -931,13 +928,7 @@
     }),
   ])
 # ---
-# name: test_recurring_todo_item_edit_single.5
-  list([
-    '20240109',
-    None,
-  ])
-# ---
-# name: test_recurring_todo_item_edit_single.6
+# name: test_recurring_todo_item_edit_single[next_instance_deleted]
   list([
     dict({
       'due': '2024-01-10',
@@ -947,4 +938,83 @@
       'uid': 'mock-uid-1',
     }),
   ])
+# ---
+# name: test_recurring_todo_item_edit_single[next_instance_deleted_ics]
+  '''
+  BEGIN:VCALENDAR
+  PRODID:-//github.com/allenporter/ical//6.1.1//EN
+  VERSION:2.0
+  BEGIN:VTODO
+  DTSTAMP:20240109T100005
+  UID:mock-uid-1
+  CREATED:20240109T100005
+  DTSTART:20240109
+  DUE:20240110
+  LAST-MODIFIED:20240109T100005
+  RECURRENCE-ID:20240109
+  SEQUENCE:1
+  STATUS:COMPLETED
+  SUMMARY:Walk dog
+  END:VTODO
+  BEGIN:VTODO
+  DTSTAMP:20240109T100005
+  UID:mock-uid-1
+  CREATED:20240109T100005
+  DTSTART:20240109
+  DUE:20240110
+  RRULE:FREQ=DAILY;COUNT=10
+  EXDATE:20240109
+  EXDATE:20240110
+  SEQUENCE:0
+  STATUS:NEEDS-ACTION
+  SUMMARY:Walk dog
+  END:VTODO
+  END:VCALENDAR
+  '''
+# ---
+# name: test_recurring_todo_item_edit_single[result_ics]
+  '''
+  BEGIN:VCALENDAR
+  PRODID:-//github.com/allenporter/ical//6.1.1//EN
+  VERSION:2.0
+  BEGIN:VTODO
+  DTSTAMP:20240109T100005
+  UID:mock-uid-1
+  CREATED:20240109T100005
+  DTSTART:20240109
+  DUE:20240110
+  LAST-MODIFIED:20240109T100005
+  RECURRENCE-ID:20240109
+  SEQUENCE:1
+  STATUS:COMPLETED
+  SUMMARY:Walk dog
+  END:VTODO
+  BEGIN:VTODO
+  DTSTAMP:20240110T100000
+  UID:mock-uid-1
+  CREATED:20240109T100005
+  DTSTART:20240109
+  DUE:20240110
+  LAST-MODIFIED:20240110T100000
+  RECURRENCE-ID:20240110
+  EXDATE:20240109
+  SEQUENCE:1
+  STATUS:COMPLETED
+  SUMMARY:Walk dog
+  END:VTODO
+  BEGIN:VTODO
+  DTSTAMP:20240109T100005
+  UID:mock-uid-1
+  CREATED:20240109T100005
+  DTSTART:20240109
+  DUE:20240110
+  RRULE:FREQ=DAILY;COUNT=10
+  EXDATE:20240109
+  EXDATE:20240110
+  SEQUENCE:0
+  STATUS:NEEDS-ACTION
+  SUMMARY:Walk dog
+  END:VTODO
+  END:VCALENDAR
+  '''
 # ---

--- a/tests/__snapshots__/test_store.ambr
+++ b/tests/__snapshots__/test_store.ambr
@@ -119,6 +119,87 @@
     'mock-uid-4',
   ])
 # ---
+# name: test_delete_instance_in_todo_series
+  list([
+    tuple(
+      '2024-01-09',
+      None,
+      Recur(freq=<Frequency.DAILY: 'DAILY'>, until=None, count=10, interval=1, by_weekday=[], by_month_day=[], by_month=[], by_setpos=[]),
+    ),
+  ])
+# ---
+# name: test_delete_instance_in_todo_series.1
+  list([
+    tuple(
+      '2024-01-09',
+      '20240109',
+      None,
+      list([
+      ]),
+    ),
+    tuple(
+      '2024-01-09',
+      None,
+      Recur(freq=<Frequency.DAILY: 'DAILY'>, until=None, count=10, interval=1, by_weekday=[], by_month_day=[], by_month=[], by_setpos=[]),
+      list([
+        FakeDate(2024, 1, 9),
+      ]),
+    ),
+  ])
+# ---
+# name: test_delete_instance_in_todo_series.2
+  list([
+    tuple(
+      '2024-01-09',
+      '20240109',
+      None,
+      list([
+      ]),
+    ),
+    tuple(
+      '2024-01-09',
+      None,
+      Recur(freq=<Frequency.DAILY: 'DAILY'>, until=None, count=10, interval=1, by_weekday=[], by_month_day=[], by_month=[], by_setpos=[]),
+      list([
+        FakeDate(2024, 1, 9),
+        FakeDate(2024, 1, 10),
+      ]),
+    ),
+  ])
+# ---
+# name: test_delete_instance_in_todo_series.3
+  list([
+    dict({
+      'due': '2024-01-10',
+      'recurrence_id': '20240109',
+      'status': <TodoStatus.COMPLETED: 'COMPLETED'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_delete_instance_in_todo_series.4
+  list([
+    dict({
+      'due': '2024-01-12',
+      'recurrence_id': '20240111',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_delete_instance_in_todo_series.5
+  list([
+    dict({
+      'due': '2024-01-13',
+      'recurrence_id': '20240112',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
 # name: test_delete_parent_todo_cascade_to_children
   list([
     'mock-uid-1',
@@ -303,13 +384,13 @@
       'dtstart': '2022-09-05T09:00:00',
       'recurrence_id': '20220905T090000',
       'summary': 'Team meeting',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-19T09:00:00',
       'recurrence_id': '20220919T090000',
       'summary': 'Team meeting',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
   ])
 # ---
@@ -362,17 +443,21 @@
     dict({
       'dtstart': '2022-08-29',
       'recurrence_id': '20220829',
+      'sequence': 0,
       'summary': 'Monday event',
       'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-06',
+      'recurrence_id': '20220905',
+      'sequence': 1,
       'summary': 'Tuesday event',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-12',
       'recurrence_id': '20220912',
+      'sequence': 0,
       'summary': 'Monday event',
       'uid': 'mock-uid-1',
     }),
@@ -383,17 +468,21 @@
     dict({
       'dtstart': '2022-08-29',
       'recurrence_id': '20220829',
+      'sequence': 0,
       'summary': 'Monday event',
       'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-06',
+      'recurrence_id': '20220905',
+      'sequence': 1,
       'summary': 'Tuesday event',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-12',
       'recurrence_id': '20220912',
+      'sequence': 0,
       'summary': 'Monday event',
       'uid': 'mock-uid-1',
     }),
@@ -411,13 +500,13 @@
       'dtstart': '2022-09-05',
       'recurrence_id': '20220905',
       'summary': 'Mondays [edit]',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-12',
       'recurrence_id': '20220912',
       'summary': 'Mondays [edit]',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
   ])
 # ---
@@ -433,13 +522,13 @@
       'dtstart': '2022-09-05',
       'recurrence_id': '20220905',
       'summary': 'Mondays [edit]',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-12',
       'recurrence_id': '20220912',
       'summary': 'Mondays [edit]',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
   ])
 # ---
@@ -497,8 +586,9 @@
     }),
     dict({
       'dtstart': '2022-09-06T09:00:00',
+      'recurrence_id': '20220905T090000',
       'summary': 'Tuesday meeting',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-12T09:00:00',
@@ -518,8 +608,9 @@
     }),
     dict({
       'dtstart': '2022-09-06T09:00:00',
+      'recurrence_id': '20220905T090000',
       'summary': 'Tuesday meeting',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-12T09:00:00',
@@ -541,13 +632,13 @@
       'dtstart': '2022-09-05T09:00:00',
       'recurrence_id': '20220905T090000',
       'summary': 'Team meeting',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-12T09:00:00',
       'recurrence_id': '20220912T090000',
       'summary': 'Team meeting',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
   ])
 # ---
@@ -563,13 +654,13 @@
       'dtstart': '2022-09-05T09:00:00',
       'recurrence_id': '20220905T090000',
       'summary': 'Team meeting',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
     dict({
       'dtstart': '2022-09-12T09:00:00',
       'recurrence_id': '20220912T090000',
       'summary': 'Team meeting',
-      'uid': 'mock-uid-2',
+      'uid': 'mock-uid-1',
     }),
   ])
 # ---
@@ -732,7 +823,7 @@
     }),
   ])
 # ---
-# name: test_recurring_item
+# name: test_recurring_todo_item_edit_series
   list([
     dict({
       'due': '2024-01-10',
@@ -743,7 +834,7 @@
     }),
   ])
 # ---
-# name: test_recurring_item.1
+# name: test_recurring_todo_item_edit_series.1
   list([
     dict({
       'due': '2024-01-10',
@@ -754,11 +845,103 @@
     }),
   ])
 # ---
-# name: test_recurring_item.2
+# name: test_recurring_todo_item_edit_series.2
   list([
     dict({
       'due': '2024-01-11',
       'recurrence_id': '20240110',
+      'status': <TodoStatus.COMPLETED: 'COMPLETED'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_recurring_todo_item_edit_single
+  list([
+    dict({
+      'due': '2024-01-10',
+      'recurrence_id': '20240109',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_recurring_todo_item_edit_single.1
+  list([
+    dict({
+      'due': '2024-01-10',
+      'recurrence_id': '20240109',
+      'status': <TodoStatus.COMPLETED: 'COMPLETED'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_recurring_todo_item_edit_single.2
+  list([
+    dict({
+      'due': '2024-01-11',
+      'recurrence_id': '20240110',
+      'status': <TodoStatus.NEEDS_ACTION: 'NEEDS-ACTION'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_recurring_todo_item_edit_single.3
+  list([
+    tuple(
+      '2024-01-09',
+      '2024-01-10',
+      '20240109',
+      None,
+      list([
+      ]),
+    ),
+    tuple(
+      '2024-01-09',
+      '2024-01-10',
+      '20240110',
+      None,
+      list([
+        FakeDate(2024, 1, 9),
+      ]),
+    ),
+    tuple(
+      '2024-01-09',
+      '2024-01-10',
+      None,
+      Recur(freq=<Frequency.DAILY: 'DAILY'>, until=None, count=10, interval=1, by_weekday=[], by_month_day=[], by_month=[], by_setpos=[]),
+      list([
+        FakeDate(2024, 1, 9),
+        FakeDate(2024, 1, 10),
+      ]),
+    ),
+  ])
+# ---
+# name: test_recurring_todo_item_edit_single.4
+  list([
+    dict({
+      'due': '2024-01-10',
+      'recurrence_id': '20240110',
+      'status': <TodoStatus.COMPLETED: 'COMPLETED'>,
+      'summary': 'Walk dog',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_recurring_todo_item_edit_single.5
+  list([
+    '20240109',
+    None,
+  ])
+# ---
+# name: test_recurring_todo_item_edit_single.6
+  list([
+    dict({
+      'due': '2024-01-10',
+      'recurrence_id': '20240109',
       'status': <TodoStatus.COMPLETED: 'COMPLETED'>,
       'summary': 'Walk dog',
       'uid': 'mock-uid-1',

--- a/tests/__snapshots__/test_store.ambr
+++ b/tests/__snapshots__/test_store.ambr
@@ -17,6 +17,7 @@
     dict({
       'created': '2022-09-03T09:38:05',
       'dtstamp': '2022-09-03T09:38:05',
+      'dtstart': '2022-08-28T09:00:00',
       'due': '2022-08-29T09:00:00',
       'sequence': 0,
       'summary': 'Monday meeting',
@@ -685,6 +686,7 @@
     dict({
       'created': '2022-09-03T09:38:05',
       'dtstamp': '2022-09-03T09:38:05',
+      'dtstart': '2022-08-28T09:00:00',
       'due': '2022-08-29T09:00:00',
       'sequence': 0,
       'summary': 'Monday morning items',
@@ -693,6 +695,7 @@
     dict({
       'created': '2022-09-03T09:38:05',
       'dtstamp': '2022-09-03T09:38:05',
+      'dtstart': '2022-08-29T09:00:00',
       'due': '2022-08-30T09:00:00',
       'sequence': 0,
       'summary': 'Tuesday morning items',
@@ -705,6 +708,7 @@
     dict({
       'created': '2022-09-03T09:38:05',
       'dtstamp': '2022-09-03T09:38:15',
+      'dtstart': '2022-08-28T09:00:00',
       'due': '2022-08-29T09:05:00',
       'last_modified': '2022-09-03T09:38:15',
       'sequence': 1,
@@ -714,6 +718,7 @@
     dict({
       'created': '2022-09-03T09:38:05',
       'dtstamp': '2022-09-03T09:38:05',
+      'dtstart': '2022-08-29T09:00:00',
       'due': '2022-08-30T09:00:00',
       'sequence': 0,
       'summary': 'Tuesday morning items',

--- a/tests/test_list.py
+++ b/tests/test_list.py
@@ -12,7 +12,7 @@ from ical.types.recur import Recur
 
 def test_empty_list() -> None:
     """Test an empty list."""
-    view = todo_list_view([], tzinfo=datetime.timezone.utc)
+    view = todo_list_view([])
     assert list(view) == []
 
 
@@ -33,7 +33,7 @@ def test_daily_recurring_item_due_today_incomplete(status: str) -> None:
             rrule=Recur.from_rrule("FREQ=DAILY"),
             status=status,
         )
-        view = list(todo_list_view([todo], tzinfo=datetime.timezone.utc))
+        view = list(todo_list_view([todo]))
 
     assert len(view) == 1
     assert view[0].summary == todo.summary
@@ -59,7 +59,7 @@ def test_daily_recurring_item_due_tomorrow(status: str) -> None:
             rrule=Recur.from_rrule("FREQ=DAILY"),
             status=status,
         )
-        view = list(todo_list_view([todo], tzinfo=datetime.timezone.utc))
+        view = list(todo_list_view([todo]))
 
     assert len(view) == 1
     assert view[0].summary == todo.summary
@@ -86,7 +86,7 @@ def test_daily_recurring_item_due_yesterday(status: str) -> None:
             rrule=Recur.from_rrule("FREQ=DAILY"),
             status=status,
         )
-        view = list(todo_list_view([todo], tzinfo=datetime.timezone.utc))
+        view = list(todo_list_view([todo]))
 
     # The item should be returned with a recurrence_id of today
     assert len(view) == 1
@@ -97,7 +97,7 @@ def test_daily_recurring_item_due_yesterday(status: str) -> None:
     assert view[0].status == status
 
     with freezegun.freeze_time("2024-01-11T08:05:00-05:00"):
-        view = list(todo_list_view([todo], tzinfo=datetime.timezone.utc))
+        view = list(todo_list_view([todo]))
 
     assert len(view) == 1
     assert view[0].summary == todo.summary

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -85,12 +85,12 @@ def mock_fetch_events(
 
 @pytest.fixture(name="fetch_todos")
 def mock_fetch_todos(
-    calendar: Calendar,
+    todo_store: TodoStore,
 ) -> Callable[..., list[dict[str, Any]]]:
     """Fixture to return todos on the calendar."""
 
     def _func(keys: set[str] | None = None) -> list[dict[str, Any]]:
-        return [compact_dict(todo.dict(), keys) for todo in calendar.todo_list()]
+        return [compact_dict(todo.dict(), keys) for todo in todo_store.todo_list()]
 
     return _func
 
@@ -415,7 +415,8 @@ def test_edit_recurring_all_day_event_instance(
         Event(start="2022-09-06", summary="Tuesday event"),
         recurrence_id="20220905",
     )
-    assert fetch_events({"uid", "recurrence_id", "dtstart", "summary"}) == snapshot
+
+    assert fetch_events({"uid", "recurrence_id", "sequence", "dtstart", "summary"}) == snapshot
 
 
 @pytest.mark.parametrize(
@@ -739,17 +740,18 @@ def test_invalid_recurrence_id(
     """Test adding an event to the store and retrieval."""
     store.add(
         Event(
+            uid="mock-uid-1",
             summary="Monday meeting",
             start="2022-08-29T09:00:00",
             end="2022-08-29T09:30:00",
         )
     )
 
-    with pytest.raises(StoreError, match=r"event is not recurring"):
-        store.delete("mock-uid-1", recurrence_id="invalid")
+    with pytest.raises(StoreError, match=r"No existing item"):
+        store.delete("mock-uid-1", recurrence_id="20220828T090000")
 
-    with pytest.raises(StoreError, match=r"event is not recurring"):
-        store.edit("mock-uid-1", Event(summary="tuesday"), recurrence_id="invalid")
+    with pytest.raises(StoreError, match=r"No existing item with"):
+        store.edit("mock-uid-1", Event(summary="tuesday"), recurrence_id="20210828")
 
 
 def test_no_timezone_for_floating(
@@ -1141,7 +1143,7 @@ def test_unsupported_todo_reltype(
         todo_store.edit(todo2.uid, todo2)
 
 
-def test_recurring_item(
+def test_recurring_todo_item_edit_series(
     todo_store: TodoStore,
     fetch_todos: Callable[..., list[dict[str, Any]]],
     frozen_time: FrozenDateTimeFactory,
@@ -1171,4 +1173,170 @@ def test_recurring_item(
     frozen_time.move_to("2024-01-10T10:00:00")
 
     # All instances are completed
+    assert fetch_todos(["uid", "recurrence_id", "due", "summary", "status"]) == snapshot
+
+
+def test_recurring_todo_item_edit_single(
+    calendar: Calendar,
+    todo_store: TodoStore,
+    fetch_todos: Callable[..., list[dict[str, Any]]],
+    frozen_time: FrozenDateTimeFactory,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test editing a single recurring item."""
+
+    frozen_time.move_to("2024-01-09T10:00:05")
+
+    # Create a recurring to-do item
+    todo_store.add(
+        Todo(
+            summary="Walk dog",
+            dtstart="2024-01-09",
+            due="2024-01-10",
+            status="NEEDS-ACTION",
+            rrule=Recur.from_rrule("FREQ=DAILY;COUNT=10"),
+        )
+    )
+    # There is a single underlying instance
+    recurrence_ids = [item.recurrence_id for item in calendar.todos]
+    assert recurrence_ids == [None]
+    assert fetch_todos(["uid", "recurrence_id", "due", "summary", "status"]) == snapshot
+
+    # Mark a single instance as completed
+    todo_store.edit("mock-uid-1", Todo(status="COMPLETED"), recurrence_id="20240109")
+    # There are now two underlying instances
+    assert len(calendar.todos) == 2
+    todo = calendar.todos[0]
+    assert todo.dtstart.isoformat() == "2024-01-09"
+    assert todo.recurrence_id == "20240109"
+    assert todo.rrule is None
+    assert todo.exdate == []
+    # Series continues from the next instance by excluding the edited instance
+    # from the series.
+    todo = calendar.todos[1]
+    assert todo.dtstart.isoformat() == "2024-01-09"
+    assert todo.recurrence_id is None
+    assert todo.rrule == Recur.from_rrule("FREQ=DAILY;COUNT=10")
+    assert todo.exdate == [datetime.date(2024, 1, 9)]
+
+    # Collapsed view of a single item
+    assert fetch_todos(["uid", "recurrence_id", "due", "summary", "status"]) == snapshot
+
+    # Advance to the next day and a new incomplete instance appears
+    frozen_time.move_to("2024-01-10T10:00:00")
+    assert fetch_todos(["uid", "recurrence_id", "due", "summary", "status"]) == snapshot
+
+    # Mark the new instance as completed
+    todo_store.edit("mock-uid-1", Todo(status="COMPLETED"), recurrence_id="20240110")
+    # Now 3 underlying objects
+    # When editing an item in the series and forking it, we need to clone the
+    # recurring instance rather than the original instance.
+
+    raw_ids = [
+        (
+            item.dtstart.isoformat(),
+            item.due.isoformat(),
+            item.recurrence_id,
+            item.rrule,
+            item.exdate,
+        )
+        for item in calendar.todos
+    ]
+    assert raw_ids == snapshot
+
+    # Collapsed view of the same item
+    assert fetch_todos(["uid", "recurrence_id", "due", "summary", "status"]) == snapshot
+
+    # Delete a single instance and the following days instance appears. This is
+    # not really a common operation, but still worth exercsing the behavior.
+    todo_store.delete("mock-uid-1", recurrence_id="20240110")
+
+    # Now only two underlying objects
+    recurrence_ids = [item.recurrence_id for item in calendar.todos]
+    assert recurrence_ids == snapshot
+    # The prior instance is the latest on the list
+    assert fetch_todos(["uid", "recurrence_id", "due", "summary", "status"]) == snapshot
+
+    # Delete the entire series
+    todo_store.delete("mock-uid-1")
+    assert not calendar.todos
+
+
+def test_delete_todo_series(
+    calendar: Calendar,
+    todo_store: TodoStore,
+    fetch_todos: Callable[..., list[dict[str, Any]]],
+    frozen_time: FrozenDateTimeFactory,
+) -> None:
+    """Test deleting a recurring todo item with edits applied."""
+    # Create a recurring to-do item
+    todo_store.add(
+        Todo(
+            summary="Walk dog",
+            dtstart="2024-01-09",
+            due="2024-01-10",
+            status="NEEDS-ACTION",
+            rrule=Recur.from_rrule("FREQ=DAILY;COUNT=10"),
+        )
+    )
+    # Mark instances as completed
+    todo_store.edit("mock-uid-1", Todo(status="COMPLETED"), recurrence_id="20240109")
+    # Delete all the items
+    todo_store.delete("mock-uid-1")
+    assert not calendar.todos
+
+
+def test_delete_instance_in_todo_series(
+    calendar: Calendar,
+    todo_store: TodoStore,
+    fetch_todos: Callable[..., list[dict[str, Any]]],
+    frozen_time: FrozenDateTimeFactory,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test deleting a single instance of a recurring todo item."""
+    # Create a recurring to-do item
+    todo_store.add(
+        Todo(
+            summary="Walk dog",
+            dtstart="2024-01-09",
+            due="2024-01-10",
+            status="NEEDS-ACTION",
+            rrule=Recur.from_rrule("FREQ=DAILY;COUNT=10"),
+        )
+    )
+    raw_ids = [
+        (item.dtstart.isoformat(), item.recurrence_id, item.rrule)
+        for item in calendar.todos
+    ]
+    assert raw_ids == snapshot
+
+    # Mark instances as completed
+    todo_store.edit("mock-uid-1", Todo(status="COMPLETED"), recurrence_id="20240109")
+    raw_ids = [
+        (item.dtstart.isoformat(), item.recurrence_id, item.rrule, item.exdate)
+        for item in calendar.todos
+    ]
+    assert raw_ids == snapshot
+
+    # Delete a another instance
+    todo_store.delete("mock-uid-1", recurrence_id="20240110")
+
+    raw_ids = [
+        (item.dtstart.isoformat(), item.recurrence_id, item.rrule, item.exdate)
+        for item in calendar.todos
+    ]
+    assert raw_ids == snapshot
+
+    # Advance to the next day.
+    frozen_time.move_to("2024-01-10T10:00:00")
+
+    # Previous item is still marked completed and new item has not started yet
+    assert fetch_todos(["uid", "recurrence_id", "due", "summary", "status"]) == snapshot
+
+    # Advance to the next day and New item appears.
+    frozen_time.move_to("2024-01-11T10:00:00")
+    assert fetch_todos(["uid", "recurrence_id", "due", "summary", "status"]) == snapshot
+
+    # Advance to the next day and New item appears.
+    frozen_time.move_to("2024-01-12T10:00:00")
     assert fetch_todos(["uid", "recurrence_id", "due", "summary", "status"]) == snapshot


### PR DESCRIPTION
Copy the original uid to edited recurring event instances, such that instances of a recurring event are preserved. Share all the code for building recurring events.