### PR TITLE
Improve Todo due and dtstart validations

### DIFF
--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -8,20 +8,14 @@ like returning all events happening today or after a specific date.
 from __future__ import annotations
 
 import datetime
-from collections.abc import Generator, Iterable, Iterator
+from collections.abc import Iterable, Iterator
 
 from .event import Event
 from .iter import (
-    MergedIterable,
-    RecurIterable,
-    SortableItem,
     SortableItemTimeline,
-    SortableItemValue,
-    SortedItemIterable,
     SpanOrderedItem,
 )
-from .recur_adapter import RecurAdapter, merge_and_expand_items
-from .timespan import Timespan
+from .recur_adapter import merge_and_expand_items
 
 __all__ = ["Timeline"]
 

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -281,17 +281,66 @@ class Todo(ComponentModel):
         )
 
     @root_validator
-    def validate_one_due_or_duration(cls, values: dict[str, Any]) -> dict[str, Any]:
+    def _validate_one_due_or_duration(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate that only one of duration or end date may be set."""
         if values.get("due") and values.get("duration"):
             raise ValueError("Only one of dtend or duration may be set." "")
         return values
 
     @root_validator
-    def validate_duration_requires_start(cls, values: dict[str, Any]) -> dict[str, Any]:
+    def _validate_duration_requires_start(cls, values: dict[str, Any]) -> dict[str, Any]:
         """Validate that a duration requires the dtstart."""
         if values.get("duration") and not values.get("dtstart"):
             raise ValueError("Duration requires that dtstart is specified")
+        return values
+
+    @root_validator
+    def _validate_due_later(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate that the due property is later than dtstart."""
+        if not (due := values.get("due")) or not (dtstart := values.get("dtstart")):
+            return values
+        if due <= dtstart:
+            raise ValueError("due value must be later in time than dtstart.")
+        return values
+
+    @root_validator(allow_reuse=True)
+    def _validate_date_types(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate that start and end values are the same date or datetime type."""
+        dtstart = values.get("dtstart")
+        due = values.get("due")
+
+        if not dtstart or not due:
+            return values
+        if isinstance(dtstart, datetime.datetime):
+            if not isinstance(due, datetime.datetime):
+                raise ValueError(
+                    f"Unexpected dtstart value '{dtstart}' was datetime but "
+                    f"dtend value '{due}' was not datetime"
+                )
+        elif isinstance(dtstart, datetime.date):
+            if isinstance(due, datetime.datetime):
+                raise ValueError(
+                    f"Unexpected dtstart value '{dtstart}' was date but "
+                    f"dtend value '{due}' was datetime"
+                )
+        return values
+    
+    @root_validator(allow_reuse=True)
+    def _validate_datetime_timezone(cls, values: dict[str, Any]) -> dict[str, Any]:
+        """Validate that start and due values have the same timezone information."""
+        if (
+            not (dtstart := values.get("dtstart"))
+            or not (due := values.get("due"))
+            or not isinstance(dtstart, datetime.datetime)
+            or not isinstance(due, datetime.datetime)
+        ):
+            return values
+        if dtstart.tzinfo is None and due.tzinfo is not None:
+            raise ValueError(
+                f"Expected end datetime value in localtime but was {due}"
+            )
+        if dtstart.tzinfo is not None and due.tzinfo is None:
+            raise ValueError(f"Expected end datetime with timezone but was {due}")
         return values
 
     _validate_until_dtstart = root_validator(allow_reuse=True)(validate_until_dtstart)

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable
 import datetime
 import enum
 from typing import Any, Optional, Union
+import logging
 
 try:
     from pydantic.v1 import Field, root_validator
@@ -38,6 +39,9 @@ from .types import (
     RelatedTo,
 )
 from .util import dtstamp_factory, normalize_datetime, uid_factory, local_timezone
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class TodoStatus(str, enum.Enum):
@@ -217,6 +221,12 @@ class Todo(ComponentModel):
             return None
         return self.due - self.dtstart
 
+    def is_due(self, tzinfo: datetime.tzinfo | None = None) -> bool:
+        """Return true if the todo is due."""
+        if tzinfo is None:
+            tzinfo = local_timezone()
+        now = datetime.datetime.now(tz=tzinfo)
+        return self.due is not None and normalize_datetime(self.due, tzinfo) < now
 
     @property
     def timespan(self) -> Timespan:

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -11,7 +11,7 @@ from syrupy import SnapshotAssertion
 
 from ical.exceptions import CalendarParseError
 from ical.calendar_stream import CalendarStream, IcsCalendarStream
-from ical.store import EventStore, TodoStore
+from ical.store import TodoStore
 
 MAX_ITERATIONS = 30
 TESTDATA_PATH = pathlib.Path("tests/testdata/")

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1058,7 +1058,7 @@ def test_todo_timezone_offset_not_supported(
     event = Todo(
         summary="Monday meeting",
         dtstart=datetime.datetime(2022, 8, 29, 9, 0, 0, tzinfo=tzinfo),
-        due=datetime.datetime(2022, 8, 29, 9, 0, 0, tzinfo=tzinfo),
+        due=datetime.datetime(2022, 8, 30, 9, 0, 0, tzinfo=tzinfo),
     )
     with pytest.raises(StoreError, match=r"No timezone information"):
         todo_store.add(event)

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -82,6 +82,12 @@ def test_duration() -> None:
         ),
         (
             {
+                "start": datetime.datetime(2022, 9, 6, 6, 0, 0),
+                "due": datetime.datetime(2022, 9, 7, 6, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Regina")),
+            }
+        ),
+        (
+            {
                 "start": datetime.date(2022, 9, 6),
                 "due": datetime.datetime(2022, 9, 7, 6, 0, 0),
             }

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -74,6 +74,30 @@ def test_duration() -> None:
         ),
         (
             {
+                "start": datetime.datetime(2022, 9, 6, 6, 0, 0),
+                "due": datetime.datetime(2022, 9, 6, 6, 0, 0),
+            }
+        ),
+        (
+            {
+                "start": datetime.date(2022, 9, 6),
+                "due": datetime.datetime(2022, 9, 7, 6, 0, 0),
+            }
+        ),
+        (
+            {
+                "start": datetime.datetime(2022, 9, 6, 6, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Regina")),
+                "due": datetime.datetime(2022, 9, 7, 6, 0, 0),  # floating
+            }
+        ),
+        (
+            {
+                "start": datetime.date(2022, 9, 6),
+                "due": datetime.date(2022, 9, 6),
+            }
+        ),
+        (
+            {
                 "duration": datetime.timedelta(hours=1),
             }
         ),

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -199,3 +199,12 @@ def test_is_due(due: datetime.date | datetime.datetime, expected: bool) -> None:
         due=due,
     )
     assert todo.is_due(tzinfo=_TEST_TZ) == expected
+
+
+def test_is_due_default_timezone() -> None:
+    """Test a Todo is due with the default timezone."""
+    todo = Todo(
+        summary="Example",
+        due=datetime.date(2022, 9, 6),
+    )
+    assert todo.is_due()


### PR DESCRIPTION
Update validation rules to match https://www.rfc-editor.org/rfc/rfc5545#section-3.8.2.3
```
Description:  This property defines the date and time before which a
      to-do is expected to be completed.  For cases where this property
      is specified in a "VTODO" calendar component that also specifies a
      "DTSTART" property, the value type of this property MUST be the
      same as the "DTSTART" property, and the value of this property
      MUST be later in time than the value of the "DTSTART" property.
      Furthermore, this property MUST be specified as a date with local
      time if and only if the "DTSTART" property is also specified as a
      date with local time.
```

Copies some event date validation rules into todo component, and adds due specific rules. Adds a property to check when a Todo is due.