### PR TITLE
Fix error message when Timezone is not found

### DIFF
--- a/ical/store.py
+++ b/ical/store.py
@@ -64,7 +64,7 @@ def _ensure_timezone(
         return Timezone.from_tzif(key)
     except TimezoneInfoError as err:
         raise EventStoreError(
-            "No timezone information available for event: {key}"
+            f"No timezone information available for event: {key}"
         ) from err
 
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -849,7 +849,7 @@ def test_timezone_offset_not_supported(
         start=datetime.datetime(2022, 8, 29, 9, 0, 0, tzinfo=tzinfo),
         end=datetime.datetime(2022, 8, 29, 9, 30, 0, tzinfo=tzinfo),
     )
-    with pytest.raises(StoreError, match=r"No timezone information"):
+    with pytest.raises(StoreError, match=r"No timezone information available for event: UTC-08:00"):
         store.add(event)
     assert not calendar.events
     assert not calendar.timezones


### PR DESCRIPTION
Fix error message when Timezone is not found. Old message was:
ical.exceptions.EventStoreError: No timezone information available for event: {key}

https://github.com/home-assistant/core/issues/112647