### PR TITLE
Fix typo and wrong value in default_factory for CalendarStream.calendars

### DIFF
--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -52,7 +52,7 @@ class CalendarStream(ComponentModel):
     support encoding. See `IcsCalendarStream` instead for encoding ics files.
     """
 
-    calendars: list[Calendar] = Field(alias="vcalendar", defaut_factory=[])
+    calendars: list[Calendar] = Field(alias="vcalendar", default_factory=list)
 
     @classmethod
     def from_ics(cls, content: str) -> "CalendarStream":


### PR DESCRIPTION
Suppose it's exceedingly rare that a stream contain no calendars, but better safe than sorry