### PR TITLE
Support for zero-length paramtext...

### DIFF
--- a/ical/parsing/parser.py
+++ b/ical/parsing/parser.py
@@ -67,7 +67,7 @@ def _create_parser() -> ParserElement:
     param_name = Or([iana_token, x_name])
     # rfc5545 Q-SAFE-CHAR is any character except CONTROL and DQUOTE which is
     # close enough to the pyparsing provided parser element
-    param_text = Word(SAFE_CHAR)
+    param_text = Word(SAFE_CHAR) | ""
     quoted_string = QuotedString('"')
 
     param_value = Or([param_text, quoted_string])

--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -142,7 +142,7 @@ def parse_property_params(
         for pair in parsed_params[PARSE_PARAMS]:
             params.append(
                 ParsedPropertyParameter(
-                    name=pair[PARSE_PARAM_NAME], values=pair.get(PARSE_PARAM_VALUE, "")
+                    name=pair[PARSE_PARAM_NAME], values=pair.get(PARSE_PARAM_VALUE, [""])
                 )
             )
     return params

--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -142,7 +142,7 @@ def parse_property_params(
         for pair in parsed_params[PARSE_PARAMS]:
             params.append(
                 ParsedPropertyParameter(
-                    name=pair[PARSE_PARAM_NAME], values=pair[PARSE_PARAM_VALUE]
+                    name=pair[PARSE_PARAM_NAME], values=pair[PARSE_PARAM_VALUE] if PARSE_PARAM_VALUE in pair else [""]
                 )
             )
     return params

--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -142,7 +142,7 @@ def parse_property_params(
         for pair in parsed_params[PARSE_PARAMS]:
             params.append(
                 ParsedPropertyParameter(
-                    name=pair[PARSE_PARAM_NAME], values=pair[PARSE_PARAM_VALUE] if PARSE_PARAM_VALUE in pair else [""]
+                    name=pair[PARSE_PARAM_NAME], values=pair.get(PARSE_PARAM_VALUE, "")
                 )
             )
     return params

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -133,7 +133,7 @@ def test_multiple_calendars() -> None:
             """))
 
 def test_blank_param_value() -> None:
-    ics = IcsCalendarStream.calendar_from_ics(
+    IcsCalendarStream.calendar_from_ics(
         textwrap.dedent("""\
             BEGIN:VCALENDAR
             PRODID:-//example//1.2.3

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -131,3 +131,52 @@ def test_multiple_calendars() -> None:
                 VERSION:2.0
                 END:VCALENDAR
             """))
+
+def test_blank_param_value() -> None:
+    ics = IcsCalendarStream.calendar_from_ics(
+        textwrap.dedent("""\
+            BEGIN:VCALENDAR
+            PRODID:-//example//1.2.3
+            VERSION:2.0
+            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=:VALUE
+            END:VCALENDAR
+        """))
+
+def test_blank_quoted_param_value() -> None:
+    ics = IcsCalendarStream.calendar_from_ics(
+        textwrap.dedent("""\
+            BEGIN:VCALENDAR
+            PRODID:-//example//1.2.3
+            VERSION:2.0
+            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM="":VALUE
+            END:VCALENDAR
+        """))
+
+def test_blank_param_value() -> None:
+    ics = IcsCalendarStream.calendar_from_ics(
+        textwrap.dedent("""\
+            BEGIN:VCALENDAR
+            PRODID:-//example//1.2.3
+            VERSION:2.0
+            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=:VALUE
+            END:VCALENDAR
+        """))
+
+def test_blank_vs_blank_quoted_param_value() -> None:
+    ics = IcsCalendarStream.calendar_from_ics(
+        textwrap.dedent("""\
+            BEGIN:VCALENDAR
+            PRODID:-//example//1.2.3
+            VERSION:2.0
+            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=:VALUE
+            END:VCALENDAR
+        """))
+    ics2 = IcsCalendarStream.calendar_from_ics(
+        textwrap.dedent("""\
+            BEGIN:VCALENDAR
+            PRODID:-//example//1.2.3
+            VERSION:2.0
+            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM="":VALUE
+            END:VCALENDAR
+        """))
+    assert ics == ics2

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -152,16 +152,6 @@ def test_blank_quoted_param_value() -> None:
             END:VCALENDAR
         """))
 
-def test_blank_param_value() -> None:
-    ics = IcsCalendarStream.calendar_from_ics(
-        textwrap.dedent("""\
-            BEGIN:VCALENDAR
-            PRODID:-//example//1.2.3
-            VERSION:2.0
-            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=:VALUE
-            END:VCALENDAR
-        """))
-
 def test_blank_vs_blank_quoted_param_value() -> None:
     ics = IcsCalendarStream.calendar_from_ics(
         textwrap.dedent("""\

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -143,7 +143,7 @@ def test_blank_param_value() -> None:
         """))
 
 def test_blank_quoted_param_value() -> None:
-    ics = IcsCalendarStream.calendar_from_ics(
+    IcsCalendarStream.calendar_from_ics(
         textwrap.dedent("""\
             BEGIN:VCALENDAR
             PRODID:-//example//1.2.3


### PR DESCRIPTION
....as allowed by RFC5545 grammer (bottom page 10, `paramtext = *SAFE-CHAR`).

Found in-the-wild with an Apple iCal ics file with `X-APPLE-FILENAME=` as param, without this PR an exception is thrown. Pyparser `Word` expressly does not match zero length strings.

I am not sure this is the best way to tackle this, but it fixes all test cases I am able to find.