### PR TITLE
Move zero length parameter text tests

### DIFF
--- a/tests/parsing/test_property.py
+++ b/tests/parsing/test_property.py
@@ -29,6 +29,7 @@ def test_from_ics(filename: str, snapshot: SnapshotAssertion) -> None:
     properties = list(parse_basic_ics_properties(unfolded_lines(filename.read_text())))
     assert properties == snapshot
 
+
 @pytest.mark.parametrize(
     "ics",
     [
@@ -37,10 +38,32 @@ def test_from_ics(filename: str, snapshot: SnapshotAssertion) -> None:
         "PROP;PARAM:VALUE",
         ";VALUE",
         ";:VALUE",
-    ]
+    ],
 )
 def test_invalid_format(ics: str) -> None:
     """Test parsing invalid property format."""
     with pytest.raises(ValueError):
-        r = list(parse_basic_ics_properties([ics]))
-        assert r == 'a'
+        list(parse_basic_ics_properties([ics]))
+
+
+@pytest.mark.parametrize(
+    "ics",
+    [
+        "X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=:VALUE",
+        "X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=" ":VALUE",
+        "X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=:VALUE",
+        "X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=" ":VALUE",
+    ],
+)
+def test_blank_parameters(ics: str) -> None:
+    """Test parsing invalid property format."""
+    properties = list(parse_basic_ics_properties([ics]))
+    assert len(properties) == 1
+    prop = properties[0]
+    assert prop.name == "x-test-blank"
+    assert prop.value == "VALUE"
+    assert len(prop.params) == 2
+    assert prop.params[0].name == "VALUE"
+    assert prop.params[0].values == ["URI"]
+    assert prop.params[1].name == "X-TEST-BLANK-PARAM"
+    assert prop.params[1].values == [""]

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -16,36 +16,36 @@ from ical.store import TodoStore
 MAX_ITERATIONS = 30
 TESTDATA_PATH = pathlib.Path("tests/testdata/")
 TESTDATA_FILES = list(TESTDATA_PATH.glob("*.ics"))
-TESTDATA_IDS = [ x.stem for x in TESTDATA_FILES ]
+TESTDATA_IDS = [x.stem for x in TESTDATA_FILES]
 
 
 def test_empty_ics(mock_prodid: Generator[None, None, None]) -> None:
     """Test serialization of an empty ics file."""
     calendar = IcsCalendarStream.calendar_from_ics("")
     ics = IcsCalendarStream.calendar_to_ics(calendar)
-    assert (
-        ics
-        == textwrap.dedent("""\
+    assert ics == textwrap.dedent(
+        """\
             BEGIN:VCALENDAR
             PRODID:-//example//1.2.3
             VERSION:2.0
             END:VCALENDAR"""
-    ))
+    )
 
     calendar.prodid = "-//example//1.2.4"
     ics = IcsCalendarStream.calendar_to_ics(calendar)
-    assert (
-        ics
-        == textwrap.dedent("""\
+    assert ics == textwrap.dedent(
+        """\
             BEGIN:VCALENDAR
             PRODID:-//example//1.2.4
             VERSION:2.0
-            END:VCALENDAR""")
+            END:VCALENDAR"""
     )
 
 
 @pytest.mark.parametrize("filename", TESTDATA_FILES, ids=TESTDATA_IDS)
-def test_parse(filename: pathlib.Path, snapshot: SnapshotAssertion, json_encoder: json.JSONEncoder) -> None:
+def test_parse(
+    filename: pathlib.Path, snapshot: SnapshotAssertion, json_encoder: json.JSONEncoder
+) -> None:
     """Fixture to read golden file and compare to golden output."""
     cal = CalendarStream.from_ics(filename.read_text())
     data = json.loads(
@@ -106,7 +106,8 @@ def test_invalid_ics() -> None:
 def test_component_failure() -> None:
     with pytest.raises(CalendarParseError, match="Failed to parse component"):
         IcsCalendarStream.calendar_from_ics(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
                 BEGIN:VCALENDAR
                 PRODID:-//example//1.2.3
                 VERSION:2.0
@@ -115,13 +116,16 @@ def test_component_failure() -> None:
                 DTEND:20220724
                 END:VEVENT
                 END:VCALENDAR
-            """))
-        
+            """
+            )
+        )
+
 
 def test_multiple_calendars() -> None:
     with pytest.raises(CalendarParseError, match="more than one calendar"):
         IcsCalendarStream.calendar_from_ics(
-            textwrap.dedent("""\
+            textwrap.dedent(
+                """\
                 BEGIN:VCALENDAR
                 PRODID:-//example//1.2.3
                 VERSION:2.0
@@ -130,43 +134,6 @@ def test_multiple_calendars() -> None:
                 PRODID:-//example//1.2.3
                 VERSION:2.0
                 END:VCALENDAR
-            """))
-
-def test_blank_param_value() -> None:
-    IcsCalendarStream.calendar_from_ics(
-        textwrap.dedent("""\
-            BEGIN:VCALENDAR
-            PRODID:-//example//1.2.3
-            VERSION:2.0
-            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=:VALUE
-            END:VCALENDAR
-        """))
-
-def test_blank_quoted_param_value() -> None:
-    IcsCalendarStream.calendar_from_ics(
-        textwrap.dedent("""\
-            BEGIN:VCALENDAR
-            PRODID:-//example//1.2.3
-            VERSION:2.0
-            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM="":VALUE
-            END:VCALENDAR
-        """))
-
-def test_blank_vs_blank_quoted_param_value() -> None:
-    ics = IcsCalendarStream.calendar_from_ics(
-        textwrap.dedent("""\
-            BEGIN:VCALENDAR
-            PRODID:-//example//1.2.3
-            VERSION:2.0
-            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM=:VALUE
-            END:VCALENDAR
-        """))
-    ics2 = IcsCalendarStream.calendar_from_ics(
-        textwrap.dedent("""\
-            BEGIN:VCALENDAR
-            PRODID:-//example//1.2.3
-            VERSION:2.0
-            X-TEST-BLANK;VALUE=URI;X-TEST-BLANK-PARAM="":VALUE
-            END:VCALENDAR
-        """))
-    assert ics == ics2
+            """
+            )
+        )


### PR DESCRIPTION
Move zero length parameter text tests added in #464 to a more appropriate location based on existing norms in the code base.