### PR TITLE
Improve readability of CalendarParseError messages

### DIFF
--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -60,7 +60,9 @@ class CalendarStream(ComponentModel):
         try:
             components = parse_content(content)
         except pyparsing.ParseException as err:
-            raise CalendarParseError(f"Failed to parse calendar stream: {err}") from err
+            raise CalendarParseError(
+                f"Failed to parse calendar contents", detailed_error=str(err)
+            ) from err
         result: dict[str, list] = {"vcalendar": []}
         for component in components:
             result.setdefault(component.name, [])

--- a/ical/exceptions.py
+++ b/ical/exceptions.py
@@ -6,7 +6,19 @@ class CalendarError(Exception):
 
 
 class CalendarParseError(CalendarError):
-    """Exception raised when parsing an ical string."""
+    """Exception raised when parsing an ical string.
+
+    The 'message' attribute contains a human-readable message about the
+    error that occurred. The 'detailed_error' attribute can provide additional
+    information about the error, such as a stack trace or detailed parsing
+    information, useful for debugging purposes.
+    """
+
+    def __init__(self, message: str, *, detailed_error: str | None = None) -> None:
+        """Initialize the CalendarParseError with a message."""
+        super().__init__(message)
+        self.message = message
+        self.detailed_error = detailed_error
 
 
 class RecurrenceError(CalendarError):

--- a/ical/journal.py
+++ b/ical/journal.py
@@ -26,7 +26,6 @@ from .types import (
     Uri,
     RelatedTo,
 )
-from .exceptions import CalendarParseError
 from .util import dtstamp_factory, normalize_datetime, uid_factory, local_timezone
 from .iter import RulesetIterable, as_rrule
 from .timespan import Timespan

--- a/ical/recurrence.py
+++ b/ical/recurrence.py
@@ -61,7 +61,9 @@ class Recurrences(ComponentModel):
         try:
             properties = list(parse_basic_ics_properties(contentlines))
         except ValueError as err:
-            raise CalendarParseError(f"Failed to parse recurrence: {err}") from err
+            raise CalendarParseError(
+                "Failed to parse recurrence", detailed_error=str(err)
+            ) from err
         component = ParsedComponent(
             name="recurrences",  # Not used in the model
             properties=properties,

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -99,12 +99,15 @@ def test_todo_list_iteration(filename: pathlib.Path) -> None:
 
 def test_invalid_ics() -> None:
     """Test parsing failures for ics content."""
-    with pytest.raises(CalendarParseError, match="Failed to parse calendar stream"):
+    with pytest.raises(CalendarParseError, match="^Failed to parse calendar contents"):
         IcsCalendarStream.calendar_from_ics("invalid")
 
 
 def test_component_failure() -> None:
-    with pytest.raises(CalendarParseError, match="Failed to parse component"):
+    with pytest.raises(
+        CalendarParseError,
+        match="^Failed to parse calendar EVENT component: Unexpected dtstart value '2022-07-24 12:00:00' was datetime but dtend value '2022-07-24' was not datetime$",
+    ):
         IcsCalendarStream.calendar_from_ics(
             textwrap.dedent(
                 """\

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -30,7 +30,10 @@ def test_status() -> None:
     journal = Journal.parse_obj({"status": "DRAFT"})
     assert journal.status == JournalStatus.DRAFT
 
-    with pytest.raises(CalendarParseError):
+    with pytest.raises(
+        CalendarParseError,
+        match="^Failed to parse calendar JOURNAL component: value is not a valid enumeration member; permitted: 'DRAFT', 'FINAL', 'CANCELLED'$",
+    ):
         Journal.parse_obj({"status": "invalid-status"})
 
 
@@ -43,7 +46,9 @@ def test_start_datetime() -> None:
 
     with patch(
         "ical.util.local_timezone", return_value=zoneinfo.ZoneInfo("America/Regina")
-    ), patch("ical.journal.local_timezone", return_value=zoneinfo.ZoneInfo("America/Regina")):
+    ), patch(
+        "ical.journal.local_timezone", return_value=zoneinfo.ZoneInfo("America/Regina")
+    ):
         assert journal.start_datetime.isoformat() == "2022-08-07T06:00:00+00:00"
         assert not journal.recurring
 
@@ -56,7 +61,13 @@ def test_start_datetime() -> None:
 def test_computed_duration_date() -> None:
     """Test computed duration for a date."""
 
-    journal = Journal(start=datetime.date(2022, 8, 7,))
+    journal = Journal(
+        start=datetime.date(
+            2022,
+            8,
+            7,
+        )
+    )
     assert journal.start
     assert journal.computed_duration == datetime.timedelta(days=1)
 

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -40,7 +40,10 @@ def test_duration() -> None:
     assert todo.duration
 
     # Both due and Duration can't be set
-    with pytest.raises(CalendarParseError):
+    with pytest.raises(
+        CalendarParseError,
+        match="Failed to parse calendar TODO component: Only one of dtend or duration may be set.",
+    ):
         Todo(
             start=datetime.date(2022, 8, 7),
             duration=datetime.timedelta(days=1),
@@ -48,7 +51,10 @@ def test_duration() -> None:
         )
 
     # Duration requires start date
-    with pytest.raises(CalendarParseError):
+    with pytest.raises(
+        CalendarParseError,
+        match="^Failed to parse calendar TODO component: Duration requires that dtstart is specified$",
+    ):
         Todo(duration=datetime.timedelta(days=1))
 
     todo = Todo(start=datetime.date(2022, 8, 7), due=datetime.date(2022, 8, 8))


### PR DESCRIPTION
Improve `CalendarParseError` by separating out `message` and `detailed_error` strings with additional debugging information.