### PR TITLE
Allow VALARM description to be empty

### DIFF
--- a/ical/alarm.py
+++ b/ical/alarm.py
@@ -88,7 +88,7 @@ class Alarm(ComponentModel):
         action = values.get("action")
         if action != Action.DISPLAY:
             return values
-        if not values.get("description"):
+        if values.get("description") is None:
             raise ValueError(f"Description value is required for action {action}")
         return values
 
@@ -98,9 +98,9 @@ class Alarm(ComponentModel):
         action = values.get("action")
         if action != Action.EMAIL:
             return values
-        if not values.get("description"):
+        if values.get("description") is None:
             raise ValueError(f"Description value is required for action {action}")
-        if not values.get("summary"):
+        if values.get("summary") is None:
             raise ValueError(f"Summary value is required for action {action}")
         return values
 

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -48,7 +48,9 @@ def test_duration_and_repeat() -> None:
 
 def test_display_required_fields() -> None:
     """Test required fields for action DISPLAY."""
-    with pytest.raises(CalendarParseError, match="Description value is required for action DISPLAY"):
+    with pytest.raises(
+        CalendarParseError, match="Description value is required for action DISPLAY"
+    ):
         Alarm(action="DISPLAY", trigger=datetime.timedelta(minutes=-5))
 
     alarm = Alarm(
@@ -60,10 +62,23 @@ def test_display_required_fields() -> None:
     assert alarm.description == "Notification description"
 
 
+def test_empty_display_field() -> None:
+    """Test required fields for action DISPLAY."""
+    alarm = Alarm(
+        action="DISPLAY",
+        trigger=datetime.timedelta(minutes=-5),
+        description="",
+    )
+    assert alarm.action == "DISPLAY"
+    assert alarm.description == ""
+
+
 def test_email_required_fields() -> None:
     """Test required fields for action EMAIL."""
     # Missing multiple fields
-    with pytest.raises(CalendarParseError, match="Description value is required for action EMAIL"):
+    with pytest.raises(
+        CalendarParseError, match="Description value is required for action EMAIL"
+    ):
         Alarm(action="EMAIL", trigger=datetime.timedelta(minutes=-5))
 
     # Missing summary


### PR DESCRIPTION
This fixes an issue with alarms created by Apple.