### PR TITLE
Parse without pyparsing

### DIFF
--- a/ical/parsing/component.py
+++ b/ical/parsing/component.py
@@ -79,7 +79,6 @@ def _fold(contentline: str) -> list[str]:
         break_on_hyphens=False,
     )
 
-
 def parse_content(content: str) -> list[ParsedComponent]:
     """Parse content into raw properties.
 
@@ -94,8 +93,7 @@ def parse_content(content: str) -> list[ParsedComponent]:
     token_results = parse_contentlines(lines)
 
     stack: list[ParsedComponent] = [ParsedComponent(name="stream")]
-    for result in token_results:
-        result_dict = result.as_dict()
+    for result_dict in token_results:
         if PARSE_NAME not in result_dict:
             raise ValueError(
                 f"Missing fields {PARSE_NAME} or {PARSE_VALUE} in {result_dict}"
@@ -109,7 +107,7 @@ def parse_content(content: str) -> list[ParsedComponent]:
             component = stack.pop()
             if value != component.name:
                 raise ValueError(
-                    f"Unexpected '{result}', expected {ATTR_END}:{component.name}"
+                    f"Unexpected '{result_dict}', expected {ATTR_END}:{component.name}"
                 )
             stack[-1].components.append(component)
         else:
@@ -122,6 +120,7 @@ def parse_content(content: str) -> list[ParsedComponent]:
                 property_dict[PARSE_PARAMS] = property_params
             stack[-1].properties.append(ParsedProperty(**property_dict))
     return stack[0].components
+
 
 
 def encode_content(components: list[ParsedComponent]) -> str:

--- a/ical/parsing/parser.py
+++ b/ical/parsing/parser.py
@@ -25,24 +25,8 @@ Note: This specific example may be a bit confusing because one of the property p
 """
 
 import logging
-import threading
-from functools import cache
-from typing import cast
 from typing import Iterable
 
-from pyparsing import (
-    Combine,
-    Group,
-    Or,
-    ParserElement,
-    ParseResults,
-    QuotedString,
-    Word,
-    ZeroOrMore,
-    alphanums,
-    alphas,
-    nums,
-)
 
 from .const import (
     PARSE_NAME,
@@ -51,61 +35,90 @@ from .const import (
     PARSE_PARAMS,
     PARSE_VALUE,
 )
-from .unicode import SAFE_CHAR, VALUE_CHAR
 
 _LOGGER = logging.getLogger(__name__)
 
 
-@cache
-def _create_parser() -> ParserElement:
-    """Create rfc5545 parser."""
-    iana_token = Word(alphanums + "-")
-    vendor_id = Word(alphanums)
-    x_name = Combine("X-" + ZeroOrMore(vendor_id + "-") + alphas + nums + "-")
-    name = Or([iana_token, x_name])
+def parse_line(line: str) -> dict:
+    """Parse a single line."""
+    
+    dict_result = {}
+    dict_result.setdefault(PARSE_PARAMS, [])
 
-    param_name = Or([iana_token, x_name])
-    # rfc5545 Q-SAFE-CHAR is any character except CONTROL and DQUOTE which is
-    # close enough to the pyparsing provided parser element
-    param_text = Word(SAFE_CHAR) | ""
-    quoted_string = QuotedString('"')
+    pos = 0
 
-    param_value = Or([param_text, quoted_string])
-    # There are multiple levels of property parameter grouping since there can
-    # either be repreated property parameters with the same name or property
-    # s parameters with repeated values. A two level structure is used to grab
-    # both, which is then flattened when consuming the result.
-    param = Group(
-        param_name.set_results_name(PARSE_PARAM_NAME)
-        + "="
-        + param_value.set_results_name(PARSE_PARAM_VALUE, list_all_matches=True)
-        + ZeroOrMore(
-            "," + param_value.set_results_name(PARSE_PARAM_VALUE, list_all_matches=True)
-        )
-    ).set_results_name(PARSE_PARAMS, list_all_matches=True)
+    # parse NAME
+    while True:
+        assert pos < len(line), "Unexpected end of line"
+        char = line[pos]
+        if char == ';' or char == ':':
+            dict_result[PARSE_NAME] = line[0:pos]
+            break
+        pos += 1
 
-    contentline = (
-        name.set_results_name(PARSE_NAME)
-        + Group(ZeroOrMore(";" + param)).set_results_name(
-            PARSE_PARAMS, list_all_matches=True
-        )
-        + ":"
-        + Word(VALUE_CHAR)[0, 1].set_results_name(PARSE_VALUE)
-    )
-    contentline.set_whitespace_chars("")
-    if _LOGGER.isEnabledFor(logging.DEBUG):
-        contentline.set_debug(flag=True)
-    return cast(ParserElement, contentline)
+    # parse PARAMS if any
+    if line[pos] == ';':
+        pos += 1
+        params_start = pos
+        value_start = 0
+        while pos < len(line):
+            char = line[pos]
+            if char == '=':
+                # param name reached
+                param_name = line[params_start:pos]
+                pos += 1
+                
+                # Now read values. (list separated by comma)
+                param_values = []
+                all_values_read = False
+                while not all_values_read:
+                    value_start = pos
+                    quoted = False
+
+                    if line[pos] == '"':
+                        # read all in quotes
+                        quoted = True
+                        pos += 1
+
+                    value_read = False
+                    while not value_read:
+                        assert pos < len(line), "Unexpected end of line"
+                        char = line[pos]
+                        
+                        if (quoted and char == '"') or (not quoted and (char == ',' or char == ';' or char == ':')):
+                            if quoted:
+                                param_value = line[value_start + 1:pos]
+                                pos += 1
+                                char = line[pos]
+                            else:
+                                param_value = line[value_start:pos]
+
+                            param_values.append(param_value)
+                            value_read = True
+                            all_values_read = char != ','
+                        pos += 1
+                    
+                dict_result[PARSE_PARAMS].append(
+                    {PARSE_PARAM_NAME: param_name, PARSE_PARAM_VALUE: param_values}
+                )
+                
+                if char == ':':
+                    break
+                params_start = pos
+            pos += 1
+    else:
+        assert line[pos] == ':', "Expected ':' after property name"
+        pos += 1
+
+    value = line[pos:]
+    dict_result[PARSE_VALUE] = value
+    return dict_result        
 
 
-_parser_lock = threading.Lock()
 
-
-def parse_contentlines(lines: Iterable[str]) -> list[ParseResults]:
+def parse_contentlines(lines: Iterable[str]) -> list[dict]:
     """Parse a set of unfolded lines into parse results.
 
     Note, this method is not threadsafe and may be called from only one method at a time.
     """
-    with _parser_lock:
-        parser = _create_parser()
-        return [parser.parse_string(line, parse_all=True) for line in lines if line]
+    return [parse_line(line) for line in lines if line]

--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -128,7 +128,6 @@ class ParsedProperty:
             params=parsed_property_parameters or None,
         )
 
-
 def parse_property_params(
     parse_result_dict: dict[str, str | list]
 ) -> list[ParsedPropertyParameter]:
@@ -137,16 +136,12 @@ def parse_property_params(
         return []
     params: list[ParsedPropertyParameter] = []
     for parsed_params in parse_result_dict[PARSE_PARAMS]:
-        if not isinstance(parsed_params, dict) or PARSE_PARAMS not in parsed_params:
-            continue
-        for pair in parsed_params[PARSE_PARAMS]:
-            params.append(
-                ParsedPropertyParameter(
-                    name=pair[PARSE_PARAM_NAME], values=pair.get(PARSE_PARAM_VALUE, [""])
-                )
+        params.append(
+            ParsedPropertyParameter(
+                name=parsed_params[PARSE_PARAM_NAME], values=parsed_params.get(PARSE_PARAM_VALUE, [""])
             )
+        )
     return params
-
 
 def parse_basic_ics_properties(
     contentlines: Iterable[str],


### PR DESCRIPTION
I don't expect this to be merged as it. It's more to start a discussion :-)

Is it overkill to use pyparsing for this library? The ical format seems not that complicated, but I'm probably missing something.

I've spend some hours implementing this basic parser just for fun: 
- All tests passes (except one where it expects a pyparsing exception to be thrown).
- I believe it's faster than using pyparsing.
- It handles unicode, but it's probably not as strict as the original implementation with regards to allowed characters.
- It may need to handle certain escape characters (not sure if this happens elsewhere in the library.

Fixes #469 (which I badly need for Home Assistant, as my calendars are currently broken).