### PR TITLE
Fix typos in documentation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -17,7 +17,7 @@ have parameters such as a timezone or alternative text display. Components
 have a hierarchy (e.g. a calendar component has an event sub-component).
 
 The ical library uses [pyparsing](https://github.com/pyparsing/pyparsing) to
-create a very simple gammar for rfc5545, converting the individual lines of an
+create a very simple grammar for rfc5545, converting the individual lines of an
 ics file (called "contentlines") into a structured `ParseResult` object which
 has a dictionary of fields. The ical library then iterates through each
 contentline and builds a stack to manage components and subcomponents, parses
@@ -43,8 +43,8 @@ internal json encoding as well as custom encoding built on top to handle
 everything. The custom logic is needed since a single field in a pydantic
 model may be a complex value in the ics output (e.g. containing property
 parameters). The json encoding using pydantic encoders could be removed
-in the future, relying on entirely custom components, but for now its kind
-of nice to reuse even if there are extera layers on top adding complexity.
+in the future, relying on entirely custom components, but for now it is kind
+of nice to reuse even if there are extra layers on top adding complexity.
 
 ## Recurrence
 
@@ -83,7 +83,7 @@ module with a lightweight and complete implementation of recurrence rules.
 Events are generated using a timeline fed by bunch of iterators. There is
 one iterator for all non-recurring events, then a separate iterator for
 each recurring event. A merged iterator peeks into the input of each
-iterator to decide which one to pull from when determinig the next item
+iterator to decide which one to pull from when determining the next item
 in the iterator.
 
 An individual instance of a recurring event is generated with the same `UID`,

--- a/ical/alarm.py
+++ b/ical/alarm.py
@@ -57,7 +57,7 @@ class Alarm(ComponentModel):
     repeat: Optional[int] = None
     """The number of times an alarm should be repeated.
 
-    If repeate is specified then duration must also be specified.
+    If repeat is specified then duration must also be specified.
     """
 
     #

--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -91,7 +91,7 @@ class Calendar(ComponentModel):
         changed live, the DATE-TIME objects are not updated.
 
         We first update the timezone objects using another pydantic model just
-        for parsing and propagaint here (TimezoneModel). We then walk through
+        for parsing and propagating here (TimezoneModel). We then walk through
         all DATE-TIME objects referenced by components and lookup any TZID
         property parameters, converting them to a datetime.tzinfo object. The
         DATE-TIME parser will use this instead of the TZID string. We prefer

--- a/ical/component.py
+++ b/ical/component.py
@@ -154,7 +154,7 @@ class ComponentModel(BaseModel):
         """Create a new object with updated values and validate it."""
         # Make a deep copy since deletion may update this objects recurrence rules
         new_item_copy = self.copy(update=update, deep=True)
-        # Create a new object using the constructore to ensure we're performing
+        # Create a new object using the constructor to ensure we're performing
         # validation on the new object.
         return self.__class__(**new_item_copy.dict())
 
@@ -289,7 +289,7 @@ class ComponentModel(BaseModel):
         # The overall data model hierarchy is created by pydantic and properties
         # are encoded using the json encoders specific for each type. These are
         # marshalled through as string values. There are then additional passes
-        # to ge the data in to the right final format for ics encoding.
+        # to get the data in to the right final format for ics encoding.
         model_data = json.loads(
             self.json(by_alias=True, exclude_none=True, exclude_defaults=True)
         )
@@ -354,7 +354,7 @@ class ComponentModel(BaseModel):
         raise ValueError(f"Unable to encode property: {value}, errors: {errors}")
 
     class Config:
-        """Pyandtic model configuration."""
+        """Pydantic model configuration."""
 
         validate_assignment = True
         allow_population_by_field_name = True

--- a/ical/event.py
+++ b/ical/event.py
@@ -158,7 +158,7 @@ class Event(ComponentModel):
     """The organizer of a group-scheduled calendar entity."""
 
     priority: Optional[Priority] = None
-    """Defines the relative priorirty of the calendar event."""
+    """Defines the relative priority of the calendar event."""
 
     recurrence_id: Optional[RecurrenceId] = Field(alias="recurrence-id", default=None)
     """Defines a specific instance of a recurring event.
@@ -216,7 +216,7 @@ class Event(ComponentModel):
     """The revision sequence number in the calendar component.
 
     When an event is created, its sequence number is 0. It is monotonically incremented
-    by the organizers calendar user agent every time a significant revision is made to
+    by the organizer's calendar user agent every time a significant revision is made to
     the calendar event.
     """
 
@@ -228,7 +228,7 @@ class Event(ComponentModel):
     """
 
     transparency: Optional[str] = Field(alias="transp", default=None)
-    """Defines whether or not an event is transparenty to busy time searches."""
+    """Defines whether or not an event is transparent to busy time searches."""
 
     url: Optional[Uri] = None
     """Defines a url associated with the event.
@@ -346,7 +346,7 @@ class Event(ComponentModel):
 
         A recurring event is typically evaluated specially on the timeline. The
         data model has a single event, but the timeline evaluates the recurrence
-        to expand and copy the the event to multiple places on the timeline
+        to expand and copy the event to multiple places on the timeline
         using `as_rrule`.
         """
         if self.rrule or self.rdate:
@@ -358,7 +358,7 @@ class Event(ComponentModel):
 
         A recurring event is typically evaluated specially on the timeline. The
         data model has a single event, but the timeline evaluates the recurrence
-        to expand and copy the the event to multiple places on the timeline.
+        to expand and copy the event to multiple places on the timeline.
 
         This is only valid for events where `recurring` is True.
         """

--- a/ical/exceptions.py
+++ b/ical/exceptions.py
@@ -25,9 +25,9 @@ class RecurrenceError(CalendarError):
     """Exception raised when evaluating a recurrence rule.
 
     Recurrence rules have complex logic and it is common for there to be
-    invalid date or bugs, so this special exception exists to help
+    invalid dates or bugs, so this special exception exists to help
     provide additional debug data to find the source of the issue. Often
-    `dateutil.rrule` has limitataions and ical has to work around them
+    `dateutil.rrule` has limitations and ical has to work around them
     by providing special wrapping libraries.
     """
 

--- a/ical/freebusy.py
+++ b/ical/freebusy.py
@@ -33,7 +33,7 @@ class FreeBusy(ComponentModel):
     """The persistent globally unique identifier."""
 
     attendees: list[CalAddress] = Field(alias="attendee", default_factory=list)
-    """The user who's free/busy time is represented."""
+    """The user whose free/busy time is represented."""
 
     comment: list[str] = Field(default_factory=list)
     """Non-processing information intended to provide comments to the calendar user."""

--- a/ical/iter.py
+++ b/ical/iter.py
@@ -7,11 +7,11 @@ recurrence rules together as a single view of recurring date/times.
 
 Some of the iterators here are primarily used to extend functionality of `dateutil.rrule`
 and work around some of the limitations when building real world calendar applications
-such as the ability to make recurrint all day events.
+such as the ability to make recurring all day events.
 
 Most of the things in this library should not be consumed directly by calendar users,
 but instead for implementing another calendar library as they support behind the
-scenes tings like timelines. These internals may be subject to a higher degree of
+scenes things like timelines. These internals may be subject to a higher degree of
 backwards incompatibility due to the internal nature.
 """
 
@@ -55,7 +55,6 @@ ItemAdapter = Callable[[Union[datetime.datetime, datetime.date]], T]
 The adapter is invoked with the date/time of the current instance and
 the callback returns an object at that time (e.g. event with updated time)
 """
-
 
 
 class SortableItem(Generic[K, T], ABC):
@@ -277,7 +276,7 @@ class MergedIterable(Iterable[T]):
 
 
 class SortedItemIterable(Iterable[SortableItem[K, T]]):
-    """Iterable that returns sortable items in sortered order.
+    """Iterable that returns sortable items in sorted order.
 
     This is useful when iterating over a subset of non-recurring events.
     """
@@ -405,7 +404,7 @@ def as_rrule(
 
     A recurring event is typically evaluated specially on the timeline. The
     data model has a single event, but the timeline evaluates the recurrence
-    to expand and copy the the event to multiple places on the timeline.
+    to expand and copy the event to multiple places on the timeline.
 
     This is only valid for events where `recurring` is True.
     """

--- a/ical/journal.py
+++ b/ical/journal.py
@@ -139,7 +139,7 @@ class Journal(ComponentModel):
 
         A recurring event is typically evaluated specially on the list. The
         data model has a single todo, but the timeline evaluates the recurrence
-        to expand and copy the the event to multiple places on the timeline
+        to expand and copy the event to multiple places on the timeline
         using `as_rrule`.
         """
         if self.rrule or self.rdate:
@@ -151,7 +151,7 @@ class Journal(ComponentModel):
 
         A recurring todo is typically evaluated specially on the todo list. The
         data model has a single todo item, but the timeline evaluates the recurrence
-        to expand and copy the the item to multiple places on the timeline.
+        to expand and copy the item to multiple places on the timeline.
 
         This is only valid for events where `recurring` is True.
         """

--- a/ical/list.py
+++ b/ical/list.py
@@ -30,7 +30,7 @@ def _pick_todo(todos: list[Todo], dtstart: datetime.datetime) -> Todo:
     next todo that is incomplete and has the latest due date.
     """
     # For a recurring todo, the dtstart is after the last due date. Therefore
-    # we can stort items by dtstart and pick the last one that hasn't happened
+    # we can sort items by dtstart and pick the last one that hasn't happened
     root_iter = merge_and_expand_items(todos, dtstart.tzinfo or local_timezone())
 
     it = iter(root_iter)

--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -81,7 +81,7 @@ class ParsedPropertyParameter:
     The values may be overridden in the parse tree so that we can directly
     set the timezone information when parsing a date-time rather than
     combining with the calendar at runtime. That is, we update the tree
-    with timezone infrmation replacing a string TZID with the zoneinfo.
+    with timezone information replacing a string TZID with the zoneinfo.
     """
 
 
@@ -124,7 +124,7 @@ class ParsedProperty:
                 for value in parameter.values:
                     if not isinstance(value, str):
                         continue  # Shouldn't happen; only strings are set by parsing
-                    # Property parameters with values contain a colon, simicolon,
+                    # Property parameters with values contain a colon, semicolon,
                     # or a comma character must be placed in quoted text
                     if _UNSAFE_CHAR_RE.search(value):
                         result_param_values.append(f'"{value}"')

--- a/ical/store.py
+++ b/ical/store.py
@@ -217,7 +217,7 @@ class GenericStore(Generic[_T]):
         either the whole item or instances of an item may be deleted. To
         delete the complete range of a recurring item, the `uid` property
         for the item must be specified and the `recurrence_id` should not
-        be specified. To delete an individual instances of the item the
+        be specified. To delete an individual instance of the item the
         `recurrence_id` must be specified.
 
         When deleting individual instances, the range property may specify

--- a/ical/timespan.py
+++ b/ical/timespan.py
@@ -41,7 +41,7 @@ class Timespan:
         end: datetime.date | datetime.datetime,
         tzinfo: datetime.tzinfo | None = None,
     ) -> "Timespan":
-        """Create a Timestapn for the specified date range."""
+        """Create a Timespan for the specified date range."""
         return Timespan(
             normalize_datetime(start, tzinfo), normalize_datetime(end, tzinfo)
         )

--- a/ical/timezone.py
+++ b/ical/timezone.py
@@ -2,7 +2,7 @@
 
 An iCal timezone is a complete description of a timezone, separate
 from the built-in timezones used by python datetime objects. You can
-think of this like fully persisting all timezone informating referenced
+think of this like fully persisting all timezone information referenced
 in the calendar for dates to reference. Timezones are captured to
 unambiguously describe time information to aid in interoperability between
 different calendaring systems.
@@ -237,7 +237,7 @@ class Timezone(ComponentModel):
         return iters
 
     def get_observance(self, value: datetime.datetime) -> _ObservanceInfo | None:
-        """Return the specified observence for the specified date."""
+        """Return the specified observance for the specified date."""
         if value.tzinfo is not None:
             raise ValueError("Start time must be in local time format")
         last_observance_info: _ObservanceInfo | None = None

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -119,7 +119,7 @@ class Todo(ComponentModel):
     percent: Optional[int] = None
 
     priority: Optional[Priority] = None
-    """Defines the relative priorirty of the todo item."""
+    """Defines the relative priority of the todo item."""
 
     recurrence_id: Optional[RecurrenceId] = Field(alias="recurrence-id")
     """Defines a specific instance of a recurring item.
@@ -172,7 +172,7 @@ class Todo(ComponentModel):
     """The revision sequence number in the calendar component.
 
     When an event is created, its sequence number is 0. It is monotonically incremented
-    by the organizers calendar user agent every time a significant revision is made to
+    by the organizer's calendar user agent every time a significant revision is made to
     the calendar event.
     """
 
@@ -261,7 +261,7 @@ class Todo(ComponentModel):
 
         A recurring event is typically evaluated specially on the list. The
         data model has a single todo, but the timeline evaluates the recurrence
-        to expand and copy the the event to multiple places on the timeline
+        to expand and copy the event to multiple places on the timeline
         using `as_rrule`.
         """
         if self.rrule or self.rdate:
@@ -273,7 +273,7 @@ class Todo(ComponentModel):
 
         A recurring todo is typically evaluated specially on the todo list. The
         data model has a single todo item, but the timeline evaluates the recurrence
-        to expand and copy the the item to multiple places on the timeline.
+        to expand and copy the item to multiple places on the timeline.
 
         This is only valid for events where `recurring` is True.
         """

--- a/ical/types/cal_address.py
+++ b/ical/types/cal_address.py
@@ -115,6 +115,6 @@ class CalAddress(BaseModel):
         return encode_model_property_params(cls.__fields__.values(), model_data)
 
     class Config:
-        """Pyandtic model configuration."""
+        """Pydantic model configuration."""
 
         allow_population_by_field_name = True

--- a/ical/types/date_time.py
+++ b/ical/types/date_time.py
@@ -83,7 +83,7 @@ class DateTimeEncoder:
 
     @classmethod
     def __encode_property_json__(cls, value: datetime.datetime) -> str | dict[str, str]:
-        """Encode an ICS value during json serializaton."""
+        """Encode an ICS value during json serialization."""
         if value.tzinfo is None:
             return value.strftime("%Y%m%dT%H%M%S")
         # Does not yet handle timezones and encoding property parameters

--- a/ical/types/geo.py
+++ b/ical/types/geo.py
@@ -12,7 +12,7 @@ from .text import TextEncoder
 @DATA_TYPE.register("GEO")
 @dataclass
 class Geo:
-    """Information related tot he global position for an activity."""
+    """Information related to the global position for an activity."""
 
     lat: float
     lng: float

--- a/ical/types/period.py
+++ b/ical/types/period.py
@@ -67,7 +67,7 @@ class Period(BaseModel):
 
     @property
     def end_value(self) -> datetime.datetime:
-        """A computed end value based on either or duration."""
+        """A computed end value based on either end or duration."""
         if self.end:
             return self.end
         if not self.duration:
@@ -76,7 +76,7 @@ class Period(BaseModel):
 
     @root_validator(pre=True, allow_reuse=True)
     def parse_period_fields(cls, values: dict[str, Any]) -> dict[str, Any]:
-        """Parse a rfc5545 prioriry value."""
+        """Parse a rfc5545 priority value."""
         if not (value := values.pop("value", None)):
             return values
         parts = value.split("/")
@@ -143,6 +143,6 @@ class Period(BaseModel):
         )
 
     class Config:
-        """Pyandtic model configuration."""
+        """Pydantic model configuration."""
 
         allow_population_by_field_name = True

--- a/ical/types/priority.py
+++ b/ical/types/priority.py
@@ -1,4 +1,4 @@
-"""Parser for the the PRIORITY type."""
+"""Parser for the PRIORITY type."""
 
 from collections.abc import Callable
 from typing import Generator

--- a/ical/tzif/tz_rule.py
+++ b/ical/tzif/tz_rule.py
@@ -229,7 +229,7 @@ def _create_parser(start_gator: bool, is_julian_date: bool) -> ParserElement:
         + "."
         + Word(nums).set_results_name("day_of_week")
     )
-    # Hack for inabiliy to have a single rule with both date types
+    # Hack for inability to have a single rule with both date types
     if is_julian_date:
         tz_days = "J" + Word(nums).set_results_name("day_of_year")
     else:

--- a/ical/tzif/tzif.py
+++ b/ical/tzif/tzif.py
@@ -38,7 +38,7 @@ _LOCAL_TIME_TYPE_STRUCT_FORMAT = "".join(
         ">",  # Use standard size of packed value bytes
         "l",  # utoff (4 bytes): Number of seconds to add to UTC to determine local time
         "?",  # dst (1 byte): Indicates the time is DST (1) or standard (0)
-        "B",  # idx (1 byte): Offset index into the time zone designiation octets (0-charcnt-1)
+        "B",  # idx (1 byte): Offset index into the time zone designation octets (0-charcnt-1)
     ]
 )
 _LOCAL_TIME_RECORD_SIZE = 6
@@ -142,7 +142,7 @@ _TransitionBlock = namedtuple(
 # A series of records specifying the local time type:
 #  - utoff (4 bytes): Number of seconds to add to UTC to determine local time
 #  - dst (1 byte): Indicates the time is DST (1) or standard (0)
-#  - idx (1 byte):  Offset index into the time zone designiation octets (0-charcnt-1)
+#  - idx (1 byte):  Offset index into the time zone designation octets (0-charcnt-1)
 # is the utoff (4 bytes), dst (1 byte), idx (1 byte).
 _LocalTimeType = namedtuple("_LocalTimeType", ["utoff", "dst", "idx"])
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,7 +20,7 @@ PyYAML==6.0.2
 types-PyYAML==6.0.12.20250516
 syrupy==4.9.1
 
-# emjoji is a dev only dependency used by script/update_emoji.py
+# emoji is a dev only dependency used by script/update_emoji.py
 emoji==2.14.1
 # tzlocal is a dev only dependency used by script/update_tzlocal.py
 tzlocal==5.3.1


### PR DESCRIPTION
Hi! This is mostly a practice pull request. We read over the code more carefully, fixed some typos, and used pytest and pre-commit to make sure the changes are fine. All changes were to documentation, none to code.

* Fix minor typos that would not have confused native speakers.

* Add missing word "end" to documentation of Period.end_value in ical/types/period.py