### PR TITLE
Fix confusing message when TZID not recognized -- Minimal version

### DIFF
--- a/ical/component.py
+++ b/ical/component.py
@@ -228,7 +228,9 @@ class ComponentModel(BaseModel):
                 )
                 errors.append(str(err))
                 continue
-        raise ValueError(f"Failed to validate: {prop.value}, errors: ({errors})")
+        raise ValueError(
+            f"Failed to validate: {prop.value} as {' or '.join(sub_type.__name__ for sub_type in field_types)}, due to: ({errors})"
+        )
 
     @classmethod
     def _parse_single_property(cls, field_type: type, prop: ParsedProperty) -> Any:

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -209,7 +209,7 @@ def test_union_parser() -> None:
 
     with pytest.raises(
         CalendarParseError,
-        match=".*Failed to validate: .*errors: .*Expected value to match DATE-TIME pattern: .*Expected value to match DATE pattern: .*",
+        match=".*Failed to validate: .* as datetime or date, due to: .*Expected value to match DATE-TIME pattern: .*Expected value to match DATE pattern: .*",
     ):
         model = TestModel.parse_obj(
             {


### PR DESCRIPTION
This is a minimal change to clarify the error message when a value cannot be validated as a Union[datetime, date]. Two error messages are displayed, but they more clearly indicate that one error message is for datetime, and one is for date.

We also made the fuller version you suggested in #491. I think the main use is for datetime+date, but this one is very simple and general.