### PR TITLE
Fix confusing message when TZID not recognized -- Full Version

### DIFF
--- a/ical/component.py
+++ b/ical/component.py
@@ -32,7 +32,7 @@ except ImportError:
 from .parsing.component import ParsedComponent
 from .parsing.property import ParsedProperty
 from .types.data_types import DATA_TYPE
-from .exceptions import CalendarParseError
+from .exceptions import CalendarParseError, ParameterValueError
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -219,6 +219,9 @@ class ComponentModel(BaseModel):
         for sub_type in field_types:
             try:
                 return cls._parse_single_property(sub_type, prop)
+            except ParameterValueError as err:
+                _LOGGER.debug("Invalid property value of type %s: %s", sub_type, err)
+                raise err
             except ValueError as err:
                 _LOGGER.debug(
                     "Unable to parse property value as type %s: %s", sub_type, err

--- a/ical/exceptions.py
+++ b/ical/exceptions.py
@@ -21,6 +21,22 @@ class CalendarParseError(CalendarError):
         self.detailed_error = detailed_error
 
 
+class ParameterValueError(ValueError):
+    """Exception raised when validating a datetime.
+
+    When validating a ParsedProperty, it may not be known what data-type
+    the result should be, so multiple validators may be called. We must
+    distinguish between "this property does not look like this data-type"
+    from "this property should be this data-type, but it is invalid". The
+    former should raise a ValueError and the latter ParameterValueError.
+    The motivating example is "DTSTART;TZID=GMT:20250601T171819" as either
+    datetime or date. It fails to be a datetime because of an unrecognized
+    timezone, and fails to be a date, because it is a datetime. Rather
+    than continue trying to validate it as a date, raise ParameterValueError
+    to stop, and simply return a single error.
+    """
+
+
 class RecurrenceError(CalendarError):
     """Exception raised when evaluating a recurrence rule.
 

--- a/ical/types/date_time.py
+++ b/ical/types/date_time.py
@@ -11,6 +11,7 @@ from typing import Any
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 from ical.compat import timezone_compat
 from ical.tzif import timezoneinfo
+from ical.exceptions import ParameterValueError
 from .data_types import DATA_TYPE
 
 _LOGGER = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ def parse_property_value(
                         if allow_invalid_timezone:
                             timezone = None
                         else:
-                            raise ValueError(
+                            raise ParameterValueError(
                                 f"Expected DATE-TIME TZID value '{value}' to be valid timezone"
                             )
     elif match.group(3):  # Example: 19980119T070000Z


### PR DESCRIPTION
This is the fuller 1,2,3 fix you suggested in #491. It introduces a little more logic, and is only used by datetime and date, but I do prefer the error message a bit more. More code to produce a shorter error message. :smile:

When validating lines of an ICS file, we may not know the data-type of the property value: perhaps it is a 20250601 date or a 20250601T171819 date-time. The validator tries each potential data-type, and uses the first successfully validated type. What happens if all report invalid?

We now distinguish two types of validation errors:
- ValueError: the property value is not of this type
- ParameterValueError: it is of this type but is not valid

A ParameterValueError will stop the checking and report only that error; otherwise all ValueErrors are reported.

If a ParameterValueError is encountered, for example in:
  DTSTART;TZID=America/New_Mork:20250601T171819
then the new error message becomes:
  Failed to parse calendar EVENT component:
  Expected DATE-TIME TZID value 'America/New_Mork' to be valid timezone
and no longer mentions that it is also not a valid date.