### PR TITLE
Fix case-insensitive property names

### DIFF
--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -222,6 +222,7 @@ def _parse_line(line: str) -> ParsedProperty:
             if delimiter == ":":
                 break  # We are done with all parameters.
 
+    property_name = property_name.upper()
     if not _RE_NAME.fullmatch(property_name):
         raise CalendarParseError(
             f"Invalid property name '{property_name}'", detailed_error=line

--- a/tests/parsing/test_property.py
+++ b/tests/parsing/test_property.py
@@ -68,3 +68,22 @@ def test_blank_parameters(ics: str) -> None:
     assert prop.params[0].values == ["URI"]
     assert prop.params[1].name == "X-TEST-BLANK-PARAM"
     assert prop.params[1].values == [""]
+
+
+@pytest.mark.parametrize(
+    "ics",
+    [
+        "BEGIN:VEVENT",
+        "begin:VEVENT",
+        "Begin:VEVENT",
+        "bEgiN:VEVENT",
+    ],
+)
+def test_mixed_case_property_name(ics: str) -> None:
+    """Test property name is case-insensitive."""
+    properties = list(parse_contentlines([ics]))
+    assert len(properties) == 1
+    prop = properties[0]
+    assert prop.name == "begin"
+    assert prop.value == "VEVENT"
+    assert prop.params is None


### PR DESCRIPTION
According to [RFC2425 sec 5.8.2](https://datatracker.ietf.org/doc/html/rfc2425#section-5.8.2) and [RFC5545 sec 2](https://datatracker.ietf.org/doc/html/rfc5545#section-2) property names are case-insensitive. A football match calendar included a mixed case property name which caused an unexpected error, which this commit fixes.

This will fix home-assistant/core#146173 once the new version of ical is included there.

Limitations (due to time): I did not create a test to verify this behavior, and I didn't expand the upper-casing to other aspects. Parameter names and many values are also supposed to be case insensitive, but I did not have time to analyze the full scope and did not want to risk an overly broad fix.