### PR TITLE
Update types-python-dateutil to v2.9.0.20250708

### DIFF
--- a/ical/iter.py
+++ b/ical/iter.py
@@ -197,9 +197,9 @@ class RulesetIterable(Iterable[Union[datetime.datetime, datetime.date]]):
         for rule in self._rrule:
             ruleset.rrule(self._converter(rule))  # type: ignore[arg-type]
         for rdate in self._rdate:
-            ruleset.rdate(self._defloat(rdate))  # type: ignore[no-untyped-call]
+            ruleset.rdate(self._defloat(rdate))
         for exdate in self._exdate:
-            ruleset.exdate(self._defloat(exdate))  # type: ignore[no-untyped-call]
+            ruleset.exdate(self._defloat(exdate))
         return ruleset
 
     def __iter__(self) -> Iterator[datetime.datetime | datetime.date]:

--- a/ical/timezone.py
+++ b/ical/timezone.py
@@ -101,7 +101,7 @@ class Observance(ComponentModel):
         if self.rrule:
             ruleset.rrule(self.rrule.as_rrule(self.start_datetime))
         for rdate in self.rdate:
-            ruleset.rdate(rdate)  # type: ignore[no-untyped-call]
+            ruleset.rdate(rdate)
         return ruleset
 
     @field_validator("dtstart")

--- a/ical/types/recur.py
+++ b/ical/types/recur.py
@@ -39,7 +39,7 @@ import enum
 import logging
 import re
 from dataclasses import dataclass
-from typing import Annotated, Any, Optional, Union
+from typing import Annotated, Any, Literal, Optional, Union
 
 from dateutil import rrule
 from pydantic import (
@@ -205,7 +205,7 @@ class RecurrenceId(str):
         )
 
 
-RRULE_FREQ = {
+RRULE_FREQ: dict[Frequency, Literal[0, 1, 2, 3]] = {
     Frequency.DAILY: rrule.DAILY,
     Frequency.WEEKLY: rrule.WEEKLY,
     Frequency.MONTHLY: rrule.MONTHLY,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,7 +13,7 @@ python-dateutil==2.9.0.post0
 freezegun==1.5.3
 pydantic==2.11.7
 pytest-benchmark==5.1.0
-types-python-dateutil==2.9.0.20250516
+types-python-dateutil==2.9.0.20250708
 wheel==0.46.1
 PyYAML==6.0.2
 types-PyYAML==6.0.12.20250516


### PR DESCRIPTION
Replaces https://github.com/allenporter/ical/pull/512