### PR TITLE
Clarify error message wording for invalid ICS calendars

### DIFF
--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -273,5 +273,6 @@ def parse_contentlines(
             yield ParsedProperty.from_ics(contentline)
         except CalendarParseError as err:
             raise CalendarParseError(
-                f"Failed to parse calendar contents", detailed_error=str(err)
+                f"Calendar contents are not valid ICS format, see the detailed_error for more information",
+                detailed_error=str(err),
             ) from err

--- a/tests/parsing/__snapshots__/test_component.ambr
+++ b/tests/parsing/__snapshots__/test_component.ambr
@@ -232,97 +232,97 @@
 # ---
 # name: test_invalid_contentlines[invalid]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Invalid property line, expected (';', ':') after property name",
   )
 # ---
 # name: test_invalid_contentlines[invalid_iana-token]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Invalid property name 'DES.RIPTION'",
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_eol copy]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     'Unexpected end of line: unclosed quoted parameter value.',
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_eol_quoted]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     'Unexpected end of line: missing parameter value delimiter.',
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_name-1]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Invalid parameter name 'PARAM NAME'",
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_name-2]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Invalid parameter name 'PARAM+NAME'",
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_value]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Invalid parameter format: missing '=' after parameter name part ';:VALUE'",
   )
 # ---
 # name: test_invalid_contentlines[invalid_params_list]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     'Unexpected end of line. Expected parameter value or delimiter.',
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_missing_value]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Unexpected end of line after parameter value 'PARAM-VAL'. Expected delimiter (',', ';', ':').",
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_name]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     'Invalid property name \'"NAME"\'',
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_param_extra_end]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Expected (',', ';', ':') after parameter value, got 'e'",
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_param_extra_start]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     'Parameter value \'extra"QUOTED-VALUE"\' for parameter \'PARAM-NAME\' is improperly quoted',
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_params]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     'Unexpected end of line: unclosed quoted parameter value.',
   )
 # ---
 # name: test_invalid_contentlines[invalid_x-name-1]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Invalid property name 'X-DES.RIPTION'",
   )
 # ---
 # name: test_invalid_contentlines[invalid_x-name-2]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Invalid property name 'X-,'",
   )
 # ---
 # name: test_invalid_contentlines[missing_colon]
   tuple(
-    'Failed to parse calendar contents',
+    'Calendar contents are not valid ICS format, see the detailed_error for more information',
     "Invalid parameter format: missing '=' after parameter name part 'This is a description'",
   )
 # ---

--- a/tests/test_calendar_stream.py
+++ b/tests/test_calendar_stream.py
@@ -144,7 +144,10 @@ def test_invalid_ics(content: str) -> None:
     These are tested here so we can add escape sequences. Most other invalid
     encodings are tested in the yaml testdata/ files.
     """
-    with pytest.raises(CalendarParseError, match="^Failed to parse calendar contents"):
+    with pytest.raises(
+        CalendarParseError,
+        match="^Calendar contents are not valid ICS format, see the detailed_error for more information$",
+    ):
         IcsCalendarStream.calendar_from_ics(content)
 
 


### PR DESCRIPTION
Clarify error message wording for invalid ICS calendars that the contents are not valid.

This may help cases like https://github.com/home-assistant/core/issues/148324