### PR TITLE
Fix DUE checking in recurrent todo

### DIFF
--- a/ical/todo.py
+++ b/ical/todo.py
@@ -330,8 +330,8 @@ class Todo(ComponentModel):
         """
         if not self.rrule and not self.rdate:
             return None
-        if not self.due:
-            raise CalendarParseError("Event must have a due date to be recurring")
+        if not self.due and not self.duration:
+            raise CalendarParseError("Event must have a due date or duration to be recurring")
         return as_rrule(self.rrule, self.rdate, self.exdate, self.dtstart)
 
     _validate_until_dtstart = model_validator(mode="after")(validate_until_dtstart)
@@ -344,7 +344,7 @@ class Todo(ComponentModel):
     def _validate_one_due_or_duration(self) -> Self:
         """Validate that only one of duration or end date may be set."""
         if self.due and self.duration:
-            raise ValueError("Only one of dtend or duration may be set.")
+            raise ValueError("Only one of due or duration may be set.")
         return self
 
     @model_validator(mode="after")

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -92,6 +92,11 @@ def test_dtstart_date_duration_hours_invalid():
         ),
         (
             {
+                "duration": datetime.timedelta(hours=1),
+            }
+        ),
+        (
+            {
                 "start": datetime.datetime(2022, 9, 6, 6, 0, 0),
                 "due": datetime.datetime(
                     2022, 9, 7, 6, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/Regina")


### PR DESCRIPTION
- Fix error message on both DUE and DURATION present
- Delete checking for DUE in `Todo.as_rrule()`
- Remove test cases that check for missing DTSTART with DTSTART present

Since DUE is exclusive with DURATION, by making DUE optional, this...

Fixes #534