### PR TITLE
Add tests for Todo.computed_duration and end properties.

### DIFF
--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -420,7 +420,7 @@ def test_default_computed_duration_zero() -> None:
     assert todo.computed_duration == datetime.timedelta()
 
 
-def test_end_start_date() -> None:
+def test_default_end_date() -> None:
     """Test that when only start is set and it's a date, end is the next day"""
     start = datetime.date(2025, 10, 27)
     todo = Todo(


### PR DESCRIPTION
Follow up to previous [PR](https://github.com/allenporter/ical/pull/541#issuecomment-3517310231)


>    end when there is a start date but not due/duration (effectively testing the default)
>    computed_duration when there is no start or duration

Also fixed test function name conflict I've introduced