### PR TITLE
Fix bug serialzing WKST as a string

### DIFF
--- a/ical/types/recur.py
+++ b/ical/types/recur.py
@@ -331,7 +331,7 @@ class Recur(BaseModel):
             elif isinstance(value, datetime.date):
                 value = DateEncoder.__encode_property_json__(value)
             elif isinstance(value, enum.Enum):
-                value = value.name
+                value = value.value
             elif key == "interval" and value == 1:
                 # Filter not None default value
                 continue

--- a/tests/types/test_recur.py
+++ b/tests/types/test_recur.py
@@ -808,6 +808,26 @@ def test_recur_by_last_day_as_string(recur: Recur) -> None:
     assert event.rrule.as_rrule_str() == "FREQ=MONTHLY;BYDAY=-1TU"
 
 
+@pytest.mark.parametrize(
+    "recur",
+    [
+        Recur(freq=Frequency.DAILY, interval=2, wkst=Weekday.MONDAY),
+        Recur.from_rrule("FREQ=DAILY;INTERVAL=2;WKST=MO"),
+    ],
+)
+def test_wkst_rrule_as_str(recur: Recur) -> None:
+    """Test converting a recurrence rule back to a string."""
+
+    event = Event(
+        summary="summary",
+        start=datetime.date(2022, 8, 1),
+        end=datetime.date(2022, 8, 2),
+        rrule=recur,
+    )
+    assert event.rrule
+    assert event.rrule.as_rrule_str() == "FREQ=DAILY;INTERVAL=2;WKST=MO"
+
+
 def test_rdate_all_day() -> None:
     """Test how all day events are handled with RDATE."""
 


### PR DESCRIPTION
When adding support for WKST in #560 this didn't fully serialize the rrule correctly when converting to a string.

Reported by an upstream usage in https://github.com/home-assistant/core/issues/158953