### PR TITLE
Accept `DATE` values with midnight time suffix

### DIFF
--- a/tests/test_recurrence.py
+++ b/tests/test_recurrence.py
@@ -92,6 +92,14 @@ def test_from_contentlines_rdate() -> None:
             [datetime.date(2022, 8, 3), datetime.date(2022, 8, 4)],
         ),
         (
+            "{property};VALUE=DATE:20220803T000000,20220804T000000",
+            [datetime.date(2022, 8, 3), datetime.date(2022, 8, 4)],
+        ),
+        (
+            "{property};VALUE=DATE:20220803T000000Z,20220804T000000Z",
+            [datetime.date(2022, 8, 3), datetime.date(2022, 8, 4)],
+        ),
+        (
             "{property};VALUE=DATE-TIME:20220803T060000,20220804T060000",
             [
                 datetime.datetime(2022, 8, 3, 6, 0, 0),


### PR DESCRIPTION
Accept `DATE` values that include a midnight time suffix (`YYYYMMDDT000000` or `YYYYMMDDT000000Z`).

Some calendar generators emit invalid `VALUE=DATE` values with a midnight time suffix. This is common in real-world ICS feeds. Strict parsing rejects these files even though the intent is unambiguous. Treating midnight time suffixes as dates improves interoperability without impacting valid `DATE-TIME` inputs.