### PR TITLE
Cache TzInfo instances and per-year DST boundaries & add regression test for Office 365 extended-timezone perf

### DIFF
--- a/ical/tzif/timezoneinfo.py
+++ b/ical/tzif/timezoneinfo.py
@@ -145,6 +145,7 @@ class TzInfo(datetime.tzinfo):
         """Initialize TzInfo."""
         self._rule: Rule = rule
         self._key: str | None = key
+        self._dst_year_cache: dict[int, tuple[datetime.datetime, datetime.datetime]] = {}
 
     @classmethod
     def from_timezoneinfo(
@@ -183,9 +184,13 @@ class TzInfo(datetime.tzinfo):
         ):
             return None
 
-        dt_year = datetime.datetime(dt.year, 1, 1)
-        dst_start = next(iter(self._rule.dst_start.as_rrule(dt_year)))
-        dst_end = next(iter(self._rule.dst_end.as_rrule(dt_year)))
+        if (cached := self._dst_year_cache.get(dt.year)) is not None:
+            dst_start, dst_end = cached
+        else:
+            dt_year = datetime.datetime(dt.year, 1, 1)
+            dst_start = next(iter(self._rule.dst_start.as_rrule(dt_year)))
+            dst_end = next(iter(self._rule.dst_end.as_rrule(dt_year)))
+            self._dst_year_cache[dt.year] = (dst_start, dst_end)
         dt_naive = dt.replace(tzinfo=None)
         dst_offset = self._rule.dst.offset - self._rule.std.offset
 
@@ -214,14 +219,33 @@ class TzInfo(datetime.tzinfo):
         return f"TzInfo({self._rule.std.name})"
 
 
-def read_tzinfo(key: str) -> TzInfo:
-    """Create a zoneinfo implementation from raw tzif data."""
-    resolved_key = _resolve_extended_timezone(key)
+@cache
+def _read_tzinfo_resolved(resolved_key: str) -> TzInfo:
+    """Read TzInfo for an already-resolved IANA timezone key.
+
+    Cached separately from ``read_tzinfo`` so the cache lookup is keyed on the
+    resolved IANA name. This avoids creating a fresh ``TzInfo`` instance for
+    every event that references the same timezone, which previously triggered
+    expensive ``utcoffset``/``dst`` recomputation during heap merges and
+    timeline materialization for large calendars.
+    """
     timezoneinfo = _read_cache(resolved_key)
     try:
         return TzInfo.from_timezoneinfo(timezoneinfo, key=resolved_key)
     except ValueError as err:
-        raise TimezoneInfoError(f"Unable create TzInfo: {key}") from err
+        raise TimezoneInfoError(f"Unable create TzInfo: {resolved_key}") from err
+
+
+def read_tzinfo(key: str) -> TzInfo:
+    """Create a zoneinfo implementation from raw tzif data.
+
+    The cache key is the resolved IANA name (after extended-timezone mapping)
+    so behaviour still depends on the current ``is_extended_timezones_enabled``
+    context: a non-IANA key like ``Pacific Standard Time`` continues to raise
+    ``TimezoneInfoError`` when compat mode is off.
+    """
+    resolved_key = _resolve_extended_timezone(key)
+    return _read_tzinfo_resolved(resolved_key)
 
 
 @cache

--- a/tests/test_timeline.py
+++ b/tests/test_timeline.py
@@ -2,6 +2,7 @@
 
 import datetime
 import random
+import time
 import zoneinfo
 from typing import Any
 from unittest.mock import patch
@@ -9,6 +10,8 @@ from unittest.mock import patch
 import pytest
 
 from ical.calendar import Calendar
+from ical.calendar_stream import IcsCalendarStream
+from ical.compat import enable_compat_mode
 from ical.event import Event
 from ical.journal import Journal
 from ical.types.recur import Recur
@@ -208,6 +211,90 @@ def test_benchmark_materialize_timeline() -> None:
         timeline,
         datetime.date(2022, 1, 1),
         datetime.date(2022, 4, 1),
+    )
+
+
+def _office365_pst_calendar(num_events: int) -> str:
+    """Build a synthetic Office 365 ICS string with N PST-tagged events."""
+    lines = [
+        "BEGIN:VCALENDAR",
+        "METHOD:PUBLISH",
+        "PRODID:Microsoft Exchange Server 2010",
+        "VERSION:2.0",
+        "BEGIN:VTIMEZONE",
+        "TZID:Pacific Standard Time",
+        "BEGIN:STANDARD",
+        "DTSTART:16010101T020000",
+        "TZOFFSETFROM:-0700",
+        "TZOFFSETTO:-0800",
+        "RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=1SU;BYMONTH=11",
+        "END:STANDARD",
+        "BEGIN:DAYLIGHT",
+        "DTSTART:16010101T020000",
+        "TZOFFSETFROM:-0800",
+        "TZOFFSETTO:-0700",
+        "RRULE:FREQ=YEARLY;INTERVAL=1;BYDAY=2SU;BYMONTH=3",
+        "END:DAYLIGHT",
+        "END:VTIMEZONE",
+    ]
+    base = datetime.datetime(2024, 1, 1, 9, 0)
+    for i in range(num_events):
+        start = base + datetime.timedelta(hours=i)
+        end = start + datetime.timedelta(minutes=30)
+        lines.extend(
+            [
+                "BEGIN:VEVENT",
+                "DTSTAMP:20240101T000000Z",
+                f"UID:event-{i}@example.com",
+                f"DTSTART;TZID=Pacific Standard Time:{start.strftime('%Y%m%dT%H%M%S')}",
+                f"DTEND;TZID=Pacific Standard Time:{end.strftime('%Y%m%dT%H%M%S')}",
+                f"SUMMARY:Event {i}",
+                "END:VEVENT",
+            ]
+        )
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"
+
+
+def test_materialize_timeline_office365_extended_timezone_perf() -> None:
+    """Regression test for home-assistant/core#148315.
+
+    Materializing a timeline for a large Office 365 calendar where every
+    event references the Windows-style ``TZID=Pacific Standard Time``
+    (mapped via compat mode to ``America/Los_Angeles``) used to take many
+    seconds because each parsed datetime got its own ``TzInfo`` instance,
+    breaking CPython's same-tzinfo comparison fast path and causing every
+    heap-merge comparison to fan out into ``dateutil.rrule`` constructions
+    inside ``TzInfo.dst``. With proper caching this completes in tens of
+    milliseconds.
+    """
+    num_events = 1500
+    ics = _office365_pst_calendar(num_events)
+
+    with enable_compat_mode(ics) as compat_ics:
+        calendar = IcsCalendarStream.calendar_from_ics(compat_ics)
+
+    assert len(calendar.events) == num_events
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    timeline = calendar.timeline_tz(now.tzinfo)
+
+    start = time.perf_counter()
+    materialized = materialize_timeline(
+        timeline,
+        start=now,
+        stop=now + datetime.timedelta(days=365),
+        max_number_of_events=20,
+    )
+    # Drain the iterator so the heap merge actually runs.
+    list(materialized)
+    elapsed = time.perf_counter() - start
+
+    # On the unfixed code path this takes 10+ seconds even on fast hardware;
+    # the cap is intentionally generous so it does not flake on slow CI.
+    assert elapsed < 1.0, (
+        f"materialize_timeline took {elapsed:.2f}s for {num_events} PST events; "
+        "regression in TzInfo caching"
     )
 
 


### PR DESCRIPTION
## Claude's Assessment

_**Note:** Below is using Opus 4.7(1M) model._

### Root cause

The slowness is in the `ical` library, specifically `ical/tzif/timezoneinfo.py`. Two compounding issues hit Office 365 calendars
hard:

1. `read_tzinfo()` was not cached. Every parsed datetime with `TZID=Pacific Standard Time` got its own fresh `TzInfo` instance. CPython's datetime comparison fast‑paths `mytz is ottz`; with every event having a unique tzinfo, every comparison falls back to calling `utcoffset()` on both sides.
2. `TzInfo.dst()` rebuilt two `dateutil.rrule` objects on every call to compute that year's DST start/end (`timezoneinfo.py:186-188`).

For your `calendar.ics` (1.82 MB, 2543 events, all referencing `Pacific Standard Time`), `materialize_timeline` calls `intersects` / heap `__lt__` ~3000+ times during the merge. Each comparison fans out into ~58k `utcoffset` calls and ~115k dateutil rrule constructions. On M1 that's 22s; on a Pi 4 it scales to 2-5 minutes — exactly the symptom in
https://github.com/home-assistant/core/issues/148315.

Issue/PR allenporter/ical#536/535 is a _different_, related issue (round-trip serialization of unknown VTIMEZONE properties). Allen has since added proper `extras` support for that.

### Fix (verified)

Two edits in `ical/ical/tzif/timezoneinfo.py`:
- Cache `_read_tzinfo_resolved(resolved_key)` so all events with the same `TZID` share one `TzInfo` instance. The cache is keyed on the resolved IANA name, so when compat mode is off, non-IANA keys like `"Pacific Standard Time"` still correctly raise `TimezoneInfoError`.
- Memoize per-year DST boundaries on the `TzInfo` instance.

Results on your real `calendar.ics`


|  | materialize_timeline |
|---|-------------------|
| Baseline          | 22.13s             |
| `read_tzinfo` cached | 5.37s           |
| Both fixes        | 0.21s (≈100×)      |

Full ical test suite: 1278 passed, 26 skipped, 0 failed.

## Tests added by Claude

The new test in `tests/test_timeline.py::test_materialize_timeline_office365_extended_timezone_perf`:
- Builds a synthetic Microsoft Exchange ICS with a `Pacific Standard Time` VTIMEZONE and 1500 events all using `TZID=Pacific Standard Time`.
- Parses with `enable_compat_mode` and runs `materialize_timeline` over a 365-day window.
- Asserts elapsed < 1.0s.

Verified behaviour: passes with the fix (~25ms on M1) and fails without it (~8s — well above the 1s budget).