### PR TITLE
Include raw offending line in detailed_error for CalendarParseError

### DIFF
--- a/ical/event.py
+++ b/ical/event.py
@@ -455,7 +455,9 @@ class Event(ComponentModel):
     def _validate_same_day_dtend(self) -> Self:
         """Fix same-day DTEND for all-day events when compat mode is enabled."""
         if same_day_dtend_compat.is_same_day_dtend_compat_enabled():
-            if isinstance(self.dtstart, datetime.date) and not isinstance(self.dtstart, datetime.datetime):
+            if isinstance(self.dtstart, datetime.date) and not isinstance(
+                self.dtstart, datetime.datetime
+            ):
                 if self.dtend and self.dtend == self.dtstart:
                     self.dtend = self.dtstart + datetime.timedelta(days=1)
         return self

--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -272,7 +272,10 @@ def parse_contentlines(
         try:
             yield ParsedProperty.from_ics(contentline)
         except CalendarParseError as err:
+            detailed_error = str(err)
+            if err.detailed_error:
+                detailed_error = f"{detailed_error}: {err.detailed_error}"
             raise CalendarParseError(
-                f"Calendar contents are not valid ICS format, see the detailed_error for more information",
-                detailed_error=str(err),
+                "Calendar contents are not valid ICS format, see the detailed_error for more information",
+                detailed_error=detailed_error,
             ) from err

--- a/tests/compat/test_make_compat.py
+++ b/tests/compat/test_make_compat.py
@@ -34,7 +34,9 @@ def mock_frozen_time() -> Generator[FrozenDateTimeFactory, None, None]:
 
 
 @pytest.mark.parametrize("filename", OFFICE_FILES, ids=OFFICE_IDS)
-def test_make_compat_office(filename: pathlib.Path, snapshot: SnapshotAssertion) -> None:
+def test_make_compat_office(
+    filename: pathlib.Path, snapshot: SnapshotAssertion
+) -> None:
     """Test Microsoft Office/Exchange Server compatibility."""
     with filename.open(encoding="utf-8") as ics_file:
         ics = ics_file.read()
@@ -51,7 +53,9 @@ def test_make_compat_office(filename: pathlib.Path, snapshot: SnapshotAssertion)
 
 
 @pytest.mark.parametrize("filename", CALENDAR_LABS_FILES, ids=CALENDAR_LABS_IDS)
-def test_make_compat_calendar_labs(filename: pathlib.Path, snapshot: SnapshotAssertion) -> None:
+def test_make_compat_calendar_labs(
+    filename: pathlib.Path, snapshot: SnapshotAssertion
+) -> None:
     """Test Calendar Labs same-day DTEND compatibility."""
     with filename.open(encoding="utf-8") as ics_file:
         ics = ics_file.read()
@@ -77,7 +81,7 @@ def test_parse_failure_office(filename: pathlib.Path) -> None:
 @pytest.mark.parametrize("filename", CALENDAR_LABS_FILES, ids=CALENDAR_LABS_IDS)
 def test_parse_success_calendar_labs(filename: pathlib.Path) -> None:
     """Test that Calendar Labs files parse successfully without compat mode.
-    
+
     Calendar Labs same-day DTEND files should parse successfully even without
     compat mode, but will have incorrect DTEND (same as DTSTART).
     """

--- a/tests/compat/test_same_day_dtend_compat.py
+++ b/tests/compat/test_same_day_dtend_compat.py
@@ -17,7 +17,7 @@ def test_same_day_dtend_fail() -> None:
     calendar = IcsCalendarStream.calendar_from_ics(
         CALENDAR_LABS_SAME_DAY.read_text(encoding="utf-8")
     )
-    
+
     event = calendar.events[0]
     # Without compat mode, DTEND should equal DTSTART (incorrect)
     assert event.dtstart == event.dtend
@@ -31,13 +31,13 @@ def test_same_day_dtend_compat() -> None:
         calendar = IcsCalendarStream.calendar_from_ics(
             CALENDAR_LABS_SAME_DAY.read_text(encoding="utf-8")
         )
-    
+
     event = calendar.events[0]
     # With compat mode, DTEND should be DTSTART + 1 day (correct)
     assert event.dtend != event.dtstart
     assert str(event.dtstart) == "2025-12-08"
     assert str(event.dtend) == "2025-12-09"
-    
+
     # Test that the output can be serialized and parsed back
     output_ics = IcsCalendarStream.calendar_to_ics(calendar)
     reparsed_calendar = IcsCalendarStream.calendar_from_ics(output_ics)
@@ -50,11 +50,11 @@ def test_same_day_dtend_compat_context_manager() -> None:
     """Test that compat mode is properly enabled/disabled."""
     # Initially disabled
     assert not same_day_dtend_compat.is_same_day_dtend_compat_enabled()
-    
+
     # Enabled within context
     with same_day_dtend_compat.enable_same_day_dtend_compat():
         assert same_day_dtend_compat.is_same_day_dtend_compat_enabled()
-    
+
     # Disabled after context
     assert not same_day_dtend_compat.is_same_day_dtend_compat_enabled()
 
@@ -71,10 +71,10 @@ DTEND:20251208T100000Z
 SUMMARY:Datetime Event
 END:VEVENT
 END:VCALENDAR"""
-    
+
     with same_day_dtend_compat.enable_same_day_dtend_compat():
         calendar = IcsCalendarStream.calendar_from_ics(datetime_ics)
-    
+
     event = calendar.events[0]
     # Datetime events should NOT be fixed (DTEND should remain same as DTSTART)
     assert event.dtstart == event.dtend
@@ -93,10 +93,10 @@ DTEND;VALUE=DATE:20251210
 SUMMARY:Multi-day Event
 END:VEVENT
 END:VCALENDAR"""
-    
+
     with same_day_dtend_compat.enable_same_day_dtend_compat():
         calendar = IcsCalendarStream.calendar_from_ics(different_dates_ics)
-    
+
     event = calendar.events[0]
     # Events with different DTSTART/DTEND should NOT be modified
     assert str(event.dtstart) == "2025-12-08"

--- a/tests/parsing/__snapshots__/test_component.ambr
+++ b/tests/parsing/__snapshots__/test_component.ambr
@@ -233,97 +233,97 @@
 # name: test_invalid_contentlines[invalid]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Invalid property line, expected (';', ':') after property name",
+    "Invalid property line, expected (';', ':') after property name: invalid",
   )
 # ---
 # name: test_invalid_contentlines[invalid_iana-token]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Invalid property name 'DES.RIPTION'",
+    "Invalid property name 'DES.RIPTION': DES.RIPTION:This is a description",
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_eol copy]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    'Unexpected end of line: unclosed quoted parameter value.',
+    'Unexpected end of line: unclosed quoted parameter value.: NAME;PARAM-NAME="PARAM-VAL',
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_eol_quoted]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    'Unexpected end of line: missing parameter value delimiter.',
+    'Unexpected end of line: missing parameter value delimiter.: NAME;PARAM-NAME=PARAMVAL',
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_name-1]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Invalid parameter name 'PARAM NAME'",
+    "Invalid parameter name 'PARAM NAME': NAME;PARAM NAME=PARAM-VALUE:VALUE",
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_name-2]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Invalid parameter name 'PARAM+NAME'",
+    "Invalid parameter name 'PARAM+NAME': NAME;PARAM+NAME=PARAM-VALUE:VALUE",
   )
 # ---
 # name: test_invalid_contentlines[invalid_param_value]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Invalid parameter format: missing '=' after parameter name part ';:VALUE'",
+    "Invalid parameter format: missing '=' after parameter name part ';:VALUE': DESCRIPTION;;:VALUE",
   )
 # ---
 # name: test_invalid_contentlines[invalid_params_list]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    'Unexpected end of line. Expected parameter value or delimiter.',
+    'Unexpected end of line. Expected parameter value or delimiter.: NAME;PARAM-NAME=,',
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_missing_value]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Unexpected end of line after parameter value 'PARAM-VAL'. Expected delimiter (',', ';', ':').",
+    'Unexpected end of line after parameter value \'PARAM-VAL\'. Expected delimiter (\',\', \';\', \':\').: NAME;PARAM-NAME="PARAM-VAL"',
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_name]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    'Invalid property name \'"NAME"\'',
+    'Invalid property name \'"NAME"\': "NAME":VALUE',
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_param_extra_end]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Expected (',', ';', ':') after parameter value, got 'e'",
+    'Expected (\',\', \';\', \':\') after parameter value, got \'e\': NAME;PARAM-NAME="QUOTED-VALUE"extra:VALUE',
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_param_extra_start]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    'Parameter value \'extra"QUOTED-VALUE"\' for parameter \'PARAM-NAME\' is improperly quoted',
+    'Parameter value \'extra"QUOTED-VALUE"\' for parameter \'PARAM-NAME\' is improperly quoted: NAME;PARAM-NAME=extra"QUOTED-VALUE":VALUE',
   )
 # ---
 # name: test_invalid_contentlines[invalid_quoted_params]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    'Unexpected end of line: unclosed quoted parameter value.',
+    'Unexpected end of line: unclosed quoted parameter value.: NAME;PARAM-NAME="QUOTED-PARAM:QUOTED-VALUE:VALUE',
   )
 # ---
 # name: test_invalid_contentlines[invalid_x-name-1]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Invalid property name 'X-DES.RIPTION'",
+    "Invalid property name 'X-DES.RIPTION': X-DES.RIPTION:This is a description",
   )
 # ---
 # name: test_invalid_contentlines[invalid_x-name-2]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Invalid property name 'X-,'",
+    "Invalid property name 'X-,': X-,:This is a description",
   )
 # ---
 # name: test_invalid_contentlines[missing_colon]
   tuple(
     'Calendar contents are not valid ICS format, see the detailed_error for more information',
-    "Invalid parameter format: missing '=' after parameter name part 'This is a description'",
+    "Invalid parameter format: missing '=' after parameter name part 'This is a description': DESCRIPTION;This is a description",
   )
 # ---
 # name: test_parse_contentlines[attendee]

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ wheels = [
 
 [[package]]
 name = "ical"
-version = "13.0.1"
+version = "13.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Includes the raw malformed property line in the `detailed_error` attribute of `CalendarParseError` in `parse_contentlines()`, making it significantly easier to debug parsing issues.