### PR TITLE
Gracefully handle ZoneInfo ValueError for bogus timezones

### DIFF
--- a/ical/types/date_time.py
+++ b/ical/types/date_time.py
@@ -41,7 +41,7 @@ def parse_property_value(
             else:
                 try:
                     timezone = zoneinfo.ZoneInfo(value)
-                except zoneinfo.ZoneInfoNotFoundError:
+                except (zoneinfo.ZoneInfoNotFoundError, ValueError):
                     try:
                         timezone = timezoneinfo.read_tzinfo(value)
                     except timezoneinfo.TimezoneInfoError:

--- a/tests/types/test_date_time.py
+++ b/tests/types/test_date_time.py
@@ -149,3 +149,56 @@ def test_datedatime_parameter_encoder() -> None:
                 ],
             }
         )
+
+
+def test_bogus_timezone_value_error() -> None:
+    """Test that a bogus timezone like tzone:// raises a clean CalendarParseError under default strict parsing."""
+
+    class TestModel(ComponentModel):
+        dt: datetime.datetime
+
+    with pytest.raises(CalendarParseError, match="valid timezone"):
+        TestModel.model_validate(
+            {
+                "dt": [
+                    ParsedProperty(
+                        name="dt",
+                        value="20220724T120000",
+                        params=[
+                            ParsedPropertyParameter(
+                                name="TZID",
+                                values=["tzone://Microsoft/Custom"],
+                            ),
+                        ],
+                    )
+                ],
+            }
+        )
+
+
+def test_bogus_timezone_allow_invalid() -> None:
+    """Test that a bogus timezone is parsed successfully when allow_invalid_timezone is True."""
+
+    class TestModel(ComponentModel):
+        dt: datetime.datetime
+
+    from ical.compat import timezone_compat
+
+    with timezone_compat.enable_allow_invalid_timezones():
+        model = TestModel.model_validate(
+            {
+                "dt": [
+                    ParsedProperty(
+                        name="dt",
+                        value="20220724T120000",
+                        params=[
+                            ParsedPropertyParameter(
+                                name="TZID",
+                                values=["tzone://Microsoft/Custom"],
+                            ),
+                        ],
+                    )
+                ],
+            }
+        )
+        assert model.dt == datetime.datetime(2022, 7, 24, 12, 0, 0, tzinfo=None)

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ wheels = [
 
 [[package]]
 name = "ical"
-version = "13.2.2"
+version = "13.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Some external calendar providers (like Microsoft Office/365) generate invalid/bogus timezone strings in the TZID parameter, such as `tzone://Microsoft/Custom`. When `zoneinfo.ZoneInfo()` is invoked with these values, it raises `ValueError` (due to the keys not being normalized relative paths) instead of `ZoneInfoNotFoundError`.

Prior to this change, this uncaught `ValueError` caused the calendar parsing process to fail entirely and crash the calendar sync (e.g. in Home Assistant).

This PR:
1. Catches both `ZoneInfoNotFoundError` and `ValueError` when instantiating `ZoneInfo`.
2. Under strict parsing (the default), this gracefully falls back to checking other ways or raises a clean `ParameterValueError` (which behaves as a `CalendarParseError`).
3. Under relaxed/compatibility parsing (`allow_invalid_timezones`), it gracefully handles the error and defaults the timezone to `None`.
4. Adds tests validating both strict error throwing and compatibility parsing modes.

https://github.com/home-assistant/core/issues/165674 