### PR TITLE
fix(timezone): avoid in-place mutation of cached system timezone set

### DIFF
--- a/ical/tzif/timezoneinfo.py
+++ b/ical/tzif/timezoneinfo.py
@@ -266,7 +266,7 @@ def available_timezones() -> set[str]:
     This includes system timezones, tzdata timezones, and extended timezones if
     enabled for compatibility mode.
     """
-    result = _read_system_timezones()
+    result = set(_read_system_timezones())
     result |= _read_tzdata_timezones()
     if timezone_compat.is_extended_timezones_enabled():
         result |= _extended_timezones()

--- a/tests/compat/test_make_compat.py
+++ b/tests/compat/test_make_compat.py
@@ -70,7 +70,14 @@ def test_make_compat_calendar_labs(
     IcsCalendarStream.calendar_from_ics(new_ics)
 
 
-@pytest.mark.parametrize("filename", OFFICE_FILES, ids=OFFICE_IDS)
+OFFICE_FAILURE_FILES = [
+    TESTDATA_PATH / "office_365_extended_timezone.ics",
+    TESTDATA_PATH / "office_365_invalid_timezone.ics",
+]
+OFFICE_FAILURE_IDS = [x.stem for x in OFFICE_FAILURE_FILES]
+
+
+@pytest.mark.parametrize("filename", OFFICE_FAILURE_FILES, ids=OFFICE_FAILURE_IDS)
 def test_parse_failure_office(filename: pathlib.Path) -> None:
     """Test that Office files fail parsing without compat mode."""
     with filename.open(encoding="utf-8") as ics_file:


### PR DESCRIPTION
This PR fixes a bug where enabling compatibility mode (with extended timezones) permanently mutates the cached set of system timezones in `_read_system_timezones()`. This mutation causes subsequent timezone lookups to incorrectly skip local calendar `VTIMEZONE` blocks and attempt to load them as system timezones (which then fails in standard mode). It also updates the parametrization of Office failure tests to explicitly list the two files that lack timezone blocks.

Issue #536 