### PR TITLE
fix(timezone): support deepcopy on custom TzInfo class

### DIFF
--- a/ical/tzif/timezoneinfo.py
+++ b/ical/tzif/timezoneinfo.py
@@ -7,6 +7,7 @@ python package.
 
 from __future__ import annotations
 
+from typing import Any
 import datetime
 import logging
 import os
@@ -164,6 +165,10 @@ class TzInfo(datetime.tzinfo):
         """Initialize TzInfo."""
         self._rule: Rule = rule
         self._key: str | None = key
+
+    def __deepcopy__(self, memo: Any) -> TzInfo:
+        """Return a deep copy of the timezone object."""
+        return TzInfo(self._rule, key=self._key)
 
     @classmethod
     def from_timezoneinfo(

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+import copy
 import datetime
 import inspect
 from typing import Any
@@ -290,31 +291,45 @@ def test_benchmark_get_observance_repeated_calls(benchmark: Any) -> None:
     assert result == len(dts)
 
 
-def test_timezone_deepcopy() -> None:
-    """Verify that TzInfo and Timezone objects can be deepcopied safely."""
-    import copy
-    from ical.tzif import timezoneinfo
+def test_calendar_deepcopy() -> None:
+    """Verify that a calendar can be deepcopied cleanly through the public API."""
 
-    # 1. Test TzInfo deepcopy
-    tz = timezoneinfo.read_tzinfo("America/New_York")
-    copied_tz = copy.deepcopy(tz)
-    assert copied_tz._key == tz._key
-    assert copied_tz._rule == tz._rule
+    ics_content = """BEGIN:VCALENDAR
+PRODID:-//Example Corp//Cal//EN
+VERSION:2.0
+BEGIN:VTIMEZONE
+TZID:Custom Time Zone
+BEGIN:STANDARD
+DTSTART:16010101T020000
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+RRULE:FREQ=YEARLY;BYDAY=-1SU;BYMONTH=10
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:event-1
+SUMMARY:Test Event
+DTSTART;TZID=Custom Time Zone:20241025T090000
+DTEND;TZID=Custom Time Zone:20241025T100000
+END:VEVENT
+END:VCALENDAR"""
 
-    # 2. Test Timezone component deepcopy
-    timezone = _customized_timezone()
-    # Trigger cache initialization
-    timezone.get_observance(datetime.datetime(2024, 7, 15, 12, 0, 0))
-    assert timezone._observance_timeline is not None
-    initial_cache_len = len(timezone._observance_timeline._cache)
-    assert initial_cache_len > 0
+    calendar = IcsCalendarStream.calendar_from_ics(ics_content)
+    # Trigger timeline/observance cache initialization
+    events = list(calendar.timeline)
+    assert len(events) == 1
+    assert isinstance(events[0].dtstart, datetime.datetime)
+    assert events[0].dtstart.tzinfo is not None
 
-    copied_timezone = copy.deepcopy(timezone)
-    assert copied_timezone._observance_timeline is not None
-    # CachedTransitionTimeline.__deepcopy__ resets the cache to empty to be rebuilt lazily
-    assert len(copied_timezone._observance_timeline._cache) == 0
+    # Deepcopy the calendar (which deepcopies the custom TzInfo and Timezone components)
+    copied_calendar = copy.deepcopy(calendar)
 
-    summer = copied_timezone.get_observance(datetime.datetime(2024, 7, 15, 12, 0, 0))
-    assert summer is not None
-    assert summer.observance.tz_offset_to.offset == datetime.timedelta(hours=2)
-    assert len(copied_timezone._observance_timeline._cache) > 0
+    # Verify the copied calendar operates identically
+    copied_events = list(copied_calendar.timeline)
+    assert len(copied_events) == 1
+    assert copied_events[0].summary == "Test Event"
+    assert copied_events[0].dtstart == events[0].dtstart
+    # Verify that the tzinfo of the copied event still works correctly
+    assert isinstance(copied_events[0].dtstart, datetime.datetime)
+    assert copied_events[0].dtstart.tzname() == events[0].dtstart.tzname()
+    assert copied_events[0].dtstart.utcoffset() == events[0].dtstart.utcoffset()

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -288,3 +288,33 @@ def test_benchmark_get_observance_repeated_calls(benchmark: Any) -> None:
 
     result = benchmark(lookup)
     assert result == len(dts)
+
+
+def test_timezone_deepcopy() -> None:
+    """Verify that TzInfo and Timezone objects can be deepcopied safely."""
+    import copy
+    from ical.tzif import timezoneinfo
+
+    # 1. Test TzInfo deepcopy
+    tz = timezoneinfo.read_tzinfo("America/New_York")
+    copied_tz = copy.deepcopy(tz)
+    assert copied_tz._key == tz._key
+    assert copied_tz._rule == tz._rule
+
+    # 2. Test Timezone component deepcopy
+    timezone = _customized_timezone()
+    # Trigger cache initialization
+    timezone.get_observance(datetime.datetime(2024, 7, 15, 12, 0, 0))
+    assert timezone._observance_timeline is not None
+    initial_cache_len = len(timezone._observance_timeline._cache)
+    assert initial_cache_len > 0
+
+    copied_timezone = copy.deepcopy(timezone)
+    assert copied_timezone._observance_timeline is not None
+    # CachedTransitionTimeline.__deepcopy__ resets the cache to empty to be rebuilt lazily
+    assert len(copied_timezone._observance_timeline._cache) == 0
+
+    summer = copied_timezone.get_observance(datetime.datetime(2024, 7, 15, 12, 0, 0))
+    assert summer is not None
+    assert summer.observance.tz_offset_to.offset == datetime.timedelta(hours=2)
+    assert len(copied_timezone._observance_timeline._cache) > 0


### PR DESCRIPTION
This PR adds `__deepcopy__` support on the custom `TzInfo` class (subclass of `datetime.tzinfo`), allowing safe deepcopying during nested Pydantic property expansions.