### PR TITLE
Add validations to recurrence rules (RFC 5545)

### DIFF
--- a/ical/types/recur.py
+++ b/ical/types/recur.py
@@ -49,6 +49,7 @@ from pydantic import (
     Field,
     GetCoreSchemaHandler,
     field_serializer,
+    field_validator,
 )
 from pydantic_core import CoreSchema, core_schema
 
@@ -92,6 +93,15 @@ class WeekdayValue:
     YEARLY "RRULE". For example +1 represents the first Monday of the
     month, or -1 represents the last Monday of the month.
     """
+
+    def __post_init__(self) -> None:
+        """Validate properties."""
+        if self.occurrence is not None and (
+            self.occurrence < -53 or self.occurrence > 53 or self.occurrence == 0
+        ):
+            raise ValueError(
+                f"Weekday occurrence must be between -53 and 53 (excluding 0): {self.occurrence}"
+            )
 
     def __str__(self) -> str:
         """Return the WeekdayValue as an encoded string."""
@@ -277,6 +287,66 @@ class Recur(BaseModel):
 
     wkst: Optional[Weekday] = None
     """The day on which the workweek starts."""
+
+    @field_validator("interval")
+    @classmethod
+    def validate_interval(cls, value: int) -> int:
+        """Validate interval is positive."""
+        if value < 1:
+            raise ValueError(f"Interval must be a positive integer: {value}")
+        return value
+
+    @field_validator("count")
+    @classmethod
+    def validate_count(cls, value: Optional[int]) -> Optional[int]:
+        """Validate count is positive."""
+        if value is not None and value < 1:
+            raise ValueError(f"Count must be a positive integer: {value}")
+        return value
+
+    @field_validator("by_month")
+    @classmethod
+    def validate_by_month(cls, values: list[int]) -> list[int]:
+        """Validate bymonth is between 1 and 12."""
+        for val in values:
+            if val < 1 or val > 12:
+                raise ValueError(f"Month must be between 1 and 12: {val}")
+        return values
+
+    @field_validator("by_month_day")
+    @classmethod
+    def validate_by_month_day(cls, values: list[int]) -> list[int]:
+        """Validate bymonthday is between -31 and 31 (excluding 0)."""
+        for val in values:
+            if val < -31 or val > 31 or val == 0:
+                raise ValueError(
+                    f"Month day must be between -31 and 31 (excluding 0): {val}"
+                )
+        return values
+
+    @field_validator("by_setpos")
+    @classmethod
+    def validate_by_setpos(cls, values: list[int]) -> list[int]:
+        """Validate bysetpos is between -366 and 366 (excluding 0)."""
+        for val in values:
+            if val < -366 or val > 366 or val == 0:
+                raise ValueError(
+                    f"Setpos must be between -366 and 366 (excluding 0): {val}"
+                )
+        return values
+
+    @field_validator("by_weekday")
+    @classmethod
+    def validate_by_weekday(cls, values: list[WeekdayValue]) -> list[WeekdayValue]:
+        """Validate byday occurrence is between -53 and 53 (excluding 0)."""
+        for val in values:
+            if val.occurrence is not None and (
+                val.occurrence < -53 or val.occurrence > 53 or val.occurrence == 0
+            ):
+                raise ValueError(
+                    f"Weekday occurrence must be between -53 and 53 (excluding 0): {val.occurrence}"
+                )
+        return values
 
     def as_rrule(self, dtstart: datetime.datetime | datetime.date) -> rrule.rrule:
         """Create a dateutil rrule for the specified event."""

--- a/tests/types/test_recur.py
+++ b/tests/types/test_recur.py
@@ -6,6 +6,8 @@ import datetime
 import zoneinfo
 
 import pytest
+from pydantic import ValidationError
+from typing import Any
 from ical.exceptions import CalendarParseError
 
 from ical.calendar import Calendar
@@ -974,3 +976,55 @@ def test_recur_freq_hourly() -> None:
         datetime.datetime(2022, 8, 29, 11, 0, 0),
         datetime.datetime(2022, 8, 29, 13, 0, 0),
     ]
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"interval": 0}, "Interval must be a positive integer"),
+        ({"interval": -5}, "Interval must be a positive integer"),
+        ({"count": 0}, "Count must be a positive integer"),
+        ({"count": -1}, "Count must be a positive integer"),
+        ({"bymonth": [0]}, "Month must be between 1 and 12"),
+        ({"bymonth": [13]}, "Month must be between 1 and 12"),
+        ({"bymonthday": [0]}, "Month day must be between -31 and 31"),
+        ({"bymonthday": [32]}, "Month day must be between -31 and 31"),
+        ({"bymonthday": [-32]}, "Month day must be between -31 and 31"),
+        ({"bysetpos": [0]}, "Setpos must be between -366 and 366"),
+        ({"bysetpos": [367]}, "Setpos must be between -366 and 366"),
+        ({"bysetpos": [-367]}, "Setpos must be between -366 and 366"),
+    ],
+)
+def test_recur_validation_errors(kwargs: dict[str, Any], match: str) -> None:
+    """Test validations for recurrence rules constructor."""
+    with pytest.raises(ValidationError, match=match):
+        Recur(freq=Frequency.DAILY, **kwargs)
+
+
+@pytest.mark.parametrize(
+    "rrule_str,match",
+    [
+        ("FREQ=DAILY;INTERVAL=0", "Interval must be a positive integer"),
+        ("FREQ=DAILY;COUNT=0", "Count must be a positive integer"),
+        ("FREQ=YEARLY;BYMONTH=13", "Month must be between 1 and 12"),
+        ("FREQ=MONTHLY;BYMONTHDAY=0", "Month day must be between -31 and 31"),
+        ("FREQ=MONTHLY;BYMONTHDAY=32", "Month day must be between -31 and 31"),
+        ("FREQ=MONTHLY;BYSETPOS=0", "Setpos must be between -366 and 366"),
+        ("FREQ=MONTHLY;BYSETPOS=-367", "Setpos must be between -366 and 366"),
+        ("FREQ=YEARLY;BYDAY=54MO", "Weekday occurrence must be between -53 and 53"),
+        ("FREQ=YEARLY;BYDAY=-54MO", "Weekday occurrence must be between -53 and 53"),
+    ],
+)
+def test_recur_from_rrule_validation_errors(rrule_str: str, match: str) -> None:
+    """Test validations for recurrence rules parsed from strings."""
+    with pytest.raises(ValidationError, match=match):
+        Recur.from_rrule(rrule_str)
+
+
+@pytest.mark.parametrize("occurrence", [0, 54, -54])
+def test_weekday_value_validation_errors(occurrence: int) -> None:
+    """Test validations for weekday occurrence range limits."""
+    with pytest.raises(
+        ValueError, match="Weekday occurrence must be between -53 and 53"
+    ):
+        WeekdayValue(Weekday.MONDAY, occurrence)


### PR DESCRIPTION
Enforces RFC 5545 constraints on BY* fields for recurrence rules using Pydantic field validators and WeekdayValue validations. Fixes #80.