### PR TITLE
feat(compat): allow parsing DATE properties with time suffixes (#576)

### DIFF
--- a/ical/compat/date_compat.py
+++ b/ical/compat/date_compat.py
@@ -1,0 +1,22 @@
+"""Compatibility layer for allowing invalid date formats in iCalendar files."""
+
+from collections.abc import Generator
+import contextlib
+import contextvars
+
+_invalid_dates = contextvars.ContextVar("invalid_dates", default=False)
+
+
+@contextlib.contextmanager
+def enable_allow_invalid_dates() -> Generator[None]:
+    """Context manager to allow invalid dates in iCalendar files."""
+    token = _invalid_dates.set(True)
+    try:
+        yield
+    finally:
+        _invalid_dates.reset(token)
+
+
+def is_allow_invalid_dates_enabled() -> bool:
+    """Check if allowing invalid dates is enabled."""
+    return _invalid_dates.get()

--- a/ical/compat/make_compat.py
+++ b/ical/compat/make_compat.py
@@ -9,7 +9,7 @@ from collections.abc import Generator
 import logging
 import re
 
-from . import dtstart_until_compat, same_day_dtend_compat, timezone_compat
+from . import date_compat, dtstart_until_compat, same_day_dtend_compat, timezone_compat
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,7 +35,10 @@ def enable_compat_mode(ics: str) -> Generator[str]:
     """Enable compatibility mode to fix known broken calendar content."""
     # Always enable same-day DTEND compatibility for all calendars
     # This is a common issue across many calendar providers
-    with same_day_dtend_compat.enable_same_day_dtend_compat():
+    with (
+        same_day_dtend_compat.enable_same_day_dtend_compat(),
+        date_compat.enable_allow_invalid_dates(),
+    ):
         # Check if the PRODID is from Microsoft Exchange Server
         prodid = _get_prodid(ics)
 

--- a/ical/types/date.py
+++ b/ical/types/date.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import re
 from typing import Any
+from ical.compat.date_compat import is_allow_invalid_dates_enabled
 
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 
@@ -27,7 +28,13 @@ class DateEncoder:
     @classmethod
     def __parse_property_value__(cls, prop: ParsedProperty) -> datetime.date | None:
         """Parse a rfc5545 into a datetime.date."""
-        if not (match := DATE_REGEX.fullmatch(prop.value)):
+        val = prop.value
+        if len(val) > 8 and "T" in val:
+            if is_allow_invalid_dates_enabled():
+                _LOGGER.debug("Stripping time suffix from DATE value: %s", prop.value)
+                val = val.split("T")[0]
+
+        if not (match := DATE_REGEX.fullmatch(val)):
             raise ValueError(f"Expected value to match DATE pattern: '{prop.value}'")
         date_value = match.group(1)
         year = int(date_value[0:4])

--- a/tests/compat/test_date_compat.py
+++ b/tests/compat/test_date_compat.py
@@ -1,0 +1,60 @@
+"""Tests for the invalid date parsing compatibility component."""
+
+import datetime
+import pytest
+
+from ical.exceptions import CalendarParseError
+from ical.calendar_stream import IcsCalendarStream
+from ical.compat import enable_compat_mode, date_compat
+
+INVALID_DATE_ICS = """BEGIN:VCALENDAR
+PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+VERSION:2.0
+BEGIN:VEVENT
+DTSTAMP:19970610T172345Z
+UID:19970610T172345Z-AF23B2@example.com
+DTSTART;VALUE=DATE:20260920T080000
+DTEND;VALUE=DATE:20260920T160000
+SUMMARY:Value Date Event
+END:VEVENT
+END:VCALENDAR"""
+
+
+def test_invalid_date_parsing_fail() -> None:
+    """Test that parsing fails under normal mode for DATE with time suffix."""
+    with pytest.raises(
+        CalendarParseError,
+        match="Expected value to match DATE pattern: '20260920T080000'",
+    ):
+        IcsCalendarStream.calendar_from_ics(INVALID_DATE_ICS)
+
+
+def test_invalid_date_parsing_compat_mode() -> None:
+    """Test that parsing succeeds under compat mode for DATE with time suffix."""
+    with enable_compat_mode(INVALID_DATE_ICS) as compat_ics:
+        calendar = IcsCalendarStream.calendar_from_ics(compat_ics)
+
+    assert len(calendar.events) == 1
+    event = calendar.events[0]
+    assert event.dtstart is not None
+    assert event.dtend is not None
+    # Verify that DTSTART/DTEND were parsed as dates and stripped of their time suffix
+    assert event.dtstart.year == 2026
+    assert event.dtstart.month == 9
+    assert event.dtstart.day == 20
+    assert event.dtend.year == 2026
+    assert event.dtend.month == 9
+    assert event.dtend.day == 21
+
+
+def test_invalid_date_parsing_direct_compat() -> None:
+    """Test that parsing succeeds directly with enable_allow_invalid_dates context manager."""
+    with date_compat.enable_allow_invalid_dates():
+        calendar = IcsCalendarStream.calendar_from_ics(INVALID_DATE_ICS)
+
+    assert len(calendar.events) == 1
+    event = calendar.events[0]
+    assert event.dtstart is not None
+    assert event.dtstart.year == 2026
+    assert event.dtstart.month == 9
+    assert event.dtstart.day == 20


### PR DESCRIPTION
This PR resolves #576 by introducing a compatibility flag to silently strip the time suffix from DATE properties (e.g., `DTSTART;VALUE=DATE:20260920T080000`) when compatibility mode is enabled.