### PR TITLE
chore: improve code quality, public API documentation and test coverage

### DIFF
--- a/ical/alarm.py
+++ b/ical/alarm.py
@@ -11,6 +11,9 @@ from .types import Attachment, CalAddress, ExtraProperty
 from .types.data_types import serialize_field
 
 
+__all__ = ["Alarm", "Action"]
+
+
 class Action(str, enum.Enum):
     """Type of actioninvoked when alarm is triggered."""
 

--- a/ical/calendar.py
+++ b/ical/calendar.py
@@ -34,9 +34,25 @@ _VERSION = "2.0"
 # Components that may contain TZID objects
 _TZID_COMPONENTS = ["vevent", "vtodo", "vjournal", "vfreebusy"]
 
+__all__ = ["Calendar"]
+
 
 class Calendar(ComponentModel):
-    """A sequence of calendar properties and calendar components."""
+    """A sequence of calendar properties and calendar components.
+
+    Example usage::
+
+        from datetime import date
+        from ical.calendar import Calendar
+        from ical.event import Event
+
+        calendar = Calendar()
+        calendar.events.append(
+            Event(summary="Meeting", start=date(2024, 1, 15), end=date(2024, 1, 16))
+        )
+        for event in calendar.timeline:
+            print(event.summary)
+    """
 
     calscale: Optional[str] = None
     method: Optional[str] = None
@@ -69,7 +85,9 @@ class Calendar(ComponentModel):
     def timeline(self) -> Timeline:
         """Return a timeline view of events on the calendar.
 
-        All day events are returned as if the attendee is viewing from UTC time.
+        All day events are returned as if the attendee is viewing from the
+        local system timezone. Use :meth:`timeline_tz` to specify a different
+        timezone.
         """
         return self.timeline_tz()
 

--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -40,6 +40,8 @@ from pydantic import ConfigDict
 
 _LOGGER = logging.getLogger(__name__)
 
+__all__ = ["CalendarStream", "IcsCalendarStream"]
+
 
 class CalendarStream(ComponentModel):
     """A container that is a collection of calendaring information.

--- a/ical/compat/timezone_compat.py
+++ b/ical/compat/timezone_compat.py
@@ -5,7 +5,7 @@ import contextlib
 import contextvars
 
 
-_invalide_timezones = contextvars.ContextVar("invalid_timezones", default=False)
+_invalid_timezones = contextvars.ContextVar("invalid_timezones", default=False)
 _extended_timezones = contextvars.ContextVar("extended_timezones", default=False)
 
 
@@ -27,13 +27,13 @@ def is_extended_timezones_enabled() -> bool:
 @contextlib.contextmanager
 def enable_allow_invalid_timezones() -> Generator[None]:
     """Context manager to allow invalid timezones in iCalendar files."""
-    token = _invalide_timezones.set(True)
+    token = _invalid_timezones.set(True)
     try:
         yield
     finally:
-        _invalide_timezones.reset(token)
+        _invalid_timezones.reset(token)
 
 
 def is_allow_invalid_timezones_enabled() -> bool:
     """Check if allowing invalid timezones is enabled."""
-    return _invalide_timezones.get()
+    return _invalid_timezones.get()

--- a/ical/event.py
+++ b/ical/event.py
@@ -59,6 +59,8 @@ from .util import (
 
 _LOGGER = logging.getLogger(__name__)
 
+__all__ = ["Event", "EventStatus"]
+
 
 class EventStatus(str, enum.Enum):
     """Status or confirmation of the event set by the organizer."""
@@ -286,7 +288,11 @@ class Event(ComponentModel):
     @property
     def start(self) -> datetime.datetime | datetime.date:
         """Return the start time for the event."""
-        assert self.dtstart is not None
+        if self.dtstart is None:
+            raise AttributeError(
+                "Event.start accessed before dtstart was set; "
+                "ensure the event was fully validated before use."
+            )
         return self.dtstart
 
     @property

--- a/ical/exceptions.py
+++ b/ical/exceptions.py
@@ -1,5 +1,15 @@
 """Exceptions for ical library."""
 
+__all__ = [
+    "CalendarError",
+    "CalendarParseError",
+    "ParameterValueError",
+    "RecurrenceError",
+    "StoreError",
+    "EventStoreError",
+    "TodoStoreError",
+]
+
 
 class CalendarError(Exception):
     """Base exception for all ical errors."""
@@ -34,6 +44,11 @@ class ParameterValueError(ValueError):
     timezone, and fails to be a date, because it is a datetime. Rather
     than continue trying to validate it as a date, raise ParameterValueError
     to stop, and simply return a single error.
+
+    Note: This exception intentionally extends ``ValueError`` rather than
+    ``CalendarError``. This allows pydantic's validation pipeline to catch it
+    during field validation. Callers catching ``CalendarError`` will **not**
+    catch this exception.
     """
 
 
@@ -49,12 +64,23 @@ class RecurrenceError(CalendarError):
 
 
 class StoreError(CalendarError):
-    """Exception thrown by a Store."""
+    """Exception raised by store operations.
+
+    Raised when a store operation fails, for example when trying to edit
+    or delete an event that does not exist, or when timezone information
+    cannot be resolved for a datetime value being added to the calendar.
+    """
 
 
 class EventStoreError(StoreError):
-    """Exception thrown by the EventStore."""
+    """Exception raised by EventStore operations.
+
+    Raised by :class:`ical.store.EventStore` when an event operation fails.
+    """
 
 
 class TodoStoreError(StoreError):
-    """Exception thrown by the TodoStore."""
+    """Exception raised by TodoStore operations.
+
+    Raised by :class:`ical.store.TodoStore` when a todo operation fails.
+    """

--- a/ical/freebusy.py
+++ b/ical/freebusy.py
@@ -23,6 +23,8 @@ from .util import (
 
 _LOGGER = logging.getLogger(__name__)
 
+__all__ = ["FreeBusy"]
+
 
 class FreeBusy(ComponentModel):
     """A single free/busy entry on a calendar."""

--- a/ical/iter.py
+++ b/ical/iter.py
@@ -377,7 +377,10 @@ class SortableItemTimeline(Iterable[T]):
         """Return an iterator containing events starting after the specified time."""
         instant_value = normalize_datetime(instant)
         if not instant_value.tzinfo:
-            raise ValueError("Expected tzinfo to be set on normalized datetime")
+            raise ValueError(
+                "Expected a timezone-aware datetime; pass a datetime with tzinfo set "
+                "(e.g. datetime.datetime.now(tz=zoneinfo.ZoneInfo('America/Los_Angeles')))"
+            )
         for item in self._iterable:
             if item.key.start > instant_value:
                 yield item.item
@@ -389,7 +392,10 @@ class SortableItemTimeline(Iterable[T]):
         """Return an iterator containing events active after the specified time."""
         instant_value = normalize_datetime(instant)
         if not instant_value.tzinfo:
-            raise ValueError("Expected tzinfo to be set on normalized datetime")
+            raise ValueError(
+                "Expected a timezone-aware datetime; pass a datetime with tzinfo set "
+                "(e.g. datetime.datetime.now(tz=zoneinfo.ZoneInfo('America/Los_Angeles')))"
+            )
         for item in self._iterable:
             if item.key.start > instant_value or item.key.end > instant_value:
                 yield item.item
@@ -397,8 +403,8 @@ class SortableItemTimeline(Iterable[T]):
     def at_instant(
         self,
         instant: datetime.date | datetime.datetime,
-    ) -> Iterator[T]:  # pylint: disable
-        """Return an iterator containing events starting after the specified time."""
+    ) -> Iterator[T]:
+        """Return an iterator containing events active at the specified instant."""
         timespan = Timespan.of(instant, instant)
         for item in self._iterable:
             if item.key.includes(timespan):
@@ -406,16 +412,16 @@ class SortableItemTimeline(Iterable[T]):
             elif item.key > timespan:
                 break
 
-    def on_date(self, day: datetime.date) -> Iterator[T]:  # pylint: disable
+    def on_date(self, day: datetime.date) -> Iterator[T]:
         """Return an iterator containing all events active on the specified day."""
         return self.overlapping(day, day + datetime.timedelta(days=1))
 
     def today(self) -> Iterator[T]:
-        """Return an iterator containing all events active on the specified day."""
+        """Return an iterator containing all events active today."""
         return self.on_date(datetime.date.today())
 
     def now(self, tz: datetime.tzinfo | None = None) -> Iterator[T]:
-        """Return an iterator containing all events active on the specified day."""
+        """Return an iterator containing all events active at the current instant."""
         return self.at_instant(datetime.datetime.now(tz=tz))
 
 

--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -41,7 +41,7 @@ import re
 import datetime
 from dataclasses import dataclass
 from collections.abc import Iterator, Generator, Iterable
-from typing import Optional, Union, Sequence, Iterable
+from typing import Optional, Union, Sequence
 
 from ical.exceptions import CalendarParseError
 

--- a/ical/recurrence.py
+++ b/ical/recurrence.py
@@ -38,6 +38,8 @@ from .types.period import Period
 
 _LOGGER = logging.getLogger(__name__)
 
+__all__ = ["Recurrences"]
+
 
 class Recurrences(ComponentModel):
     """A common set of recurrence related properties for calendar components."""

--- a/ical/store.py
+++ b/ical/store.py
@@ -125,7 +125,7 @@ def _prepare_update(
     recurrence_id: str | None = None,
     recurrence_range: Range = Range.NONE,
 ) -> dict[str, Any]:
-    """Prepare an update to an existing event."""
+    """Prepare an update to an existing event or todo."""
     partial_update = item.model_dump(
         exclude_unset=True,
         exclude={"dtstamp", "uid", "sequence", "created", "last_modified"},
@@ -185,7 +185,7 @@ def _prepare_update(
 
 
 class GenericStore(Generic[_T]):
-    """A a store manages the lifecycle of items on a Calendar."""
+    """A store manages the lifecycle of items on a Calendar."""
 
     def __init__(
         self,
@@ -360,8 +360,8 @@ class GenericStore(Generic[_T]):
         when encoded.
         """
         items_to_edit: list[tuple[int, _T]] = [
-            (index, item)
-            for index, item in _match_items(self._items, uid, recurrence_id)
+            (store_idx, store_itm)
+            for store_idx, store_itm in _match_items(self._items, uid, recurrence_id)
         ]
         if not items_to_edit:
             raise self._exc(

--- a/ical/timeline.py
+++ b/ical/timeline.py
@@ -24,6 +24,13 @@ from .recur_adapter import merge_and_expand_items, ItemType
 __all__ = ["Timeline", "generic_timeline"]
 
 Timeline = SortableItemTimeline[Event]
+"""A timeline of :class:`ical.event.Event` objects.
+
+Supports iteration and range queries such as
+:meth:`~ical.iter.SortableItemTimeline.on_date`,
+:meth:`~ical.iter.SortableItemTimeline.overlapping`, and
+:meth:`~ical.iter.SortableItemTimeline.at_instant`.
+"""
 
 
 def calendar_timeline(events: list[Event], tzinfo: datetime.tzinfo) -> Timeline:
@@ -34,11 +41,11 @@ def calendar_timeline(events: list[Event], tzinfo: datetime.tzinfo) -> Timeline:
 def generic_timeline(
     items: list[ItemType], tzinfo: datetime.tzinfo
 ) -> SortableItemTimeline[ItemType]:
-    """Return a timeline view of events on the calendar.
+    """Return a timeline view of the given items.
 
-    All events are returned as if the attendee is viewing from the
-    specified timezone. For example, this affects the order that All Day
-    events are returned.
+    Works with any :data:`ical.recur_adapter.ItemType` (events, todos, etc.).
+    All items are returned as if viewed from the specified timezone — for
+    example, this affects the order that all-day items are returned.
     """
     return SortableItemTimeline(
         merge_and_expand_items(

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -59,6 +59,8 @@ from .util import (
 
 _LOGGER = logging.getLogger(__name__)
 
+__all__ = ["Todo", "TodoStatus"]
+
 
 class TodoStatus(str, enum.Enum):
     """Status or confirmation of the to-do."""

--- a/tests/__snapshots__/test_store.ambr
+++ b/tests/__snapshots__/test_store.ambr
@@ -258,6 +258,50 @@
     'mock-uid-4',
   ])
 # ---
+# name: test_delete_partial_recurring_event[recur0]
+  list([
+    dict({
+      'dtstart': '2022-08-29T09:00:00',
+      'recurrence_id': '20220829T090000',
+      'summary': 'Monday meeting',
+      'uid': 'mock-uid-1',
+    }),
+    dict({
+      'dtstart': '2022-09-12T09:00:00',
+      'recurrence_id': '20220912T090000',
+      'summary': 'Monday meeting',
+      'uid': 'mock-uid-1',
+    }),
+    dict({
+      'dtstart': '2022-09-26T09:00:00',
+      'recurrence_id': '20220926T090000',
+      'summary': 'Monday meeting',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
+# name: test_delete_partial_recurring_event[recur1]
+  list([
+    dict({
+      'dtstart': '2022-08-29T09:00:00',
+      'recurrence_id': '20220829T090000',
+      'summary': 'Monday meeting',
+      'uid': 'mock-uid-1',
+    }),
+    dict({
+      'dtstart': '2022-09-12T09:00:00',
+      'recurrence_id': '20220912T090000',
+      'summary': 'Monday meeting',
+      'uid': 'mock-uid-1',
+    }),
+    dict({
+      'dtstart': '2022-09-26T09:00:00',
+      'recurrence_id': '20220926T090000',
+      'summary': 'Monday meeting',
+      'uid': 'mock-uid-1',
+    }),
+  ])
+# ---
 # name: test_delete_this_and_future_all_day_event[recur0]
   list([
     dict({
@@ -341,50 +385,6 @@
     dict({
       'dtstart': '2022-09-12T09:00:00',
       'recurrence_id': '20220912T090000',
-      'summary': 'Monday meeting',
-      'uid': 'mock-uid-1',
-    }),
-  ])
-# ---
-# name: test_deletel_partial_recurring_event[recur0]
-  list([
-    dict({
-      'dtstart': '2022-08-29T09:00:00',
-      'recurrence_id': '20220829T090000',
-      'summary': 'Monday meeting',
-      'uid': 'mock-uid-1',
-    }),
-    dict({
-      'dtstart': '2022-09-12T09:00:00',
-      'recurrence_id': '20220912T090000',
-      'summary': 'Monday meeting',
-      'uid': 'mock-uid-1',
-    }),
-    dict({
-      'dtstart': '2022-09-26T09:00:00',
-      'recurrence_id': '20220926T090000',
-      'summary': 'Monday meeting',
-      'uid': 'mock-uid-1',
-    }),
-  ])
-# ---
-# name: test_deletel_partial_recurring_event[recur1]
-  list([
-    dict({
-      'dtstart': '2022-08-29T09:00:00',
-      'recurrence_id': '20220829T090000',
-      'summary': 'Monday meeting',
-      'uid': 'mock-uid-1',
-    }),
-    dict({
-      'dtstart': '2022-09-12T09:00:00',
-      'recurrence_id': '20220912T090000',
-      'summary': 'Monday meeting',
-      'uid': 'mock-uid-1',
-    }),
-    dict({
-      'dtstart': '2022-09-26T09:00:00',
-      'recurrence_id': '20220926T090000',
       'summary': 'Monday meeting',
       'uid': 'mock-uid-1',
     }),

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -305,7 +305,71 @@ def test_date_intersects(
     range2: tuple[date, date],
     expected: bool,
 ) -> None:
-    """Test event intersection."""
+    """Test event intersection with date-type start/end values."""
+    event1 = Event(summary=SUMMARY, start=range1[0], end=range1[1])
+    event2 = Event(summary=SUMMARY, start=range2[0], end=range2[1])
+    assert event1.intersects(event2) == expected
+
+
+@pytest.mark.parametrize(
+    "range1,range2,expected",
+    [
+        # Overlapping datetime events (UTC)
+        (
+            (
+                datetime(2022, 8, 1, 9, 0, tzinfo=timezone.utc),
+                datetime(2022, 8, 1, 10, 0, tzinfo=timezone.utc),
+            ),
+            (
+                datetime(2022, 8, 1, 9, 30, tzinfo=timezone.utc),
+                datetime(2022, 8, 1, 11, 0, tzinfo=timezone.utc),
+            ),
+            True,
+        ),
+        # Non-overlapping datetime events (UTC)
+        (
+            (
+                datetime(2022, 8, 1, 9, 0, tzinfo=timezone.utc),
+                datetime(2022, 8, 1, 10, 0, tzinfo=timezone.utc),
+            ),
+            (
+                datetime(2022, 8, 1, 11, 0, tzinfo=timezone.utc),
+                datetime(2022, 8, 1, 12, 0, tzinfo=timezone.utc),
+            ),
+            False,
+        ),
+        # Exact boundary — adjacent events do NOT intersect (half-open intervals)
+        (
+            (
+                datetime(2022, 8, 1, 9, 0, tzinfo=timezone.utc),
+                datetime(2022, 8, 1, 10, 0, tzinfo=timezone.utc),
+            ),
+            (
+                datetime(2022, 8, 1, 10, 0, tzinfo=timezone.utc),
+                datetime(2022, 8, 1, 11, 0, tzinfo=timezone.utc),
+            ),
+            False,
+        ),
+        # Cross-timezone: same instant, different tzinfo — should intersect
+        (
+            (
+                datetime(2022, 8, 1, 9, 0, tzinfo=timezone.utc),
+                datetime(2022, 8, 1, 10, 0, tzinfo=timezone.utc),
+            ),
+            (
+                datetime(2022, 8, 1, 2, 0, tzinfo=timezone(timedelta(hours=-7))),
+                datetime(2022, 8, 1, 3, 30, tzinfo=timezone(timedelta(hours=-7))),
+            ),
+            True,
+        ),
+    ],
+)
+def test_datetime_intersects(
+    range1: tuple[datetime, datetime],
+    range2: tuple[datetime, datetime],
+    expected: bool,
+) -> None:
+    """Test event intersection with datetime-type (aware) start/end values."""
     event1 = Event(summary=SUMMARY, start=range1[0], end=range1[1])
     event2 = Event(summary=SUMMARY, start=range2[0], end=range2[1])
     assert event1.intersects(event2) == expected

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -219,7 +219,7 @@ def test_recurring_event(
         Recur.from_rrule("FREQ=WEEKLY;COUNT=5"),
     ],
 )
-def test_deletel_partial_recurring_event(
+def test_delete_partial_recurring_event(
     store: EventStore,
     fetch_events: Callable[..., list[dict[str, Any]]],
     recur: Recur,


### PR DESCRIPTION
## Summary

A collection of targeted code quality improvements identified during a comprehensive codebase review. All changes are low-risk and the test suite passes cleanly (1,359 tests, +4 new).

## Changes

### Correctness Fixes
- **`event.py`**: Replace `assert self.dtstart is not None` with a proper `raise AttributeError` — assertions are stripped in `python -O` production mode, making this safety check silently disappear
- **`compat/timezone_compat.py`**: Fix typo `_invalide_timezones` → `_invalid_timezones` (all 3 occurrences: declaration, `set()`, `reset()`, `get()`)
- **`parsing/property.py`**: Remove duplicate `Iterable` import that was shadowing the `collections.abc` version with `typing`

### Public API — `__all__` Consistency
Add `__all__` to 8 public modules that were missing it, making the public API surface explicit for IDEs, `pydoc`, and type checkers:
`calendar`, `event`, `todo`, `alarm`, `freebusy`, `calendar_stream`, `recurrence`, `exceptions`

### Docstring & Documentation Fixes
- **`iter.py`**: Fix `now()` and `today()` (both had identical, wrong text); fix `at_instant()` (said "starting after", means "active at"); remove two no-op `# pylint: disable` comments; improve `start_after`/`active_after` error messages with actionable guidance
- **`timeline.py`**: Add docstring to `Timeline` type alias; fix `generic_timeline()` (said "calendar events", works on any `ItemType`)
- **`calendar.py`**: Fix `timeline` property docstring (said "UTC", actually uses local timezone); add usage example to `Calendar` class docstring
- **`store.py`**: Fix "A a store" typo in `GenericStore`; fix `_prepare_update` docstring (said "event", handles both events and todos); rename shadowed `item`/`index` variables in `edit()` list comprehension
- **`exceptions.py`**: Add clarifying note to `ParameterValueError` explaining its intentional `ValueError` (not `CalendarError`) hierarchy; expand `StoreError`/`EventStoreError`/`TodoStoreError` docstrings

### Test Hygiene
- Fix test function name typo: `test_deletel_partial_recurring_event` → `test_delete_partial_recurring_event`; update snapshots
- Add `test_datetime_intersects`: 4 parametrized cases covering overlapping, non-overlapping, exact boundary, and cross-timezone aware datetime intersection

## Test Results
```
1359 passed, 30 skipped (benchmarks), 232 snapshots passed
```