### PR TITLE
fix: support TZID parameter in RecurrenceId (closes #480)

### DIFF
--- a/ical/store.py
+++ b/ical/store.py
@@ -92,9 +92,13 @@ def _match_item(item: _T, uid: str, recurrence_id: str | None) -> bool:
     if isinstance(dtstart, datetime.datetime) and isinstance(
         item.dtstart, datetime.datetime
     ):
-        # The recurrence_id does not support timezone information, so put it in the
-        # same timezone as the item to compare.
-        if item.dtstart.tzinfo is not None:
+        if dtstart.tzinfo is not None:
+            # The recurrence_id carries an explicit TZID: the datetime is already
+            # tz-aware, so no further adjustment is needed for comparison.
+            pass
+        elif item.dtstart.tzinfo is not None:
+            # No explicit TZID was supplied; fall back to the item's own timezone
+            # so the wall-clock time comparison is correct.
             dtstart = dtstart.replace(tzinfo=item.dtstart.tzinfo)
     for dt in cast(Any, item).as_rrule() or ():
         if isinstance(dt, datetime.datetime):
@@ -306,13 +310,14 @@ class GenericStore(Generic[_T]):
         if recurrence_range == Range.NONE:
             # A single recurrence instance is removed. Add an exclusion to
             # to the event.
-            # RecurrenceId does not support timezone information. The exclusion
-            # must have the same timezone as the item to compare.
             if (
                 isinstance(exdate, datetime.datetime)
                 and isinstance(store_item.dtstart, datetime.datetime)
-                and store_item.dtstart.tzinfo
+                and exdate.tzinfo is None
+                and store_item.dtstart.tzinfo is not None
             ):
+                # No explicit TZID was carried by the recurrence_id, so align
+                # the exdate to the item's timezone for a correct comparison.
                 exdate = exdate.replace(tzinfo=store_item.dtstart.tzinfo)
             store_item.exdate.append(exdate)
             return

--- a/ical/types/recur.py
+++ b/ical/types/recur.py
@@ -38,6 +38,7 @@ import datetime
 import enum
 import logging
 import re
+import zoneinfo
 from dataclasses import dataclass
 from typing import Annotated, Any, Literal, Optional, Union
 
@@ -163,11 +164,47 @@ class RecurrenceId(str):
 
     The full range of a recurrence set is referenced by the "UID". The
     recurrence id can reference a specific instance within the set.
+
+    The string value of a RecurrenceId is always the plain date/datetime string
+    (e.g. ``"20250511T020000"``), keeping full backwards compatibility with code
+    that compares or serialises the value as a plain string.  Additional RFC 5545
+    property parameters are exposed through the :attr:`tzinfo` and :attr:`range`
+    attributes.
     """
+
+    tzinfo: datetime.tzinfo | None
+    """Timezone parsed from the TZID property parameter, or None."""
+
+    range: Range
+    """Effective range parsed from the RANGE property parameter."""
+
+    def __new__(
+        cls,
+        value: str,
+        tzinfo: datetime.tzinfo | None = None,
+        range: Range = Range.NONE,
+    ) -> "RecurrenceId":
+        """Create a new RecurrenceId, optionally attaching TZID/RANGE metadata."""
+        obj = super().__new__(cls, value)
+        obj.tzinfo = tzinfo
+        obj.range = range
+        return obj
 
     @classmethod
     def to_value(cls, recurrence_id: str) -> datetime.datetime | datetime.date:
-        """Convert a string RecurrenceId into a date or time value."""
+        """Convert a string RecurrenceId into a date or time value.
+
+        Accepts three formats:
+
+        - Plain date: '20250511'
+        - Plain datetime (naive or UTC): '20250511T020000' or '20250511T020000Z'
+        - Inline TZID parameter: 'TZID=America/New_York:20250511T020000'
+        """
+        # Handle the inline "TZID=tz:DATETIME" format by re-parsing via ParsedProperty
+        if "=" in recurrence_id.split(":")[0]:
+            prop = ParsedProperty.from_ics(f"RECURRENCE-ID;{recurrence_id}")
+            return DateTimeEncoder.__parse_property_value__(prop)
+
         errors = []
         try:
             date_value = DateEncoder.__parse_property_value__(
@@ -190,27 +227,58 @@ class RecurrenceId(str):
         raise ValueError(f"Unable to parse date/time value: {errors}")
 
     @classmethod
-    def __parse_property_value__(cls, value: Any) -> RecurrenceId:
-        """Parse a calendar user address."""
-        if isinstance(value, ParsedProperty):
-            value = cls._parse_value(value.value)
-        if isinstance(value, str):
-            value = cls._parse_value(value)
-        if isinstance(value, datetime.datetime):
-            value = DateTimeEncoder.__encode_property_json__(value)
-        elif isinstance(value, datetime.date):
-            value = DateEncoder.__encode_property_json__(value)
-        else:
-            value = str(value)
-        return RecurrenceId(value)
+    def __parse_property_value__(cls, value: Any) -> "RecurrenceId":
+        """Parse a recurrence-id property value, preserving TZID and RANGE params."""
+        # When Pydantic's before-validator runs after ComponentModel._parse_component
+        # has already invoked this method directly (via DATA_TYPE.parse_field), the
+        # value will already be a fully-populated RecurrenceId.  Pass it through
+        # unchanged so that tzinfo/range metadata is not lost.
+        if isinstance(value, RecurrenceId):
+            return value
 
-    @classmethod
-    def _parse_value(cls, value: str) -> datetime.datetime | datetime.date | str:
-        try:
-            return cls.to_value(value)
-        except ValueError:
-            pass
-        return str(value)
+        # Handle datetime/date objects directly (e.g. from recur_adapter._recurrence_id_for).
+        # Convert to the canonical ICS string first; datetime must be checked before date
+        # since datetime is a subclass of date.
+        if isinstance(value, datetime.datetime):
+            encoded = DateTimeEncoder.__encode_property_json__(value)
+            raw_str = (
+                encoded.get("VALUE", value.strftime("%Y%m%dT%H%M%S"))
+                if isinstance(encoded, dict)
+                else encoded
+            )
+        elif isinstance(value, datetime.date):
+            raw_str = DateEncoder.__encode_property_json__(value)
+        elif isinstance(value, ParsedProperty):
+            raw_str = value.value
+        else:
+            raw_str = str(value)
+
+        tzinfo: datetime.tzinfo | None = None
+        range_val: Range = Range.NONE
+
+        if isinstance(value, ParsedProperty):
+            # Extract TZID and RANGE from property parameters before discarding them.
+            for param in value.params or []:
+                if param.name.upper() == "TZID" and param.values:
+                    raw_tz = param.values[0]
+                    if isinstance(raw_tz, datetime.tzinfo):
+                        tzinfo = raw_tz
+                    else:
+                        try:
+                            tzinfo = zoneinfo.ZoneInfo(str(raw_tz))
+                        except (zoneinfo.ZoneInfoNotFoundError, ValueError):
+                            _LOGGER.warning(
+                                "RecurrenceId: unrecognised TZID '%s', ignoring", raw_tz
+                            )
+                elif param.name.upper() == "RANGE" and param.values:
+                    if any(str(v).upper() == "THISANDFUTURE" for v in param.values):
+                        range_val = Range.THIS_AND_FUTURE
+
+        # The string value is always the plain ICS datetime without TZID
+        # (e.g. "20250511T020000") for backward compatibility.  The timezone
+        # is accessible via the .tzinfo attribute.  Unparsable values are
+        # stored as-is.
+        return RecurrenceId(raw_str, tzinfo=tzinfo, range=range_val)
 
     @classmethod
     def __get_pydantic_core_schema__(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1946,3 +1946,123 @@ def test_control_characters(
     assert len(new_calendar.events) == 1
     persisted_event = new_calendar.events[0]
     assert persisted_event.summary == "Hello, you are seeing an invalid character  here"
+
+
+# ---------------------------------------------------------------------------
+# Issue #480 — RecurrenceId TZID parameter support
+# ---------------------------------------------------------------------------
+
+NY_TZ = zoneinfo.ZoneInfo("America/New_York")
+
+
+def _make_recurring_tz_event(uid: str, tzinfo: zoneinfo.ZoneInfo) -> Event:
+    """Create a simple weekly recurring event anchored in a specific timezone."""
+    return Event(
+        uid=uid,
+        summary="Weekly meeting",
+        start=datetime.datetime(2025, 5, 5, 10, 0, 0, tzinfo=tzinfo),
+        end=datetime.datetime(2025, 5, 5, 11, 0, 0, tzinfo=tzinfo),
+        rrule=Recur.from_rrule("FREQ=WEEKLY;COUNT=5"),
+    )
+
+
+def test_edit_recurring_event_with_tzid_recurrence_id(
+    calendar: Calendar,
+    store: EventStore,
+) -> None:
+    """Edit a single tz-aware recurring instance using an inline TZID recurrence_id.
+
+    Reproduces the failure from issue #480: ``store.edit`` raises because
+    ``RecurrenceId.to_value`` could not parse the TZID-prefixed string.
+    """
+    uid = "tz-meeting-uid"
+    store.add(_make_recurring_tz_event(uid, NY_TZ))
+
+    # Pass recurrence_id in the inline "TZID=tz:DATETIME" format from #480
+    recurrence_id = "TZID=America/New_York:20250512T100000"
+    store.edit(
+        uid=uid,
+        item=Event(summary="Weekly meeting (rescheduled)"),
+        recurrence_id=recurrence_id,
+    )
+
+    events = sorted(calendar.timeline, key=lambda e: e.dtstart)
+    summaries = [e.summary for e in events]
+    assert "Weekly meeting (rescheduled)" in summaries
+    assert summaries.count("Weekly meeting") == 4
+
+
+def test_delete_recurring_event_with_tzid_recurrence_id(
+    calendar: Calendar,
+    store: EventStore,
+) -> None:
+    """Delete a single tz-aware recurring instance using an inline TZID recurrence_id.
+
+    Reproduces the failure from issue #480 for the delete path.
+    """
+    uid = "tz-delete-uid"
+    store.add(_make_recurring_tz_event(uid, NY_TZ))
+
+    recurrence_id = "TZID=America/New_York:20250519T100000"
+    store.delete(uid=uid, recurrence_id=recurrence_id)
+
+    events = sorted(calendar.timeline, key=lambda e: e.dtstart)
+    assert len(events) == 4
+    starts = [e.dtstart for e in events]
+    deleted_dt = datetime.datetime(2025, 5, 19, 10, 0, 0, tzinfo=NY_TZ)
+    assert deleted_dt not in starts
+
+
+def test_edit_recurring_event_with_parsed_tzid_property(
+    calendar: Calendar,
+    store: EventStore,
+) -> None:
+    """Edit a recurring instance using a RecurrenceId parsed from a ParsedProperty with TZID.
+
+    Verifies the store correctly handles the ``RecurrenceId`` object enriched
+    with ``.tzinfo`` metadata (the path taken when reading from an .ics file).
+    """
+    from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
+    from ical.types.recur import RecurrenceId
+
+    uid = "tz-property-uid"
+    store.add(_make_recurring_tz_event(uid, NY_TZ))
+
+    # Simulate a RecurrenceId parsed from an ICS property with a TZID param.
+    rid_prop = ParsedProperty(
+        name="RECURRENCE-ID",
+        value="20250526T100000",
+        params=[ParsedPropertyParameter(name="TZID", values=["America/New_York"])],
+    )
+    rid = RecurrenceId.__parse_property_value__(rid_prop)
+    assert rid.tzinfo == NY_TZ
+
+    store.edit(
+        uid=uid,
+        item=Event(summary="Last instance updated"),
+        recurrence_id=rid,
+    )
+
+    events = sorted(calendar.timeline, key=lambda e: e.dtstart)
+    assert any(e.summary == "Last instance updated" for e in events)
+
+
+def test_recurrence_id_naive_fallback_still_works(
+    calendar: Calendar,
+    store: EventStore,
+) -> None:
+    """Verify that a naive recurrence_id string still matches a tz-aware series.
+
+    This is the pre-existing behaviour that must not regress: when the caller
+    does NOT supply a TZID, the item's own timezone is used for the comparison.
+    """
+    uid = "tz-naive-rid-uid"
+    store.add(_make_recurring_tz_event(uid, NY_TZ))
+
+    # Plain naive string — should still work via the fallback path
+    store.delete(uid=uid, recurrence_id="20250505T100000")
+
+    events = sorted(calendar.timeline, key=lambda e: e.dtstart)
+    assert len(events) == 4
+    first_dt = datetime.datetime(2025, 5, 5, 10, 0, 0, tzinfo=NY_TZ)
+    assert first_dt not in [e.dtstart for e in events]

--- a/tests/types/test_recur.py
+++ b/tests/types/test_recur.py
@@ -17,7 +17,7 @@ from ical.event import Event
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 from ical.timeline import Timeline
 from ical.todo import Todo
-from ical.types.recur import Frequency, Recur, RecurrenceId, Weekday, WeekdayValue
+from ical.types.recur import Frequency, Range, Recur, RecurrenceId, Weekday, WeekdayValue
 
 
 def recur_timeline(event: Event) -> Timeline:
@@ -55,8 +55,8 @@ def test_recurrence_id_date() -> None:
     assert model.recurrence_id == "20220724"
 
 
-def test_recurrence_id_ignore_params() -> None:
-    """Test property parameter values are ignored."""
+def test_recurrence_id_params_range() -> None:
+    """Test that RANGE=THISANDFUTURE is captured on the RecurrenceId."""
 
     model = FakeModel.model_validate(
         {
@@ -72,6 +72,91 @@ def test_recurrence_id_ignore_params() -> None:
         }
     )
     assert model.recurrence_id == "20220724T120000"
+    # The RANGE parameter is now preserved on the RecurrenceId instance.
+    assert model.recurrence_id.range == Range.THIS_AND_FUTURE
+
+
+def test_recurrence_id_tzid_param() -> None:
+    """Test that TZID property parameter is parsed and stored on RecurrenceId."""
+
+    ny_tz = zoneinfo.ZoneInfo("America/New_York")
+    model = FakeModel.model_validate(
+        {
+            "recurrence_id": [
+                ParsedProperty(
+                    name="recurrence_id",
+                    value="20250511T020000",
+                    params=[
+                        ParsedPropertyParameter(
+                            name="TZID", values=["America/New_York"]
+                        ),
+                    ],
+                )
+            ]
+        }
+    )
+    # String value remains the plain datetime for backward compatibility.
+    assert model.recurrence_id == "20250511T020000"
+    # Timezone metadata is accessible.
+    assert model.recurrence_id.tzinfo == ny_tz
+
+
+def test_recurrence_id_tzid_param_as_tzinfo() -> None:
+    """Test TZID param already resolved to tzinfo object is handled."""
+
+    ny_tz = zoneinfo.ZoneInfo("America/New_York")
+    model = FakeModel.model_validate(
+        {
+            "recurrence_id": [
+                ParsedProperty(
+                    name="recurrence_id",
+                    value="20250511T020000",
+                    params=[
+                        ParsedPropertyParameter(name="TZID", values=[ny_tz]),
+                    ],
+                )
+            ]
+        }
+    )
+    assert model.recurrence_id == "20250511T020000"
+    assert model.recurrence_id.tzinfo == ny_tz
+
+
+def test_recurrence_id_no_params() -> None:
+    """Test that tzinfo and range default to None / NONE when no params."""
+    model = FakeModel.model_validate(
+        {
+            "recurrence_id": [
+                ParsedProperty(name="recurrence_id", value="20220724T120000")
+            ]
+        }
+    )
+    assert model.recurrence_id == "20220724T120000"
+    assert model.recurrence_id.tzinfo is None
+    assert model.recurrence_id.range == Range.NONE
+
+
+def test_recurrence_id_unknown_tzid_is_ignored() -> None:
+    """Test that an unrecognised TZID is skipped without raising an error."""
+
+    model = FakeModel.model_validate(
+        {
+            "recurrence_id": [
+                ParsedProperty(
+                    name="recurrence_id",
+                    value="20250511T020000",
+                    params=[
+                        ParsedPropertyParameter(
+                            name="TZID", values=["Not/AReal_Timezone"]
+                        ),
+                    ],
+                )
+            ]
+        }
+    )
+    # Still parses; unknown TZID is silently dropped.
+    assert model.recurrence_id == "20250511T020000"
+    assert model.recurrence_id.tzinfo is None
 
 
 def test_invalid_recurrence_id() -> None:
@@ -80,6 +165,48 @@ def test_invalid_recurrence_id() -> None:
         {"recurrence_id": [ParsedProperty(name="recurrence_id", value="invalid")]}
     )
     assert model.recurrence_id == "invalid"
+
+
+@pytest.mark.parametrize(
+    "recurrence_id_str,expected",
+    [
+        # Plain date
+        ("20250511", datetime.date(2025, 5, 11)),
+        # Naive datetime
+        ("20250511T020000", datetime.datetime(2025, 5, 11, 2, 0, 0)),
+        # UTC datetime
+        (
+            "20250511T020000Z",
+            datetime.datetime(2025, 5, 11, 2, 0, 0, tzinfo=datetime.timezone.utc),
+        ),
+        # Inline TZID parameter (the original bug from issue #480)
+        (
+            "TZID=America/New_York:20250511T020000",
+            datetime.datetime(
+                2025, 5, 11, 2, 0, 0, tzinfo=zoneinfo.ZoneInfo("America/New_York")
+            ),
+        ),
+    ],
+)
+def test_recurrence_id_to_value(
+    recurrence_id_str: str,
+    expected: datetime.date | datetime.datetime,
+) -> None:
+    """Test RecurrenceId.to_value for all supported input formats."""
+    result = RecurrenceId.to_value(recurrence_id_str)
+    assert result == expected
+
+
+def test_recurrence_id_to_value_inline_tzid_returns_aware() -> None:
+    """Test that the inline TZID format produces a tz-aware datetime."""
+    result = RecurrenceId.to_value("TZID=America/Los_Angeles:20250101T090000")
+    assert isinstance(result, datetime.datetime)
+    assert result.tzinfo is not None
+    assert result.tzinfo == zoneinfo.ZoneInfo("America/Los_Angeles")
+    assert result.year == 2025
+    assert result.month == 1
+    assert result.day == 1
+    assert result.hour == 9
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fixes #480. Relates to #278.

### Problem

`RecurrenceId.to_value()` could not parse the inline TZID format (`'TZID=America/New_York:20250511T020000'`), causing `store.edit` and `store.delete` to raise when a timezone-aware recurrence_id was supplied.

There was also a secondary bug in `store._match_item`: it unconditionally replaced the parsed datetime's timezone with the *item's* timezone, ignoring any explicit TZID the caller had provided.

### Changes

**`ical/types/recur.py`**

- `RecurrenceId` is now enriched with `.tzinfo` and `.range` attributes (via `__new__`), keeping the string value unchanged for full backward compatibility.
- `__parse_property_value__` now reads `TZID` and `RANGE` parameters from `ParsedProperty.params` and stores them as metadata on the returned `RecurrenceId`.
- `to_value()` now handles the inline `TZID=tz:DATETIME` string format by re-parsing it via `ParsedProperty.from_ics`.
- Added early-return guard for when Pydantic's before-validator is called with an already-processed `RecurrenceId` (prevents metadata loss in the two-phase parse path).
- Explicit handling for `datetime.datetime` / `datetime.date` inputs (passed from `recur_adapter`).

**`ical/store.py`**

- `_match_item`: when the `recurrence_id` carries an explicit TZID, the datetime is already tz-aware and needs no further adjustment. The fallback to the item's own timezone is preserved for plain naive strings.
- `_apply_delete`: the `exdate` timezone `replace()` is now only applied when the recurrence_id did *not* already carry a TZID.

### Tests

- Updated `test_recurrence_id_ignore_params` → `test_recurrence_id_params_range`: RANGE params are now captured, not ignored.
- New unit tests: TZID via `ParsedProperty`, TZID as a pre-resolved `tzinfo` object, no-params defaults, unknown TZID graceful degradation.
- New parametrised `test_recurrence_id_to_value`: all four input formats (date, naive datetime, UTC datetime, inline TZID).
- New store integration tests: `edit` and `delete` with an inline TZID recurrence_id, edit with a `ParsedProperty`-derived `RecurrenceId`, and regression test for naive recurrence_id matching tz-aware series.

All 1368 existing tests continue to pass.