### PR TITLE
Add PyPI keywords, classifiers, and project URLs for discoverability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,23 @@ name = "ical"
 version = "13.3.0"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
-description = "Python iCalendar implementation (rfc 2445)"
+description = "Python iCalendar implementation (rfc 5545) with built-in recurring event support"
 readme = "README.md"
 authors = [{ name = "Allen Porter", email = "allen.porter@gmail.com" }]
 requires-python = ">=3.11"
-classifiers = []
+keywords = ["icalendar", "ics", "calendar", "recurring", "rfc5545", "vcalendar", "rrule", "vcard", "caldav"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Office/Business :: Scheduling",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Typing :: Typed",
+]
 dependencies = [
   "python-dateutil>=2.8.2",
   "tzdata>=2023.3",
@@ -20,6 +32,9 @@ dependencies = [
 
 [project.urls]
 Source = "https://github.com/allenporter/ical"
+Documentation = "https://allenporter.github.io/ical/"
+"Bug Tracker" = "https://github.com/allenporter/ical/issues"
+Changelog = "https://github.com/allenporter/ical/releases"
 
 [tool.setuptools.packages.find]
 include = ["ical*"]


### PR DESCRIPTION
## Summary

Improves PyPI metadata to make the library easier to find via PyPI search, pip search tools, and AI coding assistants. Rebased cleanly on top of the Python version floor PR.

### Changes

- **Fix description**: Updates stale RFC 2445 reference → RFC 5545, and adds "with built-in recurring event support" to the one-line description (this surfaces on PyPI package pages and search results)
- **Add keywords**: `icalendar`, `ics`, `calendar`, `recurring`, `rfc5545`, `vcalendar`, `rrule`, `vcard`, `caldav` — used by PyPI search indexing
- **Add classifiers**:
  - `Development Status :: 5 - Production/Stable`
  - `Intended Audience :: Developers`
  - `Operating System :: OS Independent`
  - `Programming Language :: Python :: 3.11/3.12/3.13`
  - `Topic :: Office/Business :: Scheduling`
  - `Topic :: Software Development :: Libraries :: Python Modules`
  - `Typing :: Typed`
- **Add project URLs**: Documentation, Bug Tracker, and Changelog links (displayed on PyPI sidebar)

### Notes

The `License` classifier was intentionally omitted — it is superseded by the `license = "Apache-2.0"` SPDX expression per [PEP 639](https://peps.python.org/pep-0639/). Setuptools raises an error if both are present.