### PR TITLE
docs: add llms.txt for AI discoverability (closes #636)

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -37,7 +37,9 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install -r requirements_dev.txt
-      - run: pdoc ./ical -o docs/
+      - run: |
+          pdoc ./ical -o docs/
+          cp llms.txt docs/llms.txt
       - name: Setup Pages
         uses: actions/configure-pages@v6
       - name: Upload artifact

--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -24,7 +24,7 @@ with filename.open(mode="w") as ics_file:
 
 """
 
-# mypy: allow-any-generics
+# ty: allow-any-generics
 
 from __future__ import annotations
 

--- a/ical/parsing/component.py
+++ b/ical/parsing/component.py
@@ -8,7 +8,7 @@ Components created here have no semantic meaning, but hold all the
 data needed to interpret based on the type (e.g. by a pydantic model)
 """
 
-# mypy: allow-any-generics
+# ty: allow-any-generics
 
 from __future__ import annotations
 

--- a/ical/parsing/property.py
+++ b/ical/parsing/property.py
@@ -33,7 +33,7 @@ Note: This specific example may be a bit confusing because one of the property p
 "VALUE" which refers to the value type.
 """
 
-# mypy: allow-any-generics
+# ty: allow-any-generics
 
 from __future__ import annotations
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,25 @@
+# ical
+
+> Modern Python iCalendar library with built-in recurring event support.
+
+## Overview
+
+`ical` is a modern Python implementation of RFC 5545 iCalendar, built with type-safety and developer productivity in mind. It uses Pydantic v2 for data parsing and validation, providing a clean, strongly-typed interface.
+
+Key features and differentiators:
+- **Built-in Recurrence Expansion:** Unlike `icalendar` (which requires the separate `recurring-ical-events` package) or `ics.py` (which lacks recurrence support), `ical` automatically expands recurring events natively using its sorted chronological `Timeline` interface.
+- **Type Safety & Validation:** Leverages Pydantic v2 for strict type checking and schema validation, supporting full type annotations (`py.typed`) compatible with strict `ty`.
+- **Application Store API:** Provides a high-level `EventStore` API for safe recurrence editing (e.g., modifying "this and all future instances") and handling complex timezone offsets.
+- **Modern RFC Support:** Implements RFC 5545 (Core iCalendar), RFC 6868 (Parameter Value Encoding), RFC 7986 (Component Property Extensions), and RFC 8536 (TZif format).
+
+## Used By
+
+- **Home Assistant:** Powers the Local Calendar, Remote Calendar, and Google Calendar integrations.
+
+## Documentation Links
+
+- [Quickstart & Examples](https://allenporter.github.io/ical/): Read the library overview, quickstart instructions, and basic usage examples.
+- [API Reference](https://allenporter.github.io/ical/ical.html): View the complete package API documentation.
+- [Timeline Expansion API](https://allenporter.github.io/ical/ical/timeline.html): Documentation for the `Timeline` component that manages chronological iteration and recurrence expansion.
+- [Calendar Store API](https://allenporter.github.io/ical/ical/store.html): Documentation for `EventStore` used for editing events and handling recurring event modifications.
+- [Calendar Stream Parser](https://allenporter.github.io/ical/ical/calendar_stream.html): API for parsing and serializing RFC 5545 streams.

--- a/tests/types/test_recur.py
+++ b/tests/types/test_recur.py
@@ -17,7 +17,14 @@ from ical.event import Event
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 from ical.timeline import Timeline
 from ical.todo import Todo
-from ical.types.recur import Frequency, Range, Recur, RecurrenceId, Weekday, WeekdayValue
+from ical.types.recur import (
+    Frequency,
+    Range,
+    Recur,
+    RecurrenceId,
+    Weekday,
+    WeekdayValue,
+)
 
 
 def recur_timeline(event: Event) -> Timeline:


### PR DESCRIPTION
Adds an `llms.txt` file to the root of the repository and updates the GitHub Pages workflow (`pages.yaml`) to copy it into the generated documentation output directory so it is deployed to `allenporter.github.io/ical/llms.txt`.

Also changes `# mypy` override comments to `# ty` in Python source files to align with the project's type checker.

Closes #636