### PR TITLE
docs: add technical guides section using programmatic pdoc builder

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -38,7 +38,7 @@ jobs:
         run: |
           uv pip install -r requirements_dev.txt
       - run: |
-          pdoc ./ical -o docs/
+          python script/build_doc.py
           cp llms.txt docs/llms.txt
       - name: Setup Pages
         uses: actions/configure-pages@v6

--- a/guides/compatibility.md
+++ b/guides/compatibility.md
@@ -1,0 +1,8 @@
+# Calendar Compatibility Layer
+
+This guide covers how `ical` handles non-compliant calendar sources from major providers.
+
+## Key Topics
+- Parsing non-standard date and time formats.
+- Safe fallbacks and logging for unhandled properties.
+- Provider-specific compatibility flags (Google Calendar, Outlook/Office 365, iCloud).

--- a/guides/compatibility.md
+++ b/guides/compatibility.md
@@ -1,5 +1,7 @@
 # Calendar Compatibility Layer
 
+> **Work In Progress (WIP) / TODO**: This guide is currently a placeholder. Content will be added in a future update.
+
 This guide covers how `ical` handles non-compliant calendar sources from major providers.
 
 ## Key Topics

--- a/guides/index.md
+++ b/guides/index.md
@@ -1,0 +1,7 @@
+# Technical Guides
+
+Welcome to the technical deep-dive guides for the `ical` library. Select a topic below to learn more:
+
+- [Recurrence Rules & Event Generation](guides/recurrence.html)
+- [Timezones & Custom TzInfo](guides/timezone.html)
+- [Calendar Compatibility Layer](guides/compatibility.html)

--- a/guides/index.md
+++ b/guides/index.md
@@ -1,5 +1,7 @@
 # Technical Guides
 
+> **Work In Progress (WIP) / TODO**: This section contains placeholders for future technical documentation. The structure is in place, but content is yet to be written.
+
 Welcome to the technical deep-dive guides for the `ical` library. Select a topic below to learn more:
 
 - [Recurrence Rules & Event Generation](guides/recurrence.html)

--- a/guides/recurrence.md
+++ b/guides/recurrence.md
@@ -1,5 +1,7 @@
 # Recurrence Rules & Event Generation
 
+> **Work In Progress (WIP) / TODO**: This guide is currently a placeholder. Content will be added in a future update.
+
 This guide covers the technical architecture behind how `ical` handles recurrence rules (RFC 5545) and generates timeline events.
 
 ## Key Design Principles

--- a/guides/recurrence.md
+++ b/guides/recurrence.md
@@ -1,0 +1,8 @@
+# Recurrence Rules & Event Generation
+
+This guide covers the technical architecture behind how `ical` handles recurrence rules (RFC 5545) and generates timeline events.
+
+## Key Design Principles
+1. **Pydantic-based Data Model**: Recurrence rules are parsed into structured Python objects using validation patterns.
+2. **Timeline Iteration**: Events are evaluated lazily via a heapq-merged stream of iterators to handle potentially infinite recurrences efficiently.
+3. **Instance Modification**: Editing specific occurrences (using `RECURRENCE-ID`) excludes them from the parent series.

--- a/guides/timezone.md
+++ b/guides/timezone.md
@@ -1,5 +1,7 @@
 # Timezones & Custom TzInfo Evaluation
 
+> **Work In Progress (WIP) / TODO**: This guide is currently a placeholder. Content will be added in a future update.
+
 This guide covers how timezone information is evaluated and verified in `ical`.
 
 ## Key Topics

--- a/guides/timezone.md
+++ b/guides/timezone.md
@@ -1,0 +1,8 @@
+# Timezones & Custom TzInfo Evaluation
+
+This guide covers how timezone information is evaluated and verified in `ical`.
+
+## Key Topics
+- Custom `TzInfo` models parsing and representation.
+- Deep copy behavior and serialization round-tripping.
+- Handling missing `VTIMEZONE` objects and using `X-WR-TIMEZONE` headers.

--- a/script/build_doc.py
+++ b/script/build_doc.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Build script for generating ical documentation with embedded markdown guides."""
+
+import shutil
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Generator
+import pdoc
+
+# Constants for project paths
+ROOT_DIR = Path(__file__).resolve().parent.parent
+ICAL_DIR = ROOT_DIR / "ical"
+GUIDES_SRC_DIR = ROOT_DIR / "guides"
+TEMP_GUIDES_DIR = ICAL_DIR / "guides"
+OUTPUT_DIR = ROOT_DIR / "docs"
+INIT_FILE = ICAL_DIR / "__init__.py"
+
+# String templates for python wrappers
+INIT_TEMPLATE = """\
+\"\"\"
+.. include:: ../../guides/index.md
+\"\"\"
+
+__all__ = {guide_names}
+"""
+
+WRAPPER_TEMPLATE = """\
+\"\"\"
+.. include:: ../../guides/{name}.md
+\"\"\"
+"""
+
+
+def get_guide_names(guides_src_dir: Path) -> list[str]:
+    """Find all guide markdown files (excluding the index page) and return their stems."""
+    if not guides_src_dir.exists():
+        return []
+    md_files = sorted(guides_src_dir.glob("*.md"))
+    return [f.stem for f in md_files if f.name != "index.md"]
+
+
+@contextmanager
+def temp_guides_setup(
+    guides_src_dir: Path,
+    temp_guides_dir: Path,
+    init_file: Path,
+) -> Generator[None, None, None]:
+    """Context manager to temporarily set up python wrapper modules for guides.
+
+    Note: We must place the temporary directories inside ical/ (rather than a system
+    tempdir like /tmp/) so that pdoc's python import resolution parses them natively
+    under the ical package hierarchy (e.g. ical.guides). We run this in a context
+    manager to ensure the directory is safely cleaned up and original files restored.
+    """
+    guide_names = get_guide_names(guides_src_dir)
+    if not guide_names:
+        raise ValueError(f"No guide markdown files found in {guides_src_dir}")
+
+    # Read original __init__.py content to restore it later
+    original_init_content = ""
+    if init_file.exists():
+        original_init_content = init_file.read_text(encoding="utf-8")
+
+    try:
+        # Create temporary guides package directory inside ical/
+        temp_guides_dir.mkdir(exist_ok=True)
+
+        # Write __init__.py including guides/index.md and exposing the submodules
+        init_content = INIT_TEMPLATE.format(guide_names=repr(guide_names))
+        (temp_guides_dir / "__init__.py").write_text(init_content, encoding="utf-8")
+
+        # Write wrapper modules for each markdown file
+        for name in guide_names:
+            wrapper_content = WRAPPER_TEMPLATE.format(name=name)
+            (temp_guides_dir / f"{name}.py").write_text(
+                wrapper_content, encoding="utf-8"
+            )
+
+        # Modify ical/__init__.py to temporarily include "guides" in __all__
+        if original_init_content:
+            modified_init_content = original_init_content.replace(
+                "__all__ = [", '__all__ = [\n    "guides",'
+            )
+            init_file.write_text(modified_init_content, encoding="utf-8")
+
+        yield
+
+    finally:
+        # Always clean up the temporary directory and restore __init__.py
+        if temp_guides_dir.exists():
+            shutil.rmtree(temp_guides_dir)
+        if original_init_content and init_file.exists():
+            init_file.write_text(original_init_content, encoding="utf-8")
+
+
+def build_docs() -> None:
+    """Build the documentation using the pdoc library."""
+    pdoc.render.configure(docformat="restructuredtext")
+    pdoc.pdoc(ICAL_DIR, output_directory=OUTPUT_DIR)
+
+
+def main() -> None:
+    if not GUIDES_SRC_DIR.exists() or not (GUIDES_SRC_DIR / "index.md").exists():
+        print("Error: guides/ directory or index.md not found.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with temp_guides_setup(GUIDES_SRC_DIR, TEMP_GUIDES_DIR, INIT_FILE):
+            print("Building documentation using pdoc library...")
+            build_docs()
+            print(f"Documentation generated successfully at: {OUTPUT_DIR}")
+    except Exception as e:
+        print(f"Error building documentation: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_build_doc.py
+++ b/tests/test_build_doc.py
@@ -1,0 +1,88 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Add root folder to sys.path so we can import script.build_doc
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from script.build_doc import get_guide_names, temp_guides_setup
+
+
+def test_get_guide_names(tmp_path: Path) -> None:
+    """Test discovering guide names, ignoring index.md and filtering correctly."""
+    guides_dir = tmp_path / "guides"
+    guides_dir.mkdir()
+
+    # Empty directory
+    assert get_guide_names(guides_dir) == []
+
+    # Non-existent directory
+    assert get_guide_names(tmp_path / "does_not_exist") == []
+
+    # Populate directory
+    (guides_dir / "index.md").touch()
+    (guides_dir / "recurrence.md").touch()
+    (guides_dir / "timezone.md").touch()
+    (guides_dir / "another-guide.md").touch()
+
+    # Stems should be sorted alphabetically, excluding index.md
+    assert get_guide_names(guides_dir) == [
+        "another-guide",
+        "recurrence",
+        "timezone",
+    ]
+
+
+def test_temp_guides_setup(tmp_path: Path) -> None:
+    """Test context manager setup and automatic clean up/restoration."""
+    guides_src_dir = tmp_path / "guides"
+    guides_src_dir.mkdir()
+    (guides_src_dir / "index.md").touch()
+    (guides_src_dir / "recurrence.md").touch()
+    (guides_src_dir / "timezone.md").touch()
+
+    temp_guides_dir = tmp_path / "ical" / "guides"
+    temp_guides_dir.parent.mkdir()
+    init_file = tmp_path / "ical" / "__init__.py"
+
+    original_init_content = '__all__ = [\n    "alarm",\n    "calendar",\n]\n'
+    init_file.write_text(original_init_content, encoding="utf-8")
+
+    # Before entering context manager, temp guides folder does not exist
+    assert not temp_guides_dir.exists()
+
+    with temp_guides_setup(guides_src_dir, temp_guides_dir, init_file):
+        # Temp folder exists
+        assert temp_guides_dir.exists()
+
+        # Wrapper files created
+        assert (temp_guides_dir / "__init__.py").exists()
+        assert (temp_guides_dir / "recurrence.py").exists()
+        assert (temp_guides_dir / "timezone.py").exists()
+
+        # Content of wrappers includes correct files
+        wrapper_content = (temp_guides_dir / "recurrence.py").read_text()
+        assert ".. include:: ../../guides/recurrence.md" in wrapper_content
+
+        # ical/__init__.py is modified to include "guides"
+        modified_init = init_file.read_text()
+        assert '"guides"' in modified_init
+        assert '__all__ = [\n    "guides",\n    "alarm",\n' in modified_init
+
+    # After exiting context manager, temp folder is removed and init restored
+    assert not temp_guides_dir.exists()
+    assert init_file.read_text() == original_init_content
+
+
+def test_temp_guides_setup_no_guides(tmp_path: Path) -> None:
+    """Test context manager raises ValueError if no guides are present."""
+    guides_src_dir = tmp_path / "guides"
+    guides_src_dir.mkdir()
+    temp_guides_dir = tmp_path / "ical" / "guides"
+    init_file = tmp_path / "ical" / "__init__.py"
+
+    with pytest.raises(ValueError, match="No guide markdown files found"):
+        with temp_guides_setup(guides_src_dir, temp_guides_dir, init_file):
+            pass


### PR DESCRIPTION
This PR adds a Technical Guides/Blog section to the documentation using pdoc library API. The raw guides are written in Markdown in the root 'guides/' folder, and wrapper modules are generated dynamically during pdoc build and safely cleaned up afterwards.