### PR TITLE
docs: Add RFC5545 timezone and python ecosystem detailed guide

### DIFF
--- a/guides/timezone.md
+++ b/guides/timezone.md
@@ -1,10 +1,279 @@
-# Timezones & Custom TzInfo Evaluation
+# The Excruciating Details of iCalendar Timezones in Python
 
-> **Work In Progress (WIP) / TODO**: This guide is currently a placeholder. Content will be added in a future update.
+Timezone handling in the iCalendar (`rfc5545`) specification is complex. Developers working with calendar data in Python routinely encounter issues, such as:
+- **Incomplete or missing timezone specifications:** Calendars exported without `VTIMEZONE` blocks or with non-standard identifiers, leaving the parser with no rule definition for rendering local times.
+- **Environment and database drift:** Events behaving differently on different host systems due to discrepancies in local, system-provided timezone databases.
+- **DST transition glitches:** Hard-to-reproduce bugs occurring twice a year when events shift by an hour or more during transitions.
+- **Library fragmentation:** A fragmented Python timezone ecosystem (`pytz` vs `zoneinfo` vs `dateutil.tz`) with outdated documentation, conflicting APIs, and mismatched offset behaviors.
+- **Standard-violating files:** Validation failures caused by major calendar providers generating files that violate RFC 5545 requirements.
 
-This guide covers how timezone information is evaluated and verified in `ical`.
+This guide shares the design decisions, technical details, and learnings behind how `ical` handles timezones transparently to provide a robust, compliant, and developer-friendly calendar implementation.
 
-## Key Topics
-- Custom `TzInfo` models parsing and representation.
-- Deep copy behavior and serialization round-tripping.
-- Handling missing `VTIMEZONE` objects and using `X-WR-TIMEZONE` headers.
+---
+
+## Core Concepts: Timezones, All-Day Events, and the "Viewer"
+
+Before diving into Python-specific implementations and RFC details, it is helpful to share some basics about timezones that you don't really encounter until you think about how to develop a calendar application.
+
+### Why Timezones Matter: Unambiguous vs. Floating Time
+
+A calendar event is scheduled for humans, meaning it has a local time (e.g., "9:00 AM"). However, a local time alone is ambiguous:
+- **Timezone-Aware Time**: If a business meeting is at 9:00 AM hosted from New York, its actual instant in time shifts depending on where the other attendees are located. To resolve this, the event either specifies a local timezone identifier (e.g., `America/New_York` at `9:00 AM`) or is defined in UTC (e.g., `9:00 AM UTC`).
+- **Floating Time**: Sometimes, you *want* the time to be timezone-independent. For example, a "Breakfast at 8:00 AM" event during a trip should happen at 8:00 AM local time wherever you are, rather than shifting to 5:00 AM or 11:00 PM as you travel across timezones. In iCalendar, this is represented as a naive/floating `DATE-TIME` (e.g. `20260709T080000` without a `Z` or `TZID`), which is interpreted as the local time of whoever is viewing the calendar.
+
+### All-Day Events (Date Values)
+
+Some events don't have a time of day at all. A birthday, holiday, or vacation is an all-day event.
+- In iCalendar, these are represented as a `DATE` value type (e.g., `VALUE=DATE:20260709`).
+- All-day events do not have timezones. They are inherently floating dates: they apply to the entire calendar day for the observer. If a Birthday is July 9th on your calendar, the event is active, regardless of your physical location or current timezone offset.
+
+### Concept of a "Viewer" Timezone
+
+A calendar's event database contains a mixture of timezone-aware datetimes, floating datetimes, and all-day dates. To render these events on a single, chronological timeline, the application must adopt a specific perspective: the **Viewer Timezone**.
+
+When you query the `ical` timeline:
+- **Timezone-aware events** are translated from their source timezone (or UTC) into the viewer's local timezone, ensuring the observer sees the correct local start and end times.
+- **Floating events** (which have no timezone) are evaluated as if they occur in the viewer's local timezone (e.g., "Breakfast at 8:00 AM" remains at 8:00 AM regardless of the viewer's location).
+- **All-day events** are expanded to span the full 24-hour period of that date in the viewer's timezone (from midnight to midnight local time).
+
+By separating the event's stored timezone representation from the viewer's timezone during timeline evaluation, `ical` ensures that calendars remain highly portable while rendering correctly for any observer anywhere in the world.
+
+---
+
+## Fragmentation of Python Timezone Libraries
+
+Once you start working with dates and timezones in Python, you may come across different libraries and rules and it may be difficult to understand the legacy and history vs modern best practices.
+
+Historically, Python's timezone fragmentation arose from two core problems:
+1. **Accessing Database Rules:** Python lacked a built-in database of IANA timezone rules, forcing reliance on external packages.
+2. **Representing Transitions:** Python's early `datetime.tzinfo` API could not model transition gaps (when clocks skip forward) or folds (when clocks repeat), making it impossible to represent ambiguous wall times natively during Daylight Saving Time (DST) transitions.
+
+Understanding how the ecosystem evolved to solve these problems chronologically explains why multiple libraries exist.
+
+### Pre-PEP 495 Era: `pytz` and the Custom API
+
+Historically, Python's standard library had no built-in database of [IANA (Olson) timezones](https://www.iana.org/time-zones) (see also the comprehensive [IANA Time Zone database links](https://data.iana.org/time-zones/tz-link.html)). `pytz` became the de facto standard by bundling the database.
+
+However, because standard Python constructors did not yet support fold/gap transitions, `pytz` had to bypass the standard API—requiring custom `.localize()` and `.normalize()` calls instead. Directly passing a `pytz` object to standard constructors attached the timezone's first historical offset (such as LMT - Local Mean Time, see [UTC time off by 53 minutes?](https://github.com/stub42/pytz/issues/12)). The API is defensive against some timezone bugs, but it still considered [The Fastest Footgun in the West](https://ganssle.io/articles/2018/03/pytz-fastest-footgun.html).
+
+Additionally, `pytz` does not expose a public API to query or reconstruct the raw transition rules required to generate RFC 5545 `VTIMEZONE` blocks (see more on this below).
+
+### `dateutil.tz` (Dateutil Backend)
+
+Historically used by `dateutil.rrule` for calculating recurrence expansions, `dateutil.tz` acts as a utility backend supporting a wide range of timezone formats under a single API.
+
+It provides low-level tools for reading binary TZif files (`tz.tzfile`), though with limitations: it historically only supported the V1 header/transitions, missing the V2/V3 POSIX footer and rule information required to dynamically construct new `VTIMEZONE` blocks (as defined in [RFC 8536](https://datatracker.ietf.org/doc/html/rfc8536.html)).
+
+Additionally, it supports the Windows Registry database (`tz.tzwin`), POSIX strings (`tz.tzstr`), and local system time emulation (`tz.tzlocal`). While these are valuable low-level adapters, they lack the high-level logic needed to parse and manage structured iCalendar streams out of the box.
+
+### PEP 495 and PEP 615: Modern Timezone Standards
+
+Python 3.6+ and 3.9+ dramatically streamlined the timezone ecosystem by introducing standard native features:
+- **PEP 495 (`fold`):** Standardized how standard `tzinfo` implementations represent DST fallback repeats (folds) and spring-forward skips (gaps) directly inside standard constructors.
+- **PEP 615 (`zoneinfo`):** Added the standard `zoneinfo` module, allowing Python to natively read IANA timezone database files from the host operating system.
+
+These standards eliminated the need for custom APIs like `pytz` for standard datetime computations. However, two critical gaps remained for calendar applications:
+1. **Opaque Wrappers:** While standard `zoneinfo.ZoneInfo` is compliant, it acts as an opaque wrapper and does not expose the raw database rules (future rule recurrences or transition lists) required to generate RFC 5545 `VTIMEZONE` blocks.
+2. **Platform Parity:** `zoneinfo` relies on the host OS database, which is absent on Windows by default, requiring the PyPI `tzdata` package to be installed.
+
+---
+
+### Design Solution and Delegation Strategy
+
+To resolve this fragmentation and meet RFC 5545 requirements, `ical` adopts a hybrid approach that delegates between standard library components and new lower level implementations needed for calendar applications:
+
+- **Native IANA zones:** `ical` standardizes on standard `zoneinfo.ZoneInfo` for all standard timezone-aware datetime calculations. Standard timezone names like `America/New_York` are always handled with native speed, compatibility with the Python datetime ecosystem, and standard disambiguation support.
+- **TZif parsing:** `ical` implements a zero-dependency binary `TZif` (RFC 8536) parser used for properly exporting VTIMEZONE blocks. See below for more detail.
+- **VTIMEZONE Imports (`IcsTimezoneInfo`):** When standard `ZoneInfo` is unavailable or when the calendar file contains custom transition rules (via `VTIMEZONE` blocks), `ical` parses these definitions into its custom `IcsTimezoneInfo` class (a subclass of `datetime.tzinfo`). This custom timezone wrapper dynamically resolves local times using the specific standard recurrence rules (`RRULE` / `RDATE`) parsed directly from the iCalendar stream.
+
+---
+
+## DST Transitions and Recurrence Expansion
+
+A common source of bugs in calendar applications is expanding recurring events across DST boundaries.
+
+Consider a weekly meeting scheduled at **9:00 AM America/New_York**.
+- In February (Standard Time), the offset is **UTC-5** (9:00 AM EST / 2:00 PM UTC).
+- In April (Daylight Saving Time), the offset is **UTC-4** (9:00 AM EDT / 1:00 PM UTC).
+
+If recurrence expansion is evaluated using naive (timezone-unaware) datetimes and converted to UTC later, or if the timezone transitions are not properly aligned, the meeting can easily "jump" to 10:00 AM or 8:00 AM local time after a clock change.
+
+`ical` addresses this by leveraging `dateutil.rrule` in a timezone-aware context. The start time (`DTSTART`) is passed with its full `tzinfo`. The recurrence engine expands the ruleset directly in local time, allowing the timezone object to dynamically determine the correct UTC offset for each recurrence instance. The resulting occurrences are correctly mapped on the timeline without drifting.
+
+Implementing recurring events was is it's own unique adventure, covered in another guide.
+
+### DST Transitions are subtle
+
+A calendar library also needs to handle local times during a DST transition, when the standard time resumes and clocks repeat. Under RFC 5545 section 3.3.5, a local time referencing a timezone is represented as:
+
+```ics
+DTSTART;TZID=America/New_York:20261101T013000
+```
+
+During a fall-back DST transition, this local time occurs twice (once with the daylight saving offset, e.g. UTC-4, and once with the standard offset, e.g. UTC-5). Because the iCalendar format does not provide any parameter or syntax to specify the active UTC offset or a "fold" parameter on individual properties, there is no way to explicitly serialize the second occurrence.
+
+To resolve this, **RFC 5545 (Section 3.3.5) explicitly defines a resolution policy:**
+> "If, based on the definition of the referenced time zone, the local time described occurs more than once (when changing from daylight to standard time), the DATE-TIME value refers to the first occurrence of the referenced time."
+
+#### How `ical` Resolves Ambiguities
+
+`ical` is designed to be fully compliant with this RFC 5545 resolution mandate across its timezone backends:
+
+- **Standard `ZoneInfo`**: For events parsed using standard IANA timezones, `ical` delegates to the standard library `ZoneInfo` wrapper. `ZoneInfo` resolves local time lookups using Python's **PEP 495** standard behavior. By default, constructing a datetime without specifying the `fold` attribute (e.g. `datetime(2026, 11, 1, 1, 30, tzinfo=ZoneInfo("America/New_York"))`) defaults to `fold=0` (the first occurrence, which is EDT), perfectly matching the RFC mandate. If a developer manually creates a datetime with `fold=1`, Python's `ZoneInfo` resolves it correctly to the second occurrence (EST).
+- **Custom `IcsTimezoneInfo`**: For custom timezone rules resolved via parsed `VTIMEZONE` transitions, `IcsTimezoneInfo` performs a binary search (`bisect_right`) on the timeline of transition onsets. Because standard Python naive datetime comparisons (used in `bisect_right`) ignore the PEP 495 `fold` attribute, this lookup **always defaults to the pre-transition (daylight saving) offset** for overlapping local times, resolving to the first occurrence in compliance with the RFC.
+
+#### Best Practices for Unambiguous Calendars
+
+Because serialized iCalendar streams cannot natively encode transition offsets or fold markers on individual timezone-aware datetime fields, the best practice to ensure absolute, unambiguous precision during transition windows is to **convert local datetimes to UTC before creating calendar events.**
+
+In Python, this is done by specifying standard timezone objects (like standard library `ZoneInfo`) with the `fold` attribute to disambiguate the transition local time, and then calling `.astimezone(datetime.timezone.utc)` to obtain an unambiguous UTC value:
+
+```python
+import datetime
+from zoneinfo import ZoneInfo
+from ical.event import Event
+
+# Create local time at the second occurrence of 1:30 AM (EST, fold=1)
+dt_local = datetime.datetime(2026, 11, 1, 1, 30, fold=1, tzinfo=ZoneInfo("America/New_York"))
+
+# Convert to UTC to ensure it is unambiguous when serialized
+dt_utc = dt_local.astimezone(datetime.timezone.utc)
+
+# Create the event using the UTC datetime
+event = Event(summary="Unambiguous Transition Meeting", start=dt_utc)
+```
+
+When serialized, `ical` writes this using the UTC format:
+```ics
+DTSTART:20261101T063000Z
+```
+This UTC representation contains no DST transitions and is interpreted identically by all standard-compliant calendar engines.
+
+> [!NOTE]
+> **Future Work / TODO**: In the future, we plan to introduce validation rules and diagnostics in `ical` to automatically detect when a parsed or added local time lands inside a DST transition fold or gap, and issue a warning or diagnostic indicator to help developers flag these ambiguous inputs.
+
+---
+
+## Automated VTIMEZONE Generation & Interoperability
+
+The iCalendar standard requires that timezone offsets are fully specified and unambiguous. Any timezone referenced in event start (`DTSTART`) or end (`DTEND`) properties must be fully defined within a `VTIMEZONE` component in the same calendar stream. This makes the calendar self-contained and immune to differences in local timezone databases between different clients.
+
+In practice, this requirement is rarely followed by most calendar exporters because constructing compliant rules is difficult. `ical`, however, automates this generation seamlessly.
+
+A typical `VTIMEZONE` block contains standard and daylight observance rules, including transition offsets and rules:
+
+```ics
+BEGIN:VTIMEZONE
+TZID:America/New_York
+BEGIN:STANDARD
+DTSTART:20071104T020000
+TZOFFSETFROM:-0400
+TZOFFSETTO:-0500
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+TZNAME:EST
+END:STANDARD
+BEGIN:DAYLIGHT
+DTSTART:20070311T020000
+TZOFFSETFROM:-0500
+TZOFFSETTO:-0400
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+TZNAME:EDT
+END:DAYLIGHT
+END:VTIMEZONE
+```
+
+In many Python libraries, developers must manually construct and inject `VTIMEZONE` components. This is error-prone and requires tracking standard and daylight transitions alongside dynamic IANA database updates.
+
+In `ical`, this process is completely automated. When an event is stored via `EventStore.add()`, the store inspects the event's `tzinfo` and automatically invokes `Timezone.from_tzif()` to fetch transition rules and append them to the calendar's timezone definition list.
+
+---
+
+## Deep Dive: Decoding TZif (RFC 8536)
+
+To generate valid `VTIMEZONE` transitions, the library needs to inspect the actual transition offsets and daylight observance dates. Because Python's standard `zoneinfo` database behaves as an opaque wrapper and does not expose its raw timezone transition tables, `ical` implements a custom, zero-dependency binary parser for the **TZif (Time Zone Information Format)** files defined in **RFC 8536**.
+
+This parser is located in the [ical/tzif](https://github.com/allenporter/ical/tree/main/ical/tzif) package and is designed to parse TZif files directly from the host operating system's timezone paths or the standard `tzdata` package on PyPI.
+
+### How the TZif Parser Works
+
+When `Timezone.from_tzif(...)` is invoked, the library reads the binary file through the following steps:
+
+1. **Header Parsing**: Uses Python's standard `struct` module to read the 44-byte header, validating the magic bytes (`TZif`), format version (supporting V1, V2, and V3 formats), and reading the counts for standard/wall indicators, leap seconds, transitions, and local time types.
+2. **64-bit Transition Records**: For V2 and V3 files, the parser bypasses the initial 32-bit datablock and reads the subsequent 64-bit datablock. It extracts the chronological transition times (as 64-bit integers) and maps each transition to a local time type record (which specifies the UTC offset and DST status).
+3. **POSIX TZ String Decoding**: At the end of V2/V3 TZif files, the parser extracts the POSIX-style TZ environment variable string (e.g., `EST5EDT,M3.2.0,M11.1.0`). The TZ string format is nice and simple because it describes the transitions going forward in a simple way without explicitly defining all transitions.
+4. **Transition Rule Conversion**: A specialized parser in [ical/tzif/tz_rule.py](https://github.com/allenporter/ical/blob/main/ical/tzif/tz_rule.py) decodes the POSIX string into standard iCalendar recurrence rules (`RRULE`).
+
+This custom implementation allows `ical` to accurately represent real-world historical and future timezone transitions. For example, when Türkiye abolished DST in 2016 or when Samarkand adjusted its offset rules in 2024, `ical` extracts these rules directly from the latest binary `tzdata` updates, generating compliant `VTIMEZONE` blocks dynamically without hardcoded tables.
+
+These are further helpful resources if you want to learn more:
+- https://developer.ibm.com/articles/au-aix-posix/
+- https://www.di-mgt.com.au/wclock/help/wclo_tzexplain.html
+
+---
+
+## Microsoft Exchange and Outlook Timezones
+
+Microsoft Exchange Server and Outlook have historical timezone formats that deviate from the standard IANA timezone database names. When they export iCalendar files, they frequently write the `TZID` parameter using **Windows Standard Timezone Names** (like `W. Europe Standard Time`) rather than standard IANA names (like `Europe/Berlin`). Because standard libraries like Python's `zoneinfo` only recognize standard IANA keys, attempting to parse these feeds directly would normally crash the parser.
+
+`ical` handles Microsoft Exchange Server feeds by detecting the `Microsoft Exchange Server` identifier in the calendar's generator metadata (`PRODID`) and enabling a robust two-layer compatibility handler:
+
+- **Extended Timezone Mapping:** `ical` loads a generated mapping based on Unicode CLDR (Common Locale Data Repository) Windows-to-IANA translations (contained in [ical/tzif/extended_timezones.py](https://github.com/allenporter/ical/blob/main/ical/tzif/extended_timezones.py)). When a property references a Windows name (e.g. `TZID=W. Europe Standard Time`), the compatibility layer resolves it dynamically to its standard IANA equivalent (`Europe/Berlin`), enabling native performance and correctness.
+- **Invalid Timezone Fallback:** If the calendar file references a completely unrecognized or invalid timezone string that cannot be resolved, `ical` prevents a parser crash by falling back to treating the property as a naive/floating datetime (setting `tzinfo = None` instead of raising a `ParameterValueError`), allowing the rest of the calendar to be processed safely.
+
+### Performance Heroics for 1601-Epoch Custom Timezones
+
+Microsoft Exchange Server and Outlook custom timezone definitions (`VTIMEZONE` blocks) frequently include start dates (`DTSTART`) going back *hundreds of years* into the past. To parse a timezone-aware datetime, a client must evaluate these timezone transitions and find the appropriate offset for the date on the calendar. In naive implementations, resolving offsets requires expanding the timezone's recurrence rule all the way from year 1601 to the date on the calendar for every single datetime offset query, causing poor performance when parsing calendar feeds with many events.
+
+`ical` solves this through a custom [CachedTransitionTimeline](https://github.com/allenporter/ical/blob/main/ical/iter.py#L454) utility. Timezone transition recurrences are evaluated lazily. The underlying recurrence rule is only expanded up to the highest date queried so far and cached. Subsequent offset queries at or before that date read from the cache using binary search (`bisect_right`). A year-1601 recurrence is therefore expanded only once up to the query threshold rather than on every lookup.
+
+---
+
+## UNTIL Timezones
+
+You'll often find that timezones are used inconsistently in the iCalendar spec. In particular, according to RFC 5545 section 3.3.10:
+> "If the DTSTART property is specified as a DATE-TIME with a local time and a time zone reference, then the UNTIL rule part MUST be specified as a DATE-TIME with UTC time."
+
+In practice, major calendar providers frequently violate this constraint, generating files where `DTSTART` is a `DATE-TIME` with a timezone, but the `UNTIL` property in the `RRULE` is formatted as a `DATE` (without time/timezone information). This mismatch causes strict RFC-compliant parsers to reject the calendar.
+
+`ical` resolves this through its compatibility layer (`ical.compat.enable_compat_mode`). When compatibility mode is enabled, `ical` inspects the calendar's generator (`PRODID`). If it detects Google Calendar, it silently converts the `UNTIL` `DATE` value to a `DATE-TIME` matching the `DTSTART` timezone rules:
+
+```python
+# From ical/component.py
+if dtstart_until_compat.is_dtstart_until_compat_enabled():
+    # Convert UNTIL DATE to DATE-TIME matching the DTSTART type.
+    return datetime.datetime.fromordinal(date_value.toordinal()).replace(
+        tzinfo=datetime.timezone.utc if dtstart.tzinfo is not None else None
+    )
+```
+
+---
+
+## Non-Standard Timezones: `X-WR-TIMEZONE`
+
+Google Calendar and other clients often export calendars containing the non-standard `X-WR-TIMEZONE` top-level property (e.g., `X-WR-TIMEZONE:America/New_York`).
+- `X-WR-TIMEZONE` is intended to specify a default timezone for naive/floating datetimes in the calendar.
+- However, it is not part of the RFC 5545 standard, and relying on it can lead to parsing errors on systems that do not recognize it.
+
+`ical` remains strictly compliant by always parsing and generating real, fully-described `VTIMEZONE` blocks for any timezone-aware times, ensuring your exported calendars remain readable by any standard client, regardless of whether they recognize `X-WR-TIMEZONE`.
+
+---
+
+## Summary: Why Doing Timezones Right is Hard
+
+If there is one key lesson from building the `ical` library, it is that **doing calendar timezones right is exceptionally hard.**
+
+Timezone handling in iCalendar files is not just a mathematical exercise of adding offsets to datetimes. Instead, it is a complex intersection of:
+- **Historical and Political Reality:** Timezone databases are dynamic. Offset rules change frequently due to political decisions (like Türkiye abolishing DST, or regional changes in Central Asia), making hardcoded rule tables useless.
+- **Incompatible Ecosystems:** Python standard libraries and external packages evolved separately. Bridging the legacy `pytz` API, the historical `dateutil.rrule` recurrence logic, and modern PEP 495/615 standards under a single codebase is a maze of technical constraints.
+- **Broken Real-World Feeds:** Major industry providers (like Google Calendar, Outlook, and Microsoft Exchange Server) continuously generate standard-violating iCalendar feeds. From Google's `UNTIL` rule date-time mismatches to Exchange's 1601-epoch custom timezone transitions and Registry-specific naming conventions, the calendar engine must serve as a highly resilient compatibility adapter.
+
+### Case Study: Home Assistant
+
+The original motivation for building this library was to support **Home Assistant**, the open-source
+home automation platform. In home automation, calendar precision is critical:
+
+- **Triggering physical events:** A calendar event scheduling a heater to turn on at 8:00 AM must resolve to exactly 8:00 AM local time, and they expect it to work consistently and reliably.
+- **Integrations must not fail:** When a remote Google Calendar feed violates the RFC, or an Outlook server exports a legacy Windows timezone, the home automation system must silently heal the feed rather than crashing the background scheduler -- and users expect to bring their own calendar and have it just work.
+- **All-day event shifts and timeline order:** In home automation, the "home" itself acts as the viewer. All-day events (like holidays) are defined as date-only values (e.g., `2026-12-25`). If the parser naively expands this date in UTC (starting at `00:00:00Z`), it translates to `2026-12-24 16:00:00-08:00` for a home in California (PST). If the user has a Christmas Eve event scheduled at 6:00 PM local time, the calendar timeline's chronological order becomes jumbled, sorting the all-day Christmas event *before* the Christmas Eve dinner event. Because automation engines query the timeline for the "next upcoming event" or "currently active event" to schedule physical state changes, this ordering mismatch causes triggers to fire out of sequence. `ical` resolves this by anchoring all-day events to the local home timezone, expanding them to a proper local midnight-to-midnight window so that timeline ordering remains correct.
+
+By combining native standard `zoneinfo` performance, zero-dependency binary `TZif` parsing, custom `IcsTimezoneInfo` evaluation, and compatibility-mode heuristics, `ical` hides these excruciating timezone details behind a clean, standard-compliant, and developer-friendly interface.


### PR DESCRIPTION
Author a guide on everything we've learned about timezones and python.

Issue #638