### PR TITLE
feat(compat): resolve DURATION/DTEND conflicts, audit remaining patterns (#637)

### DIFF
--- a/guides/compatibility.md
+++ b/guides/compatibility.md
@@ -34,6 +34,22 @@ Microsoft Exchange and Outlook often output Windows-specific timezone names (e.g
 Some feeds contain date strings with an illegal time suffix (e.g., `20240115T000000` for a `DATE` type).
 * **Fixup (`date_compat`)**: Strips the invalid time suffix to parse the date correctly.
 
+### DURATION and DTEND Conflict
+RFC 5545 Section 3.6.1 forbids specifying both `DTEND` and `DURATION` on the same event, but some real-world generators emit both anyway (often redundantly, with `DTEND` equal to `DTSTART` + `DURATION`).
+* **Fixup (`duration_dtend_compat`)**: Prefers the more explicit `DTEND` value and discards `DURATION` rather than failing to parse.
+
+## Audited But Not Fixed
+
+As part of auditing this module (see [issue #637](https://github.com/allenporter/ical/issues/637)), the following commonly-reported broken patterns were investigated and found to already parse correctly without any compatibility fixup, so no change was made for them:
+
+* **Missing `VTIMEZONE` with a valid IANA `TZID`** — an event referencing e.g. `TZID=America/New_York` with no matching `VTIMEZONE` block already resolves correctly, because timezone resolution falls back to the system/`tzdata` `zoneinfo` database for any TZID that is a valid IANA name.
+* **Long, unfolded property lines** — the parsing grammar does not require RFC 5545 line folding; single long lines (e.g. long `DESCRIPTION` values) parse without issue.
+* **Missing `UID`** — the `Event` model auto-generates a `UID` when one isn't present in the source data.
+* **Smart quotes and other Unicode text** — as long as the file is valid UTF-8, quotes, em-dashes, and similar characters in text fields parse without modification.
+* **`ORGANIZER`/`ATTENDEE` without a `mailto:` prefix, or with an empty value** — these are treated as opaque URI strings and are not required to have a `mailto:` prefix, so they parse successfully as-is.
+
+These are intentionally left undocumented as "fixups" since there is nothing to fix — flagging that distinction here so a future audit doesn't re-investigate the same ground.
+
 ## The `ical.compat` Design & PRODID Detection
 
 Instead of using a blanket "lenient mode" that disables all validation, `ical.compat` uses targeted fixups driven by the `PRODID` (Product Identifier) of the calendar. This is superior because:

--- a/ical/compat/duration_dtend_compat.py
+++ b/ical/compat/duration_dtend_compat.py
@@ -1,0 +1,31 @@
+"""Compatibility layer for resolving conflicting DURATION and DTEND values.
+
+RFC 5545 Section 3.6.1 states that a VEVENT may specify either DTEND or
+DURATION to describe its end, but never both. Some real-world calendar
+generators emit both properties on the same event regardless (often
+redundantly, with DTEND equal to DTSTART + DURATION). Strict parsing
+rejects this outright; this compatibility fixup instead prefers the
+more explicit DTEND value and discards DURATION.
+"""
+
+from collections.abc import Generator
+import contextlib
+import contextvars
+
+
+_duration_dtend_compat = contextvars.ContextVar("duration_dtend_compat", default=False)
+
+
+@contextlib.contextmanager
+def enable_duration_dtend_compat() -> Generator[None]:
+    """Context manager to enable DURATION/DTEND conflict compatibility mode."""
+    token = _duration_dtend_compat.set(True)
+    try:
+        yield
+    finally:
+        _duration_dtend_compat.reset(token)
+
+
+def is_duration_dtend_compat_enabled() -> bool:
+    """Check if DURATION/DTEND conflict compatibility mode is enabled."""
+    return _duration_dtend_compat.get()

--- a/ical/compat/make_compat.py
+++ b/ical/compat/make_compat.py
@@ -9,7 +9,13 @@ from collections.abc import Generator
 import logging
 import re
 
-from . import date_compat, dtstart_until_compat, same_day_dtend_compat, timezone_compat
+from . import (
+    date_compat,
+    dtstart_until_compat,
+    duration_dtend_compat,
+    same_day_dtend_compat,
+    timezone_compat,
+)
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,6 +44,7 @@ def enable_compat_mode(ics: str) -> Generator[str]:
     with (
         same_day_dtend_compat.enable_same_day_dtend_compat(),
         date_compat.enable_allow_invalid_dates(),
+        duration_dtend_compat.enable_duration_dtend_compat(),
     ):
         # Check if the PRODID is from Microsoft Exchange Server
         prodid = _get_prodid(ics)

--- a/ical/event.py
+++ b/ical/event.py
@@ -22,7 +22,7 @@ from typing import Annotated, Any, Optional, Self, Union
 
 from pydantic import BeforeValidator, Field, field_serializer, model_validator
 
-from ical.compat import same_day_dtend_compat
+from ical.compat import duration_dtend_compat, same_day_dtend_compat
 from ical.types.data_types import serialize_field
 
 from .alarm import Alarm
@@ -475,7 +475,20 @@ class Event(ComponentModel):
     def _validate_one_end_or_duration(self) -> Self:
         """Validate that only one of duration or end date may be set."""
         if self.dtend and self.duration:
-            raise ValueError("Only one of dtend or duration may be set.")
+            if duration_dtend_compat.is_duration_dtend_compat_enabled():
+                # RFC 5545 3.6.1 forbids specifying both DTEND and DURATION,
+                # but some real-world generators emit both anyway (often
+                # redundantly). Prefer the more explicit DTEND value and
+                # drop DURATION rather than failing to parse.
+                _LOGGER.warning(
+                    "Event has both DTEND (%s) and DURATION (%s) set; "
+                    "dropping DURATION per compat mode",
+                    self.dtend,
+                    self.duration,
+                )
+                self.duration = None
+            else:
+                raise ValueError("Only one of dtend or duration may be set.")
         return self
 
     @model_validator(mode="after")

--- a/tests/compat/test_duration_dtend_compat.py
+++ b/tests/compat/test_duration_dtend_compat.py
@@ -1,0 +1,110 @@
+"""Tests for the DURATION/DTEND conflict compatibility component.
+
+RFC 5545 Section 3.6.1 states that a VEVENT may have either DTEND or
+DURATION, but never both. Some real-world calendar generators emit both
+properties redundantly (e.g. a DTEND that is simply DTSTART + DURATION),
+which causes strict parsing to fail outright even though the event's
+intent is unambiguous.
+"""
+
+import pytest
+
+from ical.exceptions import CalendarParseError
+from ical.calendar_stream import IcsCalendarStream
+from ical.compat import duration_dtend_compat, enable_compat_mode
+
+DUPLICATE_DURATION_DTEND_ICS = """BEGIN:VCALENDAR
+PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+VERSION:2.0
+BEGIN:VEVENT
+DTSTAMP:19970610T172345Z
+UID:19970610T172345Z-AF23B2@example.com
+DTSTART:20260920T080000Z
+DTEND:20260920T090000Z
+DURATION:PT1H
+SUMMARY:Both DTEND and DURATION set
+END:VEVENT
+END:VCALENDAR"""
+
+# DTEND that disagrees with DTSTART + DURATION.
+CONFLICTING_DURATION_DTEND_ICS = """BEGIN:VCALENDAR
+PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+VERSION:2.0
+BEGIN:VEVENT
+DTSTAMP:19970610T172345Z
+UID:19970610T172345Z-AF23B3@example.com
+DTSTART:20260920T080000Z
+DTEND:20260920T093000Z
+DURATION:PT1H
+SUMMARY:Conflicting DTEND and DURATION values
+END:VEVENT
+END:VCALENDAR"""
+
+
+def test_duration_dtend_conflict_fails_without_compat() -> None:
+    """Test that parsing fails under strict mode when both are set."""
+    with pytest.raises(
+        CalendarParseError, match="Only one of dtend or duration may be set"
+    ):
+        IcsCalendarStream.calendar_from_ics(DUPLICATE_DURATION_DTEND_ICS)
+
+
+def test_duration_dtend_conflict_compat_mode() -> None:
+    """Test that compat mode resolves the conflict by preferring DTEND."""
+    with enable_compat_mode(DUPLICATE_DURATION_DTEND_ICS) as compat_ics:
+        calendar = IcsCalendarStream.calendar_from_ics(compat_ics)
+
+    assert len(calendar.events) == 1
+    event = calendar.events[0]
+    assert event.duration is None
+    assert str(event.dtend) == "2026-09-20 09:00:00+00:00"
+
+    # Verify the output re-serializes and re-parses cleanly (no DURATION
+    # property line; note "DURATION" also appears inside the free-text
+    # SUMMARY, so match on the property line specifically).
+    output_ics = IcsCalendarStream.calendar_to_ics(calendar)
+    assert "\nDURATION:" not in output_ics
+    reparsed = IcsCalendarStream.calendar_from_ics(output_ics)
+    assert str(reparsed.events[0].dtend) == "2026-09-20 09:00:00+00:00"
+
+
+def test_duration_dtend_conflicting_values_compat_mode() -> None:
+    """Test that compat mode prefers DTEND even when values disagree."""
+    with duration_dtend_compat.enable_duration_dtend_compat():
+        calendar = IcsCalendarStream.calendar_from_ics(CONFLICTING_DURATION_DTEND_ICS)
+
+    event = calendar.events[0]
+    assert event.duration is None
+    # DTEND (the more explicit, unambiguous property) wins.
+    assert str(event.dtend) == "2026-09-20 09:30:00+00:00"
+
+
+def test_duration_dtend_compat_context_manager() -> None:
+    """Test that compat mode is properly enabled/disabled."""
+    assert not duration_dtend_compat.is_duration_dtend_compat_enabled()
+
+    with duration_dtend_compat.enable_duration_dtend_compat():
+        assert duration_dtend_compat.is_duration_dtend_compat_enabled()
+
+    assert not duration_dtend_compat.is_duration_dtend_compat_enabled()
+
+
+def test_duration_only_still_works_under_compat() -> None:
+    """Test that events with only DURATION (no DTEND) are unaffected."""
+    ics = """BEGIN:VCALENDAR
+PRODID:-//hacksw/handcal//NONSGML v1.0//EN
+VERSION:2.0
+BEGIN:VEVENT
+DTSTAMP:19970610T172345Z
+UID:duration-only@example.com
+DTSTART:20260920T080000Z
+DURATION:PT1H
+SUMMARY:Duration only event
+END:VEVENT
+END:VCALENDAR"""
+    with duration_dtend_compat.enable_duration_dtend_compat():
+        calendar = IcsCalendarStream.calendar_from_ics(ics)
+
+    event = calendar.events[0]
+    assert event.duration is not None
+    assert event.dtend is None


### PR DESCRIPTION
## Summary

Works on #637, which asks to audit `ical.compat` coverage, document what real-world broken `.ics` patterns are/aren't handled, and expand test coverage.

**Note on scope**: the issue's top-priority gap — `X-WR-TIMEZONE` without `VTIMEZONE` — was already implemented and merged in #645 (closing #511, though the auto-close link to #637 didn't fire). I re-verified this is live on `main` before starting, so this PR picks up the next highest-value item from the issue's list instead of duplicating that work.

## What I audited

I wrote small reproduction scripts for each pattern in the issue's "Moderate/Lower Frequency" list and ran them against current `main` (no compat mode) to see what actually breaks today:

| Pattern | Result |
|---|---|
| Missing `VTIMEZONE` for a valid IANA `TZID` | **Already works** — falls back to system/`tzdata` `zoneinfo` |
| Long, unfolded property lines | **Already works** — grammar doesn't require RFC 5545 folding |
| Missing `UID` | **Already works** — auto-generated |
| Smart quotes / Unicode text | **Already works** — plain UTF-8 text |
| `ORGANIZER`/`ATTENDEE` without `mailto:`, or empty | **Already works** — treated as opaque URI |
| **`DURATION` + `DTEND` both set (RFC 5545 §3.6.1 forbids this)** | **Fails today** — raises `CalendarParseError` |

Only the last one is a genuine gap, so that's the fix in this PR. The others are documented in `guides/compatibility.md` under a new "Audited But Not Fixed" section so a future pass doesn't re-investigate the same ground.

## The fix

Adds `ical/compat/duration_dtend_compat.py`, following the exact pattern of the existing `same_day_dtend_compat`/`date_compat` modules (a `contextvars`-backed context manager). It's wired into `enable_compat_mode()` as an always-on fixup (not PRODID-gated), same as those two, since the conflict isn't tied to a specific producer.

When both `DTEND` and `DURATION` are present and compat mode is enabled, `Event._validate_one_end_or_duration` now prefers the more explicit `DTEND` value, drops `DURATION`, and logs a warning — instead of raising. Without compat mode, behavior is unchanged (still raises).

## What I intentionally left out

- Didn't touch `X-WR-TIMEZONE` handling (already done in #645).
- Didn't add fixups for the "already works" patterns above — there's nothing broken to fix, and adding tolerance without a real failure would just be scope creep / "security theater" for a parser.
- Didn't attempt a full audit of every RFC 5545 corner case in one PR — picked the one concrete, demonstrated gap plus documentation of what was ruled out, so this stays reviewable.

## Testing

- `tests/compat/test_duration_dtend_compat.py` (new): confirms strict-mode still raises without compat, confirms compat mode resolves both a "redundant" case (DTEND == DTSTART+DURATION) and a "conflicting" case (DTEND != DTSTART+DURATION, DTEND wins), checks the context manager toggles cleanly, checks DURATION-only events are unaffected, and round-trips output back through the parser.
- Verified the new test **fails on `main`** before the fix (`ImportError: cannot import name 'duration_dtend_compat'`), confirming it isn't a vacuous test.
- Full suite: `1438 passed, 35 skipped` (up from `1433 passed, 35 skipped` on `main`, i.e. only the 5 new tests added, no regressions).
- `script/lint` (ruff check/format, ty, codespell, yamllint via pre-commit): all green.

## Left for a future pass

- `ORGANIZER`/`ATTENDEE` never had strict `mailto:` validation to begin with, so there isn't a "before/after" fixup to add there — flagged in the issue as worth a closer look, but I found no failure mode.
- The issue also asks for a "Handling broken ICS files" README/quickstart callout; `guides/compatibility.md` (added in #648) and `guides/timezone.md` already cover this fairly prominently, so I didn't duplicate that here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)