### PR TITLE
fix: Support parsing CONFERENCE property with VALUE=URI parameter (#670)

### DIFF
--- a/ical/types/conference.py
+++ b/ical/types/conference.py
@@ -28,7 +28,7 @@ class Feature(ExtensibleEnum):
     MORE = "MORE"
 
 
-@DATA_TYPE.register("CONFERENCE")
+@DATA_TYPE.register("CONFERENCE", disable_value_param=True)
 class Conference(BaseModel):
     """A value type for a property that contains conference information."""
 

--- a/tests/types/test_conference.py
+++ b/tests/types/test_conference.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ical.calendar_stream import IcsCalendarStream
 from ical.types import Conference, Feature, Uri
 
 
@@ -27,3 +28,81 @@ def test_feature_enum() -> None:
     assert Feature("audio") == Feature.AUDIO  # case insensitive fallback lookup
     assert Feature("x-custom") == "x-custom"  # custom token fallback
     assert Feature._missing_(None) is None
+
+
+def test_conference_value_uri() -> None:
+    """Test parsing CONFERENCE property with VALUE=URI parameter (issue #670)."""
+    ics = (
+        "BEGIN:VCALENDAR\n"
+        "VERSION:2.0\n"
+        "PRODID:-//Example//EN\n"
+        "BEGIN:VEVENT\n"
+        "UID:test-conference-uri\n"
+        "DTSTART:20260805T100000Z\n"
+        "DTEND:20260805T110000Z\n"
+        "SUMMARY:Meeting with Conference Link\n"
+        "CONFERENCE;VALUE=URI:https://zoom.us/j/1234567890\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n"
+    )
+    calendar = IcsCalendarStream.calendar_from_ics(ics)
+    assert len(calendar.events) == 1
+    event = calendar.events[0]
+    assert len(event.conference) == 1
+    assert event.conference[0].uri == Uri("https://zoom.us/j/1234567890")
+
+
+def test_rfc7986_canonical_examples() -> None:
+    """Test canonical RFC 7986 Section 5.11 CONFERENCE examples."""
+    ics = (
+        "BEGIN:VCALENDAR\n"
+        "VERSION:2.0\n"
+        "PRODID:-//Example//EN\n"
+        "BEGIN:VEVENT\n"
+        "UID:rfc7986-conference-examples\n"
+        "DTSTART:20260805T100000Z\n"
+        "DTEND:20260805T110000Z\n"
+        "SUMMARY:RFC 7986 Conference Test\n"
+        "CONFERENCE;VALUE=URI;FEATURE=AUDIO,VIDEO;"
+        'LABEL="Web video chat, access code=76543":'
+        "https://video-chat.example.com/;group-id=1234\n"
+        'CONFERENCE;VALUE=URI;FEATURE=AUDIO;LABEL="Attendee dial-in":'
+        "tel:+1-412-555-0123,,,654321#\n"
+        "CONFERENCE;VALUE=URI;FEATURE=MODERATOR,AUDIO;"
+        'LABEL="Moderator dial-in":tel:+1-412-555-0123,,,987654#\n'
+        "CONFERENCE;VALUE=URI;FEATURE=CHAT:"
+        "xmpp:room123@chat.example.com?join\n"
+        "CONFERENCE;VALUE=URI;FEATURE=AUDIO,VIDEO:sip:user@example.com\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR\n"
+    )
+    calendar = IcsCalendarStream.calendar_from_ics(ics)
+    assert len(calendar.events) == 1
+    event = calendar.events[0]
+    assert len(event.conference) == 5
+
+    # Web video chat
+    assert event.conference[0].uri == Uri(
+        "https://video-chat.example.com/;group-id=1234"
+    )
+    assert event.conference[0].feature == [Feature.AUDIO, Feature.VIDEO]
+    assert event.conference[0].label == "Web video chat, access code=76543"
+
+    # Attendee tel: dial-in
+    assert event.conference[1].uri == Uri("tel:+1-412-555-0123,,,654321#")
+    assert event.conference[1].feature == [Feature.AUDIO]
+    assert event.conference[1].label == "Attendee dial-in"
+
+    # Moderator tel: dial-in
+    assert event.conference[2].uri == Uri("tel:+1-412-555-0123,,,987654#")
+    assert event.conference[2].feature == ["MODERATOR", Feature.AUDIO]
+    assert event.conference[2].label == "Moderator dial-in"
+
+    # XMPP chat
+    assert event.conference[3].uri == Uri("xmpp:room123@chat.example.com?join")
+    assert event.conference[3].feature == [Feature.CHAT]
+
+    # SIP call
+    assert event.conference[4].uri == Uri("sip:user@example.com")
+    assert event.conference[4].feature == [Feature.AUDIO, Feature.VIDEO]
+

--- a/tests/types/test_conference.py
+++ b/tests/types/test_conference.py
@@ -105,4 +105,3 @@ def test_rfc7986_canonical_examples() -> None:
     # SIP call
     assert event.conference[4].uri == Uri("sip:user@example.com")
     assert event.conference[4].feature == [Feature.AUDIO, Feature.VIDEO]
-


### PR DESCRIPTION
Fixes #670

### Motivation
Fixes a `CalendarParseError` when parsing iCalendar streams containing `CONFERENCE` properties with explicit `VALUE=URI` parameters (e.g., `CONFERENCE;VALUE=URI:https://zoom.us/j/1234567890` or `CONFERENCE;VALUE=URI:tel:1234567890`).

### High-Level Fix
- Instructed the property registry to retain model-level parsing for `CONFERENCE` properties rather than letting a top-level `VALUE=URI` parameter bypass the `Conference` model and produce a standalone `Uri` instance.
- Preserves full `Conference` model instantiation (including parameters like `LABEL`, `FEATURE`, and `LANGUAGE`) while still performing full URI parsing on the underlying `uri` field.
- Added comprehensive unit tests covering `VALUE=URI` and canonical RFC 7986 Section 5.11 conference examples in [`tests/types/test_conference.py`](file:///workspaces/ical/tests/types/test_conference.py).