### PR TITLE
fix: Allow duration values missing T separator in compat mode (#671)

### DIFF
--- a/ical/compat/duration_compat.py
+++ b/ical/compat/duration_compat.py
@@ -1,0 +1,22 @@
+"""Compatibility layer for allowing non-conforming duration formats in iCalendar files."""
+
+from collections.abc import Generator
+import contextlib
+import contextvars
+
+_duration_compat = contextvars.ContextVar("duration_compat", default=False)
+
+
+@contextlib.contextmanager
+def enable_duration_compat() -> Generator[None]:
+    """Context manager to allow non-conforming duration formats in iCalendar files."""
+    token = _duration_compat.set(True)
+    try:
+        yield
+    finally:
+        _duration_compat.reset(token)
+
+
+def is_duration_compat_enabled() -> bool:
+    """Check if non-conforming duration compatibility is enabled."""
+    return _duration_compat.get()

--- a/ical/compat/make_compat.py
+++ b/ical/compat/make_compat.py
@@ -12,6 +12,7 @@ import re
 from . import (
     date_compat,
     dtstart_until_compat,
+    duration_compat,
     duration_dtend_compat,
     same_day_dtend_compat,
     timezone_compat,
@@ -39,11 +40,12 @@ def _get_prodid(ics: str) -> str | None:
 @contextlib.contextmanager
 def enable_compat_mode(ics: str) -> Generator[str]:
     """Enable compatibility mode to fix known broken calendar content."""
-    # Always enable same-day DTEND compatibility for all calendars
+    # Always enable same-day DTEND, invalid dates, and duration compatibility for all calendars
     # This is a common issue across many calendar providers
     with (
         same_day_dtend_compat.enable_same_day_dtend_compat(),
         date_compat.enable_allow_invalid_dates(),
+        duration_compat.enable_duration_compat(),
         duration_dtend_compat.enable_duration_dtend_compat(),
     ):
         # Check if the PRODID is from Microsoft Exchange Server

--- a/ical/types/duration.py
+++ b/ical/types/duration.py
@@ -3,6 +3,7 @@
 import datetime
 import re
 
+from ical.compat.duration_compat import is_duration_compat_enabled
 from ical.parsing.property import ParsedProperty
 
 from .data_types import DATA_TYPE
@@ -12,6 +13,10 @@ TIME_PART = r"T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?"
 DATETIME_PART = f"(?:{DATE_PART})?(?:{TIME_PART})?"
 WEEKS_PART = r"(?:(\d+)W)?"
 DURATION_REGEX = re.compile(f"([-+]?)P(?:{WEEKS_PART}{DATETIME_PART})$")
+
+COMPAT_TIME_PART = r"(?:T)?(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?"
+COMPAT_DATETIME_PART = f"(?:{DATE_PART})?(?:{COMPAT_TIME_PART})?"
+COMPAT_DURATION_REGEX = re.compile(f"([-+]?)P(?:{WEEKS_PART}{COMPAT_DATETIME_PART})$")
 
 
 @DATA_TYPE.register("DURATION")
@@ -27,7 +32,10 @@ class DurationEncoder:
         """Parse a rfc5545 into a datetime.date."""
         if not isinstance(prop, ParsedProperty):
             raise ValueError(f"Expected ParsedProperty but was {prop}")
-        if not (match := DURATION_REGEX.fullmatch(prop.value)):
+        match = DURATION_REGEX.fullmatch(prop.value)
+        if not match and is_duration_compat_enabled():
+            match = COMPAT_DURATION_REGEX.fullmatch(prop.value)
+        if not match:
             raise ValueError(f"Expected value to match DURATION pattern: {prop.value}")
         sign, weeks, days, hours, minutes, seconds = match.groups()
         result: datetime.timedelta = datetime.timedelta(

--- a/tests/compat/test_duration_compat.py
+++ b/tests/compat/test_duration_compat.py
@@ -1,0 +1,67 @@
+"""Tests for non-conforming duration string compatibility layer."""
+
+import datetime
+import pytest
+
+from ical.calendar_stream import IcsCalendarStream
+from ical.compat import duration_compat, enable_compat_mode
+from ical.exceptions import CalendarParseError
+from ical.parsing.property import ParsedProperty
+from ical.types.duration import DurationEncoder
+
+INVALID_DURATION_ICS = """BEGIN:VCALENDAR
+PRODID:-//Example//EN
+VERSION:2.0
+BEGIN:VEVENT
+UID:test-duration-p1h
+DTSTART:20260805T100000Z
+DURATION:P1H
+SUMMARY:Event with non-standard duration
+END:VEVENT
+END:VCALENDAR"""
+
+
+def test_duration_missing_t_parsing_fail() -> None:
+    """Test that parsing fails in strict mode for DURATION missing T separator."""
+    with pytest.raises(
+        CalendarParseError,
+        match=r"Expected value to match DURATION pattern: P1H",
+    ):
+        IcsCalendarStream.calendar_from_ics(INVALID_DURATION_ICS)
+
+
+def test_duration_missing_t_parsing_compat_mode() -> None:
+    """Test that parsing succeeds in compat mode for DURATION missing T separator."""
+    with enable_compat_mode(INVALID_DURATION_ICS) as compat_ics:
+        calendar = IcsCalendarStream.calendar_from_ics(compat_ics)
+
+    assert len(calendar.events) == 1
+    event = calendar.events[0]
+    assert event.duration == datetime.timedelta(hours=1)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("P1H", datetime.timedelta(hours=1)),
+        ("P30M", datetime.timedelta(minutes=30)),
+        ("P45S", datetime.timedelta(seconds=45)),
+        ("P1H30M", datetime.timedelta(hours=1, minutes=30)),
+        ("P1D2H30M", datetime.timedelta(days=1, hours=2, minutes=30)),
+        ("-P15M", datetime.timedelta(minutes=-15)),
+    ],
+)
+def test_duration_direct_compat(value: str, expected: datetime.timedelta) -> None:
+    """Test that parsing non-conforming durations directly succeeds when duration_compat is enabled."""
+    # Fails in strict mode
+    with pytest.raises(ValueError, match="Expected value to match DURATION pattern"):
+        DurationEncoder.__parse_property_value__(
+            ParsedProperty(name="DURATION", value=value)
+        )
+
+    # Succeeds with compat manager
+    with duration_compat.enable_duration_compat():
+        result = DurationEncoder.__parse_property_value__(
+            ParsedProperty(name="DURATION", value=value)
+        )
+        assert result == expected


### PR DESCRIPTION
Fixes #671 by introducing duration compatibility support when compatibility mode is enabled. Non-conforming duration strings missing the `T` time separator (such as `P1H`, `P30M`, `P1H30M`, `P1D2H`) are parsed gracefully in compat mode while maintaining strict RFC 5545 validation by default.