### PR TITLE
fix: Single-pass unescaping for RFC 5545 TEXT property values

### DIFF
--- a/ical/types/text.py
+++ b/ical/types/text.py
@@ -1,11 +1,26 @@
 """Library for parsing TEXT values."""
 
+import re
+
+
 from ical.parsing.property import ParsedProperty, RE_CONTROL_CHARS
 
 from .data_types import DATA_TYPE
 
-UNESCAPE_CHAR = {"\\\\": "\\", "\\;": ";", "\\,": ",", "\\N": "\n", "\\n": "\n"}
-ESCAPE_CHAR = {v: k for k, v in UNESCAPE_CHAR.items()}
+_UNESCAPE_RE = re.compile(r"\\([\\;,Nn])")
+_UNESCAPE_MAP = {
+    "\\": "\\",
+    ";": ";",
+    ",": ",",
+    "N": "\n",
+    "n": "\n",
+}
+ESCAPE_CHAR = {
+    "\\": "\\\\",
+    ";": "\\;",
+    ",": "\\,",
+    "\n": "\\n",
+}
 
 
 @DATA_TYPE.register("TEXT")
@@ -19,11 +34,7 @@ class TextEncoder:
     @classmethod
     def __parse_property_value__(cls, prop: ParsedProperty) -> str:
         """Parse a rfc5545 into a text value."""
-        for key, vin in UNESCAPE_CHAR.items():
-            if key not in prop.value:
-                continue
-            prop.value = prop.value.replace(key, vin)
-        return prop.value
+        return _UNESCAPE_RE.sub(lambda m: _UNESCAPE_MAP[m.group(1)], prop.value)
 
     @classmethod
     def __encode_property__(cls, value: str) -> ParsedProperty:

--- a/tests/__snapshots__/test_calendar_stream.ambr
+++ b/tests/__snapshots__/test_calendar_stream.ambr
@@ -1315,6 +1315,29 @@
     ]),
   })
 # ---
+# name: test_parse[todo_text_escaping]
+  dict({
+    'calendars': list([
+      dict({
+        'prodid': '-//example//1.2.3',
+        'todos': list([
+          dict({
+            'description': '''
+              Item with path C:\notes\todo.txt, semicolons \; and commas \, and actual
+              newline and uppercase 
+  
+            ''',
+            'dtstamp': '2026-08-16T17:00:00Z',
+            'status': 'NEEDS-ACTION',
+            'summary': 'old\\new',
+            'uid': 'todo-text-escaping-1',
+          }),
+        ]),
+        'version': '2.0',
+      }),
+    ]),
+  })
+# ---
 # name: test_parse[todo_valarm]
   dict({
     'calendars': list([
@@ -2183,6 +2206,22 @@
   PRIORITY:1
   STATUS:NEEDS-ACTION
   SUMMARY:Submit Revised Internet-Draft
+  END:VTODO
+  END:VCALENDAR
+  '''
+# ---
+# name: test_serialize[todo_text_escaping]
+  '''
+  BEGIN:VCALENDAR
+  PRODID:-//example//1.2.3
+  VERSION:2.0
+  BEGIN:VTODO
+  DTSTAMP:20260816T170000Z
+  UID:todo-text-escaping-1
+  DESCRIPTION:Item with path C:\\notes\\todo.txt\, semicolons \\\; and commas
+    \\\, and actual\nnewline and uppercase \n
+  STATUS:NEEDS-ACTION
+  SUMMARY:old\\new
   END:VTODO
   END:VCALENDAR
   '''

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2180,3 +2180,90 @@ def test_recurrence_id_naive_fallback_still_works(
     assert len(events) == 4
     first_dt = datetime.datetime(2025, 5, 5, 10, 0, 0, tzinfo=NY_TZ)
     assert first_dt not in [e.dtstart for e in events]
+
+
+def test_todo_store_escaping_roundtrip(
+    calendar: Calendar,
+    todo_store: TodoStore,
+) -> None:
+    """Test end-to-end that todo characters requiring escaping survive serialize/reload."""
+    original_summary = r"old\new"
+    original_description = (
+        "Multi-line:\n"
+        r"- Path C:\notes\todo.txt" + "\n"
+        r"- Escaped delimiters: \; and \," + "\n"
+        r"- Literal double backslash: \\" + "\n"
+        r"- Semicolon ; and comma ,"
+    )
+
+    todo_store.add(
+        Todo(
+            summary=original_summary,
+            description=original_description,
+        )
+    )
+
+    # Serialize to ICS string
+    ics_text = IcsCalendarStream.calendar_to_ics(calendar)
+
+    # Reload into a completely new Calendar and TodoStore
+    reloaded_calendar = IcsCalendarStream.calendar_from_ics(ics_text)
+    reloaded_store = TodoStore(reloaded_calendar, tzinfo=TZ)
+
+    todos = list(reloaded_store.todo_list())
+    assert len(todos) == 1
+    assert todos[0].summary == original_summary
+    assert todos[0].description == original_description
+
+    # Test editing with escaping characters and roundtripping again
+    updated_summary = r"edited\new summary with ; and ,"
+    updated_description = r"edited\new description with \;"
+    reloaded_store.edit(
+        uid=todos[0].uid,
+        item=Todo(
+            summary=updated_summary,
+            description=updated_description,
+        ),
+    )
+
+    ics_text_2 = IcsCalendarStream.calendar_to_ics(reloaded_calendar)
+    reloaded_calendar_2 = IcsCalendarStream.calendar_from_ics(ics_text_2)
+    reloaded_store_2 = TodoStore(reloaded_calendar_2, tzinfo=TZ)
+
+    todos_2 = list(reloaded_store_2.todo_list())
+    assert len(todos_2) == 1
+    assert todos_2[0].summary == updated_summary
+    assert todos_2[0].description == updated_description
+
+
+def test_event_store_escaping_roundtrip(
+    calendar: Calendar,
+    store: EventStore,
+) -> None:
+    """Test end-to-end that event characters requiring escaping survive serialize/reload."""
+    original_summary = r"Meeting: Review old\new designs"
+    original_description = (
+        r"Notes: C:\docs\review.pdf; check items (a, b) and \n literal"
+    )
+    original_location = r"Room 101\; Building \B"
+
+    store.add(
+        Event(
+            summary=original_summary,
+            description=original_description,
+            location=original_location,
+            start=datetime.datetime(2025, 5, 5, 10, 0, 0, tzinfo=TZ),
+            end=datetime.datetime(2025, 5, 5, 11, 0, 0, tzinfo=TZ),
+        )
+    )
+
+    ics_text = IcsCalendarStream.calendar_to_ics(calendar)
+
+    reloaded_calendar = IcsCalendarStream.calendar_from_ics(ics_text)
+    reloaded_store = EventStore(reloaded_calendar)
+
+    events = list(reloaded_calendar.timeline)
+    assert len(events) == 1
+    assert events[0].summary == original_summary
+    assert events[0].description == original_description
+    assert events[0].location == original_location

--- a/tests/testdata/todo_text_escaping.ics
+++ b/tests/testdata/todo_text_escaping.ics
@@ -1,0 +1,11 @@
+BEGIN:VCALENDAR
+PRODID:-//example//1.2.3
+VERSION:2.0
+BEGIN:VTODO
+UID:todo-text-escaping-1
+DTSTAMP:20260816T170000Z
+SUMMARY:old\\new
+DESCRIPTION:Item with path C:\\notes\\todo.txt\, semicolons \\; and commas \\, and actual\nnewline and uppercase \N
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR

--- a/tests/types/test_text.py
+++ b/tests/types/test_text.py
@@ -56,3 +56,59 @@ def test_text_control_characters() -> None:
             )
         ],
     )
+
+
+def test_text_escaping_combinations() -> None:
+    """Test parsing and encoding of various escaped characters."""
+    # Test rfc5545 escaped characters: \\n, \\N, \\;, \\,, \\\\
+    component = ParsedComponent(name="text-model")
+    component.properties.append(
+        ParsedProperty(
+            name="text_value",
+            value=r"old\\new and a\;b and c\,d and e\\f and g\nh and i\Nj",
+        )
+    )
+    model = Model.model_validate(component.as_dict())
+    assert model.text_value == "old\\new and a;b and c,d and e\\f and g\nh and i\nj"
+
+    # Test round trip encoding
+    encoded = model.__encode_component_root__()
+    assert encoded == ParsedComponent(
+        name="Model",
+        properties=[
+            ParsedProperty(
+                name="text_value",
+                value=r"old\\new and a\;b and c\,d and e\\f and g\nh and i\nj",
+            )
+        ],
+    )
+
+
+def test_text_literal_escaped_characters() -> None:
+    """Test that literal backslashes followed by delimiter characters are parsed correctly."""
+    # Input has escaped backslash followed by ;, ,, n
+    component = ParsedComponent(name="text-model")
+    component.properties.append(
+        ParsedProperty(
+            name="text_value",
+            value=r"path\\name and delim\\; and comma\\, and double\\\\slash",
+        )
+    )
+    model = Model.model_validate(component.as_dict())
+    assert model.text_value == r"path\name and delim\; and comma\, and double\\slash"
+
+    # When encoded, the literal backslashes and delimiters are properly escaped
+    encoded = model.__encode_component_root__()
+    assert encoded == ParsedComponent(
+        name="Model",
+        properties=[
+            ParsedProperty(
+                name="text_value",
+                value=r"path\\name and delim\\\; and comma\\\, and double\\\\slash",
+            )
+        ],
+    )
+
+    # When decoded again, we get the exact same text_value back
+    reparsed = Model.model_validate(encoded.as_dict())
+    assert reparsed.text_value == model.text_value


### PR DESCRIPTION
## Description
Fixes an issue where character sequences such as `old\new`, `\;`, and `\,` in RFC 5545 `TEXT` properties (e.g. `SUMMARY`, `DESCRIPTION`) were improperly unescaped when reloading from an iCalendar file (such as in Home Assistant's `local_todo` integration, reported in home-assistant/core#175556).

### Cause
`TextEncoder.__parse_property_value__` previously performed sequential dictionary replacement over `UNESCAPE_CHAR`. During the first pass, `\\\\` was unescaped to `\\`, creating a backslash that was re-evaluated and matched by subsequent `\\n`, `\\;`, or `\\,` rules in the same pass.

### Solution
- Replaced sequential dictionary replacement with a single-pass regex (`_UNESCAPE_RE = re.compile(r"\\([\\;,Nn])")`) mapping each escape sequence directly to its decoded character without rescanning unescaped backslashes.
- Added a new test calendar `tests/testdata/todo_text_escaping.ics`.
- Added unit tests in `tests/types/test_text.py` covering all RFC 5545 escaping combinations and literal backslashes.
- Added end-to-end `TodoStore` and `EventStore` roundtrip tests in `tests/test_store.py` validating that creating, editing, serializing, and reloading items with characters requiring escaping maintains exact string fidelity.