### PR TITLE
feat(diff): compare two versions of the same calendar

### DIFF
--- a/ical/__init__.py
+++ b/ical/__init__.py
@@ -6,6 +6,7 @@ __all__ = [
     "alarm",
     "calendar",
     "calendar_stream",
+    "diff",
     "event",
     "freebusy",
     "journal",

--- a/ical/diff.py
+++ b/ical/diff.py
@@ -24,6 +24,15 @@ def _identity(event: Event) -> tuple[str, str]:
     specific instance within it additionally needs `recurrence_id`. Two
     events sharing both identify the same occurrence, even across separate
     parses of separate fetches.
+
+    Compared as a plain string. `RecurrenceId` also carries `tzinfo` and
+    `range`, parsed from the TZID/RANGE property parameters, but they are
+    ordinary instance attributes bolted onto a `str` subclass rather than
+    part of its `__eq__` -- so two occurrences with the same recurrence_id
+    string but different tzinfo/range would still identify the same
+    occurrence here. That can't produce a missed content change: since
+    recurrence_id is the identity key, it is always equal-by-construction
+    within a pair `_content_equal` ever compares.
     """
     return (event.uid, event.recurrence_id or "")
 

--- a/ical/diff.py
+++ b/ical/diff.py
@@ -1,0 +1,108 @@
+"""Comparing two versions of the same set of events.
+
+A calendar fetched on a recurring basis -- a sports fixture list, a class
+timetable, a shared team calendar -- changes between fetches. This module
+answers what changed, using the identity rule rfc5545 already defines
+rather than a naive comparison by `uid` alone, which is wrong the moment a
+recurring event has a modified instance: those share a `uid` with the
+series and differ only by `recurrence_id`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+from .event import Event
+
+__all__ = ["EventChange", "EventDiff", "diff_events"]
+
+
+def _identity(event: Event) -> tuple[str, str]:
+    """Return the rfc5545 identity of an event occurrence.
+
+    The full range of a recurrence set is referenced by `uid` alone; a
+    specific instance within it additionally needs `recurrence_id`. Two
+    events sharing both identify the same occurrence, even across separate
+    parses of separate fetches.
+    """
+    return (event.uid, event.recurrence_id or "")
+
+
+def _content_equal(old: Event, new: Event) -> bool:
+    """Return whether two same-identity events have the same content.
+
+    `dtstamp` is excluded: it records when the ics object was generated,
+    not the event's own content, and some producers regenerate it on every
+    export of an otherwise unchanged event. Comparing it would report every
+    event from such a producer as changed, defeating the point of a diff.
+    Every other field, including `extras` (passthrough unknown properties),
+    is compared -- a producer that encodes something volatile there is a
+    real gap, not one to guess a fix for without a sample to test against.
+    """
+    return old.model_copy(update={"dtstamp": None}) == new.model_copy(
+        update={"dtstamp": None}
+    )
+
+
+@dataclasses.dataclass
+class EventChange:
+    """An occurrence present in both calendars with different content."""
+
+    old: Event
+    """The occurrence as it appeared in the old calendar."""
+
+    new: Event
+    """The occurrence as it appears in the new calendar."""
+
+
+@dataclasses.dataclass
+class EventDiff:
+    """The result of comparing the events of two calendars."""
+
+    added: list[Event]
+    """Occurrences present in the new calendar but not the old one."""
+
+    removed: list[Event]
+    """Occurrences present in the old calendar but not the new one."""
+
+    changed: list[EventChange]
+    """Occurrences present in both, with different content."""
+
+
+def diff_events(old: list[Event], new: list[Event]) -> EventDiff:
+    """Compare the events of two fetches of the same calendar.
+
+    Matches occurrences by `uid` and `recurrence_id`, the identity rfc5545
+    defines for a specific instance of a (possibly recurring) event, not by
+    `uid` alone -- which conflates a whole recurring series with any single
+    modified instance within it, since both carry the same `uid`.
+
+    If the same identity appears more than once within `old` or within
+    `new` -- a malformed but not impossible calendar -- the last occurrence
+    for that identity in the list wins, matching the semantics of building
+    a `dict` from it. Results are ordered by each identity's first
+    appearance in the respective list.
+    """
+    old_by_identity: dict[tuple[str, str], Event] = {}
+    for event in old:
+        old_by_identity[_identity(event)] = event
+
+    new_by_identity: dict[tuple[str, str], Event] = {}
+    for event in new:
+        new_by_identity[_identity(event)] = event
+
+    added: list[Event] = []
+    changed: list[EventChange] = []
+    for identity, new_event in new_by_identity.items():
+        if (old_event := old_by_identity.get(identity)) is None:
+            added.append(new_event)
+        elif not _content_equal(old_event, new_event):
+            changed.append(EventChange(old=old_event, new=new_event))
+
+    removed = [
+        event
+        for identity, event in old_by_identity.items()
+        if identity not in new_by_identity
+    ]
+
+    return EventDiff(added=added, removed=removed, changed=changed)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,157 @@
+"""Tests for comparing two versions of the same calendar (#677)."""
+
+import datetime
+
+from ical.calendar_stream import IcsCalendarStream
+from ical.diff import EventChange, diff_events
+from ical.event import Event
+
+_UTC = datetime.timezone.utc
+
+
+def _event(**kwargs) -> Event:
+    kwargs.setdefault("summary", "Race")
+    kwargs.setdefault("start", datetime.datetime(2025, 10, 26, 20, 0, tzinfo=_UTC))
+    return Event(**kwargs)
+
+
+def test_an_added_event_has_no_prior_occurrence() -> None:
+    new_event = _event(uid="race-2")
+
+    result = diff_events([], [new_event])
+
+    assert result.added == [new_event]
+    assert result.removed == []
+    assert result.changed == []
+
+
+def test_a_removed_event_has_no_later_occurrence() -> None:
+    old_event = _event(uid="race-1")
+
+    result = diff_events([old_event], [])
+
+    assert result.added == []
+    assert result.removed == [old_event]
+    assert result.changed == []
+
+
+def test_an_unchanged_event_is_neither_added_removed_nor_changed() -> None:
+    old_event = _event(uid="race-1")
+    new_event = _event(uid="race-1")
+
+    result = diff_events([old_event], [new_event])
+
+    assert result.added == []
+    assert result.removed == []
+    assert result.changed == []
+
+
+def test_a_changed_field_is_reported_with_old_and_new_values() -> None:
+    """The motivating case from the issue: the same race, a new start time."""
+    old_event = _event(uid="race-1", sequence=0)
+    new_event = _event(
+        uid="race-1",
+        start=datetime.datetime(2025, 10, 26, 20, 30, tzinfo=_UTC),
+        sequence=1,
+    )
+
+    result = diff_events([old_event], [new_event])
+
+    assert result.added == []
+    assert result.removed == []
+    assert result.changed == [EventChange(old=old_event, new=new_event)]
+
+
+def test_regenerated_dtstamp_alone_is_not_a_change() -> None:
+    """Some producers restamp DTSTAMP on every export of an unchanged event.
+
+    Comparing it would report every such event as changed on every fetch,
+    which defeats the point of a diff.
+    """
+    old_event = _event(uid="race-1", dtstamp=datetime.datetime(2025, 1, 1, tzinfo=_UTC))
+    new_event = _event(uid="race-1", dtstamp=datetime.datetime(2025, 1, 2, tzinfo=_UTC))
+
+    result = diff_events([old_event], [new_event])
+
+    assert result.changed == []
+
+
+def test_a_modified_recurrence_instance_is_matched_by_recurrence_id_not_uid_alone() -> (
+    None
+):
+    """The bug a naive `uid`-only diff has: a series and its own modified
+    instance share a `uid`, and are not the same occurrence."""
+    series = _event(uid="standup")
+    modified_instance = _event(
+        uid="standup",
+        recurrence_id="20251027T140000Z",
+        summary="Standup (moved)",
+    )
+
+    result = diff_events([series], [series, modified_instance])
+
+    assert result.added == [modified_instance]
+    assert result.removed == []
+    assert result.changed == []
+
+
+def test_a_change_to_a_modified_instance_is_reported_against_itself_not_the_series() -> (
+    None
+):
+    old_instance = _event(
+        uid="standup", recurrence_id="20251027T140000Z", summary="Standup (moved)"
+    )
+    new_instance = _event(
+        uid="standup",
+        recurrence_id="20251027T140000Z",
+        summary="Standup (moved again)",
+    )
+
+    result = diff_events([old_instance], [new_instance])
+
+    assert result.changed == [EventChange(old=old_instance, new=new_instance)]
+
+
+def test_a_duplicate_identity_within_one_list_keeps_the_last_occurrence() -> None:
+    """Documented, tested behaviour for a malformed-but-not-impossible input,
+    rather than leaving it as unspecified dict-overwrite behaviour."""
+    first = _event(uid="race-1", summary="Race (first copy)")
+    second = _event(uid="race-1", summary="Race (second copy)")
+
+    result = diff_events([], [first, second])
+
+    assert result.added == [second]
+
+
+def test_extras_are_part_of_the_comparison() -> None:
+    """Unlike `dtstamp`, passthrough unknown properties are not excluded:
+    a producer encoding real content there should still be caught."""
+    ics = """BEGIN:VCALENDAR
+PRODID:-//Example//Example//EN
+VERSION:2.0
+BEGIN:VEVENT
+DTSTAMP:20250715T100000Z
+UID:race-1
+DTSTART:20251026T200000Z
+SUMMARY:Race
+X-CUSTOM-STATUS:confirmed
+END:VEVENT
+END:VCALENDAR
+"""
+    old_event = IcsCalendarStream.calendar_from_ics(ics).events[0]
+    new_event = IcsCalendarStream.calendar_from_ics(
+        ics.replace("X-CUSTOM-STATUS:confirmed", "X-CUSTOM-STATUS:cancelled")
+    ).events[0]
+
+    result = diff_events([old_event], [new_event])
+
+    assert result.changed == [EventChange(old=old_event, new=new_event)]
+
+
+def test_result_order_follows_first_appearance_in_each_input_list() -> None:
+    a = _event(uid="a")
+    b = _event(uid="b")
+
+    result = diff_events([], [b, a])
+
+    assert result.added == [b, a]


### PR DESCRIPTION
Fixes #677.

## Summary

`diff_events(old, new)` compares the events of two fetches of the same
calendar and reports `added`, `removed`, and `changed` (old and new value
side by side), matching occurrences by `(uid, recurrence_id)` -- the identity
rfc5545 defines for a specific instance of a possibly-recurring event, not by
`uid` alone. `uid` alone conflates a whole series with a single modified
instance within it, since both carry the same `uid` and differ only by
`recurrence_id`.

## A design decision that needed checking before I could trust it: `dtstamp`

Naive full-field equality would compare `dtstamp` along with everything else.
I checked what that field actually means before relying on it: it records
when the ics object was generated, not the event's own content, and some
producers regenerate it on every export even when nothing about the event
changed. Measured directly -- two parses of the same event differing only in
`DTSTAMP` compare unequal under plain `==`:

```
solo DTSTAMP distinto -> e1 == e2: False
con dtstamp neutralizado -> igual:  True
```

Comparing it as-is would report every event from such a producer as changed
on every single fetch, which defeats the entire point of a diff. It's
excluded from the content comparison; every other field, including `extras`
(passthrough unknown properties), is compared as-is.

## Every design decision is pinned by a test that fails if reverted

Checked by mutating the implementation back to the wrong version and
confirming the *right* test breaks each time, not just that something
breaks:

- Removing the `dtstamp` exclusion → `test_regenerated_dtstamp_alone_is_not_a_change`
  fails (and so does the plain unchanged-event case).
- Matching by `uid` alone instead of `(uid, recurrence_id)` →
  `test_a_modified_recurrence_instance_is_matched_by_recurrence_id_not_uid_alone`
  fails.
- Comparing `new` against `old` without deduplicating `new` the same way
  `old` is deduplicated → `test_a_duplicate_identity_within_one_list_keeps_the_last_occurrence`
  fails. This one caught a real bug in my own first draft: I built a dedup
  dict for `old` but iterated `new` as a raw list, so a duplicate identity in
  `new` would be compared and reported twice instead of once. Caught by the
  test before this was ever run against the good version once.

## Two things worth flagging, found on a second pass

**A narrow, non-blocking equality gap.** `RecurrenceId` bolts `tzinfo` and
`range` onto a `str` subclass without a custom `__eq__` -- confirmed by
constructing two instances with the same string and different tzinfo/range
and comparing them: `True`. Two occurrences with the same recurrence_id
string but different tzinfo/range would compare equal on that field.
Harmless in practice: recurrence_id is the identity key `diff_events` matches
on, so it's always equal-by-construction within any pair that gets compared.
Checked it isn't a wider pattern first -- `Priority` and `Uri` are the only
other `str`/`int` subclasses in the type system, and neither bolts on extra
state. Documented in `_identity`'s docstring (`88c8144a`).

**An API scope question I should raise rather than decide silently.** The
issue's title says "compare two versions of the same calendar," but this PR
takes `list[Event]`, not `Calendar`. I scoped it that way because the
issue's own example is a bare `VEVENT`, but a `diff_calendars(old: Calendar,
new: Calendar) -> EventDiff` convenience wrapper would be more discoverable
and closer to the title. Happy to add it if you'd rather have it than the
current signature.

## Scope

`Event` only, matching the issue's example. `Todo` and `Journal` carry the
identical `uid` / `recurrence_id` / `sequence` / `last_modified` shape, so
the same approach would extend to them with no new design work -- flagging
that as a natural follow-up rather than building it here unrequested.

## Validation

- `pytest`: 1484 passed, 35 skipped (full suite, this branch).
- `ruff check` / `ruff format --check`: clean.
- `ty check`: clean.
- `pre-commit run --all-files`: clean (trailing-whitespace, ruff, ty, codespell).
- Confirmed `ical.diff` does not exist on `main` (`git stash` + import check),
  so this is new capability, not a fix to something already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

