### PR TITLE
feat: Add RFC 7265 (jCal) parsing and encoding support

### DIFF
--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -38,7 +38,7 @@ stream = await IcsCalendarStream.from_url("https://example.com/calendar.ics")
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, field_serializer
 
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
-__all__ = ["CalendarStream", "IcsCalendarStream"]
+__all__ = ["CalendarStream", "IcsCalendarStream", "JcalCalendarStream"]
 
 _ASYNC_EXTRA_ERROR = (
     "The aiohttp library is required for async URL fetching. Install it "
@@ -120,9 +120,27 @@ class CalendarStream(ComponentModel):
                 content = await _fetch(owned_session)
         return cls.from_ics(content)
 
+    @classmethod
+    def from_jcal(cls, jcal_data: list[Any]) -> "CalendarStream":
+        """Factory method to create a new instance from an RFC 7265 jCal content."""
+        if not isinstance(jcal_data, (list, tuple)) or not jcal_data:
+            raise CalendarParseError(
+                f"Invalid jCal data: expected non-empty list, got {jcal_data!r}"
+            )
+        if isinstance(jcal_data[0], str):
+            return cls(calendars=[Calendar.from_jcal(jcal_data)])
+
+        return cls(calendars=[Calendar.from_jcal(c) for c in jcal_data])
+
     def ics(self) -> str:
         """Encode the calendar stream as an rfc5545 iCalendar Stream content."""
         return encode_content(self.__encode_component_root__().components)
+
+    def jcal(self) -> list[Any]:
+        """Encode the calendar stream as an RFC 7265 jCal Stream content."""
+        if len(self.calendars) == 1:
+            return self.calendars[0].as_jcal()
+        return [cal.as_jcal() for cal in self.calendars]
 
 
 class IcsCalendarStream(CalendarStream):
@@ -166,3 +184,33 @@ class IcsCalendarStream(CalendarStream):
         populate_by_name=True,
     )
     serialize_fields = field_serializer("*")(serialize_field)  # type: ignore[pydantic-field]
+
+
+class JcalCalendarStream(CalendarStream):
+    """A calendar stream that supports parsing and encoding jCal."""
+
+    @classmethod
+    def calendar_from_jcal(cls, jcal_data: list[Any]) -> Calendar:
+        """Load a single calendar from a jCal object or stream."""
+        if not isinstance(jcal_data, (list, tuple)) or not jcal_data:
+            raise CalendarParseError(
+                f"Invalid jCal data: expected non-empty list, got {jcal_data!r}"
+            )
+        if isinstance(jcal_data[0], str):
+            return Calendar.from_jcal(jcal_data)
+        stream = cls.from_jcal(jcal_data)
+        return cls._single_calendar(stream)
+
+    @classmethod
+    def calendar_to_jcal(cls, calendar: Calendar) -> list[Any]:
+        """Serialize a calendar as a jCal object."""
+        return calendar.as_jcal()
+
+    @staticmethod
+    def _single_calendar(stream: "CalendarStream") -> Calendar:
+        """Return the single calendar in the stream, or raise an error."""
+        if len(stream.calendars) == 1:
+            return stream.calendars[0]
+        if len(stream.calendars) == 0:
+            return Calendar()
+        raise CalendarParseError("Calendar Stream had more than one calendar")

--- a/ical/calendar_stream.py
+++ b/ical/calendar_stream.py
@@ -132,6 +132,15 @@ class CalendarStream(ComponentModel):
 
         return cls(calendars=[Calendar.from_jcal(c) for c in jcal_data])
 
+    @staticmethod
+    def _single_calendar(stream: "CalendarStream") -> Calendar:
+        """Return the single calendar in the stream, or raise an error."""
+        if len(stream.calendars) == 1:
+            return stream.calendars[0]
+        if len(stream.calendars) == 0:
+            return Calendar()
+        raise CalendarParseError("Calendar Stream had more than one calendar")
+
     def ics(self) -> str:
         """Encode the calendar stream as an rfc5545 iCalendar Stream content."""
         return encode_content(self.__encode_component_root__().components)
@@ -164,15 +173,6 @@ class IcsCalendarStream(CalendarStream):
         stream = await cls.from_url(url, session=session)
         return cls._single_calendar(stream)
 
-    @staticmethod
-    def _single_calendar(stream: "CalendarStream") -> Calendar:
-        """Return the single calendar in the stream, or raise an error."""
-        if len(stream.calendars) == 1:
-            return stream.calendars[0]
-        if len(stream.calendars) == 0:
-            return Calendar()
-        raise CalendarParseError("Calendar Stream had more than one calendar")
-
     @classmethod
     def calendar_to_ics(cls, calendar: Calendar) -> str:
         """Serialize a calendar as an ICS stream."""
@@ -198,19 +198,9 @@ class JcalCalendarStream(CalendarStream):
             )
         if isinstance(jcal_data[0], str):
             return Calendar.from_jcal(jcal_data)
-        stream = cls.from_jcal(jcal_data)
-        return cls._single_calendar(stream)
+        return cls._single_calendar(cls.from_jcal(jcal_data))
 
     @classmethod
     def calendar_to_jcal(cls, calendar: Calendar) -> list[Any]:
         """Serialize a calendar as a jCal object."""
         return calendar.as_jcal()
-
-    @staticmethod
-    def _single_calendar(stream: "CalendarStream") -> Calendar:
-        """Return the single calendar in the stream, or raise an error."""
-        if len(stream.calendars) == 1:
-            return stream.calendars[0]
-        if len(stream.calendars) == 0:
-            return Calendar()
-        raise CalendarParseError("Calendar Stream had more than one calendar")

--- a/ical/component.py
+++ b/ical/component.py
@@ -271,10 +271,7 @@ class ComponentModel(BaseModel):
                 f"Invalid jCal component structure: expected 3 elements, got {jcal_data!r}"
             )
 
-        name = str(jcal_data[0]).lower()
-        raw_props = jcal_data[1]
-        raw_subcomps = jcal_data[2]
-
+        _, raw_props, raw_subcomps = jcal_data
         if not isinstance(raw_props, list) or not isinstance(raw_subcomps, list):
             raise CalendarParseError(
                 f"Invalid jCal component properties or subcomponents list: {jcal_data!r}"
@@ -310,32 +307,29 @@ class ComponentModel(BaseModel):
                 ):
                     is_subcomponent = True
                     if subcomp_list := subcomponents_by_name.get(key):
-                        if type_info.is_repeated:
-                            model_data[field_name] = [
-                                field_type.from_jcal(sc) for sc in subcomp_list
-                            ]
-                        else:
-                            model_data[field_name] = field_type.from_jcal(
-                                subcomp_list[0]
-                            )
+                        model_data[field_name] = (
+                            [field_type.from_jcal(sc) for sc in subcomp_list]
+                            if type_info.is_repeated
+                            else field_type.from_jcal(subcomp_list[0])
+                        )
                     break
 
-            if not is_subcomponent:
-                if prop_list := properties_by_name.get(key):
-                    matched_prop_keys.add(key)
-                    model_data[field_name] = DATA_TYPE.parse_jcal_field(
-                        field, key, prop_list
-                    )
+            if not is_subcomponent and (prop_list := properties_by_name.get(key)):
+                matched_prop_keys.add(key)
+                model_data[field_name] = DATA_TYPE.parse_jcal_field(
+                    field, key, prop_list
+                )
 
-        extras: list[ExtraProperty] = []
-        for prop_key, prop_list in properties_by_name.items():
-            if prop_key not in matched_prop_keys:
-                for p in prop_list:
-                    val = p[3] if len(p) == 4 else (p[3:] if len(p) > 4 else "")
-                    extras.append(
-                        ExtraPropertyEncoder.__parse_jcal_value__(val, p[1], name=p[0])
-                    )
-
+        extras = [
+            ExtraPropertyEncoder.__parse_jcal_value__(
+                p[3] if len(p) == 4 else (p[3:] if len(p) > 4 else ""),
+                p[1] if isinstance(p[1], dict) else {},
+                name=p[0],
+            )
+            for prop_key, prop_list in properties_by_name.items()
+            if prop_key not in matched_prop_keys
+            for p in prop_list
+        ]
         if extras:
             model_data["extras"] = extras
 
@@ -344,19 +338,20 @@ class ComponentModel(BaseModel):
         except ValidationError as err:
             raise CalendarParseError(f"Failed to parse jCal component: {err}") from err
 
-    def as_jcal(self) -> list[Any]:
+    def as_jcal(self, name: str | None = None) -> list[Any]:
         """Encode this component model as an RFC 7265 jCal array."""
-        name = self.__class__.__name__.lower()
-        if not name.startswith("v"):
-            name = f"v{name}"
+        if not name:
+            name = self.__class__.__name__.lower()
+            if not name.startswith("v"):
+                name = f"v{name}"
 
         properties: list[list[Any]] = []
         subcomponents: list[list[Any]] = []
         for field_name, field in self.__class__.model_fields.items():
-            key = field.alias or field_name
             if (val := getattr(self, field_name)) is None:
                 continue
 
+            key = field.alias or field_name
             type_info = get_field_type_info(field.annotation)
             if type_info.is_repeated and not val:
                 continue
@@ -368,15 +363,25 @@ class ComponentModel(BaseModel):
                     field_type, ComponentModel
                 ):
                     for subcomp in values:
-                        subcomponents.append(subcomp.as_jcal())
+                        subcomponents.append(subcomp.as_jcal(name=key.lower()))
                     break
             else:
                 if type_info.is_repeated and key.lower() in EXPAND_REPEATED_VALUES:
-                    properties.append(
-                        DATA_TYPE.encode_jcal_property(
-                            key.lower(), field.annotation, val
+                    encoded_props = [
+                        DATA_TYPE.encode_jcal_property(key.lower(), annotation, item)
+                        for item in values
+                    ]
+                    grouped: dict[tuple[str, str, str], list[Any]] = {}
+                    for prop in encoded_props:
+                        group_key = (
+                            prop[0],
+                            json.dumps(prop[1], sort_keys=True),
+                            prop[2],
                         )
-                    )
+                        if group_key not in grouped:
+                            grouped[group_key] = [prop[0], prop[1], prop[2]]
+                        grouped[group_key].extend(prop[3:])
+                    properties.extend(grouped.values())
                 else:
                     for item in values:
                         properties.append(

--- a/ical/component.py
+++ b/ical/component.py
@@ -21,15 +21,15 @@ import datetime
 import json
 from functools import cache
 import logging
-from typing import TYPE_CHECKING, Any, Union, get_args, get_origin
+from typing import TYPE_CHECKING, Any, Self, Union, get_args, get_origin
 
 from pydantic import BaseModel, ConfigDict, ValidationError, model_validator
 from pydantic.fields import FieldInfo
 
 from .parsing.property import ParsedProperty, ParsedPropertyParameter
 from .parsing.component import ParsedComponent
-from .types.extra import ExtraProperty
-from .types.data_types import DATA_TYPE, get_field_type_info
+from .types.extra import ExtraProperty, ExtraPropertyEncoder
+from .types.data_types import DATA_TYPE, EXPAND_REPEATED_VALUES, get_field_type_info
 from .types.text import TextEncoder
 from .exceptions import CalendarParseError, ParameterValueError
 from .compat import dtstart_until_compat
@@ -262,6 +262,130 @@ class ComponentModel(BaseModel):
                                 )
                         parent.properties.append(prop)
         return parent
+
+    @classmethod
+    def from_jcal(cls, jcal_data: list[Any]) -> Self:
+        """Parse an RFC 7265 jCal component array into a ComponentModel."""
+        if not isinstance(jcal_data, (list, tuple)) or len(jcal_data) != 3:
+            raise CalendarParseError(
+                f"Invalid jCal component structure: expected 3 elements, got {jcal_data!r}"
+            )
+
+        name = str(jcal_data[0]).lower()
+        raw_props = jcal_data[1]
+        raw_subcomps = jcal_data[2]
+
+        if not isinstance(raw_props, list) or not isinstance(raw_subcomps, list):
+            raise CalendarParseError(
+                f"Invalid jCal component properties or subcomponents list: {jcal_data!r}"
+            )
+
+        properties_by_name: dict[str, list[list[Any]]] = {}
+        for p in raw_props:
+            if not isinstance(p, (list, tuple)) or len(p) < 3:
+                raise CalendarParseError(
+                    f"Invalid jCal property structure: expected at least 3 elements, got {p!r}"
+                )
+            properties_by_name.setdefault(str(p[0]).lower(), []).append(p)
+
+        subcomponents_by_name: dict[str, list[list[Any]]] = {}
+        for c in raw_subcomps:
+            if not isinstance(c, (list, tuple)) or len(c) != 3:
+                raise CalendarParseError(
+                    f"Invalid jCal subcomponent structure: expected 3 elements, got {c!r}"
+                )
+            subcomponents_by_name.setdefault(str(c[0]).lower(), []).append(c)
+
+        model_data: dict[str, Any] = {}
+        matched_prop_keys: set[str] = set()
+
+        for field_name, field in cls.model_fields.items():
+            key = (field.alias or field_name).lower()
+            type_info = get_field_type_info(field.annotation)
+
+            is_subcomponent = False
+            for field_type in DATA_TYPE.get_ordered_field_types(type_info.annotation):
+                if isinstance(field_type, type) and issubclass(
+                    field_type, ComponentModel
+                ):
+                    is_subcomponent = True
+                    if subcomp_list := subcomponents_by_name.get(key):
+                        if type_info.is_repeated:
+                            model_data[field_name] = [
+                                field_type.from_jcal(sc) for sc in subcomp_list
+                            ]
+                        else:
+                            model_data[field_name] = field_type.from_jcal(
+                                subcomp_list[0]
+                            )
+                    break
+
+            if not is_subcomponent:
+                if prop_list := properties_by_name.get(key):
+                    matched_prop_keys.add(key)
+                    model_data[field_name] = DATA_TYPE.parse_jcal_field(
+                        field, key, prop_list
+                    )
+
+        extras: list[ExtraProperty] = []
+        for prop_key, prop_list in properties_by_name.items():
+            if prop_key not in matched_prop_keys:
+                for p in prop_list:
+                    val = p[3] if len(p) == 4 else (p[3:] if len(p) > 4 else "")
+                    extras.append(
+                        ExtraPropertyEncoder.__parse_jcal_value__(val, p[1], name=p[0])
+                    )
+
+        if extras:
+            model_data["extras"] = extras
+
+        try:
+            return cls(**model_data)
+        except ValidationError as err:
+            raise CalendarParseError(f"Failed to parse jCal component: {err}") from err
+
+    def as_jcal(self) -> list[Any]:
+        """Encode this component model as an RFC 7265 jCal array."""
+        name = self.__class__.__name__.lower()
+        if not name.startswith("v"):
+            name = f"v{name}"
+
+        properties: list[list[Any]] = []
+        subcomponents: list[list[Any]] = []
+        for field_name, field in self.__class__.model_fields.items():
+            key = field.alias or field_name
+            if (val := getattr(self, field_name)) is None:
+                continue
+
+            type_info = get_field_type_info(field.annotation)
+            if type_info.is_repeated and not val:
+                continue
+            annotation = type_info.annotation
+            values = val if type_info.is_repeated else [val]
+
+            for field_type in DATA_TYPE.get_ordered_field_types(annotation):
+                if isinstance(field_type, type) and issubclass(
+                    field_type, ComponentModel
+                ):
+                    for subcomp in values:
+                        subcomponents.append(subcomp.as_jcal())
+                    break
+            else:
+                if type_info.is_repeated and key.lower() in EXPAND_REPEATED_VALUES:
+                    properties.append(
+                        DATA_TYPE.encode_jcal_property(
+                            key.lower(), field.annotation, val
+                        )
+                    )
+                else:
+                    for item in values:
+                        properties.append(
+                            DATA_TYPE.encode_jcal_property(
+                                key.lower(), annotation, item
+                            )
+                        )
+
+        return [name.lower(), properties, subcomponents]
 
     model_config = ConfigDict(
         validate_assignment=True,

--- a/ical/todo.py
+++ b/ical/todo.py
@@ -155,7 +155,7 @@ class Todo(ComponentModel):
     organizer: Optional[CalAddress] = None
     """The organizer of a group-scheduled calendar entity."""
 
-    percent: Optional[int] = None
+    percent: Optional[int] = Field(alias="percent-complete", default=None)
 
     priority: Optional[Priority] = None
     """Defines the relative priority of the todo item."""

--- a/ical/types/attachment.py
+++ b/ical/types/attachment.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_valid
 
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 
-from .data_types import DATA_TYPE, encode_model_property_params
+from .data_types import DATA_TYPE, EncodedJcalValue, encode_model_property_params
 from .parsing import parse_parameter_values
 from .uri import Uri
 
@@ -77,6 +77,35 @@ class Attachment(BaseModel):
         return base64.b64encode(content).decode("ascii")
 
     __parse_property_value__ = dataclasses.asdict
+
+    @classmethod
+    def __parse_jcal_value__(
+        cls, value: Any, params: dict[str, Any], type_name: str | None = None
+    ) -> Attachment:
+        """Parse an RFC 7265 jCal attach property."""
+        if isinstance(value, Attachment):
+            return value
+        data: dict[str, Any] = {"value": value, "params": dict(params)}
+        if type_name and type_name.upper() == "BINARY":
+            data["params"]["VALUE"] = "BINARY"
+        return cls.model_validate(data)
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if isinstance(value, Attachment):
+            params: dict[str, Any] = {}
+            if value.fmttype:
+                params["fmttype"] = value.fmttype
+            if value.content is not None:
+                content_str = (
+                    base64.b64encode(value.content).decode("ascii")
+                    if isinstance(value.content, bytes)
+                    else str(value.content)
+                )
+                return EncodedJcalValue(params, [content_str], type_name="binary")
+            return EncodedJcalValue(params, [str(value.uri or "")], type_name="uri")
+        return None
 
     @classmethod
     def __encode_property__(cls, model_data: dict[str, Any]) -> ParsedProperty:

--- a/ical/types/cal_address.py
+++ b/ical/types/cal_address.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 
-from .data_types import DATA_TYPE, encode_model_property_params
+from .data_types import DATA_TYPE, EncodedJcalValue, encode_model_property_params
 from .parsing import parse_parameter_values
 from .uri import Uri
 
@@ -95,6 +95,42 @@ class CalAddress(BaseModel):
     _parse_parameter_values = model_validator(mode="before")(parse_parameter_values)
 
     __parse_property_value__ = dataclasses.asdict
+
+    @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> CalAddress:
+        """Parse an RFC 7265 jCal cal-address property."""
+        if isinstance(value, CalAddress):
+            return value
+        return cls.model_validate({"value": value, "params": params})
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if isinstance(value, CalAddress):
+            params: dict[str, Any] = {}
+            for name, field in cls.model_fields.items():
+                if name == "uri" or (val := getattr(value, name)) is None:
+                    continue
+                key = (field.alias or name).lower()
+                if isinstance(val, list):
+                    params[key] = [str(x) for x in val]
+                elif isinstance(val, enum.Enum):
+                    params[key] = val.value
+                elif isinstance(val, Uri):
+                    params[key] = str(val)
+                else:
+                    params[key] = val
+            return EncodedJcalValue(params, [str(value.uri)])
+        if isinstance(value, dict):
+            val = value.get("value", "")
+            params = {
+                p["name"].lower(): (
+                    p["values"][0] if len(p["values"]) == 1 else p["values"]
+                )
+                for p in value.get("params", [])
+            }
+            return EncodedJcalValue(params, [val])
+        return None
 
     @classmethod
     def __encode_property__(cls, model_data: dict[str, Any]) -> ParsedProperty:

--- a/ical/types/conference.py
+++ b/ical/types/conference.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from ical.parsing.property import ParsedProperty
 
 from .const import ExtensibleEnum
-from .data_types import DATA_TYPE, encode_model_property_params
+from .data_types import DATA_TYPE, EncodedJcalValue, encode_model_property_params
 from .parsing import parse_parameter_values
 from .uri import Uri
 
@@ -47,6 +47,30 @@ class Conference(BaseModel):
     _parse_parameter_values = model_validator(mode="before")(parse_parameter_values)
 
     __parse_property_value__ = dataclasses.asdict
+
+    @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> Conference:
+        """Parse an RFC 7265 jCal conference property."""
+        if isinstance(value, Conference):
+            return value
+        return cls.model_validate({"value": value, "params": params})
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if isinstance(value, Conference):
+            params: dict[str, Any] = {}
+            if value.feature:
+                params["feature"] = [
+                    f.value if isinstance(f, enum.Enum) else str(f)
+                    for f in value.feature
+                ]
+            if value.label:
+                params["label"] = value.label
+            if value.language:
+                params["language"] = value.language
+            return EncodedJcalValue(params, [str(value.uri)], type_name="uri")
+        return None
 
     @classmethod
     def __encode_property__(cls, model_data: dict[str, Any]) -> ParsedProperty:

--- a/ical/types/data_types.py
+++ b/ical/types/data_types.py
@@ -38,6 +38,7 @@ class EncodedJcalValue(NamedTuple):
 
     params: dict[str, Any]
     values: list[Any]
+    type_name: str | None = None
 
 
 @dataclasses.dataclass
@@ -82,7 +83,9 @@ class DataType(Protocol):
         """Parse the specified property value as a python type."""
 
     @classmethod
-    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> Any:
+    def __parse_jcal_value__(
+        cls, value: Any, params: dict[str, Any], *args: Any, **kwargs: Any
+    ) -> Any:
         """Parse the specified jCal property value as a python type."""
         return value
 
@@ -112,10 +115,8 @@ class Registry:
         self._type_names: dict[type, str] = {}
         self._parse_property_value: dict[type, Callable[[ParsedProperty], Any]] = {}
         self._parse_parameter_by_name: dict[str, Callable[[ParsedProperty], Any]] = {}
-        self._parse_jcal_value: dict[type, Callable[[Any, dict[str, Any]], Any]] = {}
-        self._parse_jcal_parameter_by_name: dict[
-            str, Callable[[Any, dict[str, Any]], Any]
-        ] = {}
+        self._parse_jcal_value: dict[type, Callable[..., Any]] = {}
+        self._parse_jcal_parameter_by_name: dict[str, Callable[..., Any]] = {}
         self._encode_property: dict[type, Callable[[Any], ParsedProperty | None]] = {}
         self._encode_property_json: dict[
             type, Callable[[Any], str | dict[str, str]]
@@ -303,6 +304,47 @@ class Registry:
     ) -> Any:
         """Parse an individual jCal value as the specified field type."""
         field_types = self.get_ordered_field_types(field_type)
+        errors = []
+
+        if type_name:
+            upper_name = type_name.upper()
+            matching = [
+                st for st in field_types if self._type_names.get(st) == upper_name
+            ]
+            non_matching = [
+                st for st in field_types if self._type_names.get(st) != upper_name
+            ]
+            search_types = matching + non_matching
+        else:
+            search_types = field_types
+
+        for sub_type in search_types:
+            if decoder := self._parse_jcal_value.get(sub_type):
+                try:
+                    try:
+                        return decoder(value, params, type_name=type_name)
+                    except TypeError:
+                        return decoder(value, params)
+                except (ValueError, TypeError) as err:
+                    _LOGGER.debug(
+                        "Unable to parse jCal value as type %s: %s", sub_type, err
+                    )
+                    errors.append(str(err))
+                    continue
+            if isinstance(sub_type, type):
+                if issubclass(sub_type, (str, int, float, bool)):
+                    try:
+                        return sub_type(value)
+                    except (ValueError, TypeError) as err:
+                        errors.append(str(err))
+                        continue
+                if issubclass(sub_type, BaseModel) and isinstance(value, dict):
+                    try:
+                        return sub_type.model_validate(value)
+                    except (ValueError, TypeError) as err:
+                        errors.append(str(err))
+                        continue
+
         if (
             type_name
             and (func := self._parse_jcal_parameter_by_name.get(type_name.upper()))
@@ -317,32 +359,14 @@ class Registry:
                     type_name,
                     err,
                 )
-
-        errors = []
-        for sub_type in field_types:
-            if decoder := self._parse_jcal_value.get(sub_type):
-                try:
-                    return decoder(value, params)
-                except (ValueError, TypeError) as err:
-                    _LOGGER.debug(
-                        "Unable to parse jCal value as type %s: %s", sub_type, err
-                    )
-                    errors.append(str(err))
-                    continue
-            if isinstance(sub_type, type) and issubclass(
-                sub_type, (str, int, float, bool)
-            ):
-                try:
-                    return sub_type(value)
-                except (ValueError, TypeError) as err:
-                    errors.append(str(err))
-                    continue
+                errors.append(str(err))
 
         if value is not None and not errors:
             return value
 
+        type_names = " or ".join(getattr(st, "__name__", str(st)) for st in field_types)
         raise ValueError(
-            f"Failed to validate jCal value: {value} as {' or '.join(getattr(st, '__name__', str(st)) for st in field_types)}, due to: ({errors})"
+            f"Failed to validate jCal value: {value} as {type_names}, due to: ({errors})"
         )
 
     def parse_jcal_field(
@@ -356,58 +380,81 @@ class Registry:
         if not type_info.annotation:
             raise ValueError(f"Unable to determine field type for field: {name}")
 
+        def _extract_meta(p: list[Any]) -> tuple[dict[str, Any], str | None]:
+            params = p[1] if len(p) > 1 and isinstance(p[1], dict) else {}
+            type_name = str(p[2]) if len(p) > 2 else None
+            return params, type_name
+
         if type_info.is_repeated:
             if name.lower() in EXPAND_REPEATED_VALUES:
-                all_values = []
-                for p in props:
-                    params = p[1] if len(p) > 1 and isinstance(p[1], dict) else {}
-                    type_name = str(p[2]) if len(p) > 2 else None
-                    raw_values = p[3:] if len(p) > 3 else []
-                    for val in raw_values:
-                        all_values.append(
-                            self.parse_jcal_single_value(
-                                type_info.annotation, val, params, type_name
-                            )
-                        )
-                return all_values
+                return [
+                    self.parse_jcal_single_value(
+                        type_info.annotation, val, params, type_name
+                    )
+                    for p in props
+                    for params, type_name in [_extract_meta(p)]
+                    for val in p[3:]
+                ]
             return [
                 self.parse_jcal_single_value(
                     type_info.annotation,
                     p[3] if len(p) > 3 else "",
-                    p[1] if len(p) > 1 and isinstance(p[1], dict) else {},
-                    str(p[2]) if len(p) > 2 else None,
+                    params,
+                    type_name,
                 )
                 for p in props
+                for params, type_name in [_extract_meta(p)]
             ]
 
         if len(props) > 1:
             raise ValueError(f"Expected one value for field: {name}")
 
         p = props[0]
-        params = p[1] if len(p) > 1 and isinstance(p[1], dict) else {}
-        type_name = str(p[2]) if len(p) > 2 else None
-        val = p[3] if len(p) > 3 else ""
+        params, type_name = _extract_meta(p)
         return self.parse_jcal_single_value(
-            type_info.annotation, val, params, type_name
+            type_info.annotation,
+            p[3] if len(p) > 3 else "",
+            params,
+            type_name,
         )
 
     def encode_jcal_property(self, key: str, field_type: type, value: Any) -> list[Any]:
         """Encode an individual property value into a jCal 4-element array."""
         errors = []
         for sub_type in self.get_ordered_field_types(field_type):
-            if sub_type in self._type_names:
-                encoder = self._encode_jcal_value.get(
-                    sub_type, lambda val: EncodedJcalValue({}, [val])
+            encoder = None
+            type_name = None
+            if isinstance(sub_type, type):
+                for base in sub_type.__mro__:
+                    if base in self._encode_jcal_value and encoder is None:
+                        encoder = self._encode_jcal_value[base]
+                    if base in self._type_names and type_name is None:
+                        type_name = self._type_names[base]
+                    if encoder and type_name:
+                        break
+
+            if encoder is None and type_name is not None:
+                encoder = lambda val: EncodedJcalValue(
+                    {}, [val.value if hasattr(val, "value") else val]
                 )
+
+            if encoder:
                 try:
                     if result := encoder(value):
-                        type_name = self._type_names[sub_type].lower()
+                        resolved_type_name = (
+                            result.type_name or type_name or "text"
+                        ).lower()
                         prop_name = (
                             value.name.lower()
                             if hasattr(value, "name") and key == "extras"
                             else key
                         )
-                        return [prop_name, result.params, type_name, *result.values]
+                        return [
+                            prop_name,
+                            result.params,
+                            resolved_type_name,
+                            *result.values,
+                        ]
                 except (ValueError, TypeError) as err:
                     _LOGGER.debug(
                         "jCal encoding failed for property type %s: %s", sub_type, err

--- a/ical/types/data_types.py
+++ b/ical/types/data_types.py
@@ -13,6 +13,7 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    NamedTuple,
     Protocol,
     TypeVar,
     Union,
@@ -32,6 +33,13 @@ _LOGGER = logging.getLogger(__name__)
 T_TYPE = TypeVar("T_TYPE", bound=type)
 
 
+class EncodedJcalValue(NamedTuple):
+    """An encoded jCal property value pre-serialization."""
+
+    params: dict[str, Any]
+    values: list[Any]
+
+
 @dataclasses.dataclass
 class FieldTypeInfo:
     """Information about a field type."""
@@ -40,13 +48,13 @@ class FieldTypeInfo:
     """The base type of the field (e.g. without Optional or list)."""
 
     is_repeated: bool = False
-    """Whether the field is a list."""
+    """True if the field is a list."""
 
     is_optional: bool = False
-    """Whether the field is Optional."""
+    """True if the field is an Optional."""
 
 
-# Repeated values can either be specified as multiple separate values, but
+# Properties that are represented as a list in the python data model, but
 # also some values support repeated values within a single value with a
 # comma delimiter, listed here.
 EXPAND_REPEATED_VALUES = {
@@ -74,6 +82,11 @@ class DataType(Protocol):
         """Parse the specified property value as a python type."""
 
     @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> Any:
+        """Parse the specified jCal property value as a python type."""
+        return value
+
+    @classmethod
     def __encode_property__(cls, value: Any) -> ParsedProperty | None:
         """Encode the property from the object model to a ParsedProperty."""
         return ParsedProperty(name="", value=value)
@@ -81,6 +94,11 @@ class DataType(Protocol):
     @classmethod
     def __encode_property_json__(cls, value: Any) -> str | dict[str, str]:
         """Encode the property during pydantic serialization to object model."""
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode the property value as jCal parameters dict and value list."""
+        return EncodedJcalValue({}, [value])
 
 
 class Registry:
@@ -91,11 +109,19 @@ class Registry:
     ) -> None:
         """Initialize Registry."""
         self._items: dict[str, type] = {}
+        self._type_names: dict[type, str] = {}
         self._parse_property_value: dict[type, Callable[[ParsedProperty], Any]] = {}
         self._parse_parameter_by_name: dict[str, Callable[[ParsedProperty], Any]] = {}
+        self._parse_jcal_value: dict[type, Callable[[Any, dict[str, Any]], Any]] = {}
+        self._parse_jcal_parameter_by_name: dict[
+            str, Callable[[Any, dict[str, Any]], Any]
+        ] = {}
         self._encode_property: dict[type, Callable[[Any], ParsedProperty | None]] = {}
         self._encode_property_json: dict[
             type, Callable[[Any], str | dict[str, str]]
+        ] = {}
+        self._encode_jcal_value: dict[
+            type, Callable[[Any], EncodedJcalValue | None]
         ] = {}
         self._disable_value_param: set[type] = set()
         self._parse_order: dict[type, int] = {}
@@ -244,14 +270,22 @@ class Registry:
             data_type = func
             if data_type_func := getattr(func, "__property_type__", None):
                 data_type = data_type_func()
+            if name:
+                self._type_names[data_type] = name
             if parse_property_value := getattr(func, "__parse_property_value__", None):
                 self._parse_property_value[data_type] = parse_property_value
                 if name:
                     self._parse_parameter_by_name[name] = parse_property_value
+            if parse_jcal_value := getattr(func, "__parse_jcal_value__", None):
+                self._parse_jcal_value[data_type] = parse_jcal_value
+                if name:
+                    self._parse_jcal_parameter_by_name[name] = parse_jcal_value
             if encode_property := getattr(func, "__encode_property__", None):
                 self._encode_property[data_type] = encode_property
             if encode_property_json := getattr(func, "__encode_property_json__", None):
                 self._encode_property_json[data_type] = encode_property_json
+            if encode_jcal_value := getattr(func, "__encode_jcal_value__", None):
+                self._encode_jcal_value[data_type] = encode_jcal_value
             if disable_value_param:
                 self._disable_value_param |= set({data_type})
             if parse_order:
@@ -259,6 +293,134 @@ class Registry:
             return func
 
         return decorator
+
+    def parse_jcal_single_value(
+        self,
+        field_type: type,
+        value: Any,
+        params: dict[str, Any],
+        type_name: str | None = None,
+    ) -> Any:
+        """Parse an individual jCal value as the specified field type."""
+        field_types = self.get_ordered_field_types(field_type)
+        if (
+            type_name
+            and (func := self._parse_jcal_parameter_by_name.get(type_name.upper()))
+            and field_type not in self._disable_value_param
+        ):
+            try:
+                return func(value, params)
+            except (ValueError, TypeError) as err:
+                _LOGGER.debug(
+                    "Parsing jCal value '%s' with type name '%s' failed: %s",
+                    value,
+                    type_name,
+                    err,
+                )
+
+        errors = []
+        for sub_type in field_types:
+            if decoder := self._parse_jcal_value.get(sub_type):
+                try:
+                    return decoder(value, params)
+                except (ValueError, TypeError) as err:
+                    _LOGGER.debug(
+                        "Unable to parse jCal value as type %s: %s", sub_type, err
+                    )
+                    errors.append(str(err))
+                    continue
+            if isinstance(sub_type, type) and issubclass(
+                sub_type, (str, int, float, bool)
+            ):
+                try:
+                    return sub_type(value)
+                except (ValueError, TypeError) as err:
+                    errors.append(str(err))
+                    continue
+
+        if value is not None and not errors:
+            return value
+
+        raise ValueError(
+            f"Failed to validate jCal value: {value} as {' or '.join(getattr(st, '__name__', str(st)) for st in field_types)}, due to: ({errors})"
+        )
+
+    def parse_jcal_field(
+        self,
+        field: FieldInfo,
+        name: str,
+        props: list[list[Any]],
+    ) -> Any:
+        """Parse a list of jCal property items for a specific model field."""
+        type_info = get_field_type_info(field.annotation)
+        if not type_info.annotation:
+            raise ValueError(f"Unable to determine field type for field: {name}")
+
+        if type_info.is_repeated:
+            if name.lower() in EXPAND_REPEATED_VALUES:
+                all_values = []
+                for p in props:
+                    params = p[1] if len(p) > 1 and isinstance(p[1], dict) else {}
+                    type_name = str(p[2]) if len(p) > 2 else None
+                    raw_values = p[3:] if len(p) > 3 else []
+                    for val in raw_values:
+                        all_values.append(
+                            self.parse_jcal_single_value(
+                                type_info.annotation, val, params, type_name
+                            )
+                        )
+                return all_values
+            return [
+                self.parse_jcal_single_value(
+                    type_info.annotation,
+                    p[3] if len(p) > 3 else "",
+                    p[1] if len(p) > 1 and isinstance(p[1], dict) else {},
+                    str(p[2]) if len(p) > 2 else None,
+                )
+                for p in props
+            ]
+
+        if len(props) > 1:
+            raise ValueError(f"Expected one value for field: {name}")
+
+        p = props[0]
+        params = p[1] if len(p) > 1 and isinstance(p[1], dict) else {}
+        type_name = str(p[2]) if len(p) > 2 else None
+        val = p[3] if len(p) > 3 else ""
+        return self.parse_jcal_single_value(
+            type_info.annotation, val, params, type_name
+        )
+
+    def encode_jcal_property(self, key: str, field_type: type, value: Any) -> list[Any]:
+        """Encode an individual property value into a jCal 4-element array."""
+        errors = []
+        for sub_type in self.get_ordered_field_types(field_type):
+            if sub_type in self._type_names:
+                encoder = self._encode_jcal_value.get(
+                    sub_type, lambda val: EncodedJcalValue({}, [val])
+                )
+                try:
+                    if result := encoder(value):
+                        type_name = self._type_names[sub_type].lower()
+                        prop_name = (
+                            value.name.lower()
+                            if hasattr(value, "name") and key == "extras"
+                            else key
+                        )
+                        return [prop_name, result.params, type_name, *result.values]
+                except (ValueError, TypeError) as err:
+                    _LOGGER.debug(
+                        "jCal encoding failed for property type %s: %s", sub_type, err
+                    )
+                    errors.append(str(err))
+                    continue
+
+        if hasattr(value, "as_jcal"):
+            return value.as_jcal(key)
+
+        raise ValueError(
+            f"Unable to encode jCal property for field '{key}': {value}, errors: {errors}"
+        )
 
     @property
     def encode_property_json(self) -> dict[type, Callable[[Any], str | dict[str, str]]]:

--- a/ical/types/date.py
+++ b/ical/types/date.py
@@ -51,11 +51,11 @@ class DateEncoder:
     @classmethod
     def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> datetime.date:
         """Parse an RFC 7265 jCal date into a datetime.date."""
-        if isinstance(value, datetime.date) and not isinstance(
-            value, datetime.datetime
-        ):
+        if type(value) is datetime.date:
             return value
         if isinstance(value, str):
+            if "T" in value:
+                raise ValueError(f"Expected date string without time in jCal: {value}")
             try:
                 return datetime.date.fromisoformat(value)
             except ValueError as err:
@@ -81,6 +81,6 @@ class DateEncoder:
     @classmethod
     def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
         """Encode as jCal parameters and value list."""
-        if not isinstance(value, datetime.date) or isinstance(value, datetime.datetime):
+        if type(value) is not datetime.date:
             return None
         return EncodedJcalValue({}, [value.isoformat()])

--- a/ical/types/date.py
+++ b/ical/types/date.py
@@ -10,7 +10,7 @@ from ical.compat.date_compat import is_allow_invalid_dates_enabled
 
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 
-from .data_types import DATA_TYPE
+from .data_types import DATA_TYPE, EncodedJcalValue
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +29,9 @@ class DateEncoder:
     def __parse_property_value__(cls, prop: ParsedProperty) -> datetime.date | None:
         """Parse a rfc5545 into a datetime.date."""
         val = prop.value
+        if isinstance(val, datetime.date):
+            return val
+
         if len(val) > 8 and "T" in val:
             if is_allow_invalid_dates_enabled():
                 _LOGGER.debug("Stripping time suffix from DATE value: %s", prop.value)
@@ -46,6 +49,20 @@ class DateEncoder:
         return result
 
     @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> datetime.date:
+        """Parse an RFC 7265 jCal date into a datetime.date."""
+        if isinstance(value, datetime.date) and not isinstance(
+            value, datetime.datetime
+        ):
+            return value
+        if isinstance(value, str):
+            try:
+                return datetime.date.fromisoformat(value)
+            except ValueError as err:
+                raise ValueError(f"Invalid jCal date value: {value}") from err
+        raise ValueError(f"Expected string or date for jCal date, got {type(value)}")
+
+    @classmethod
     def __encode_property_json__(cls, value: datetime.date) -> str:
         """Serialize as an ICS value."""
         return value.strftime("%Y%m%d")
@@ -60,3 +77,10 @@ class DateEncoder:
                 params=[ParsedPropertyParameter(name="VALUE", values=["DATE"])],
             )
         return None
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if not isinstance(value, datetime.date) or isinstance(value, datetime.datetime):
+            return None
+        return EncodedJcalValue({}, [value.isoformat()])

--- a/ical/types/date_time.py
+++ b/ical/types/date_time.py
@@ -87,9 +87,11 @@ class DateTimeEncoder:
             return value
         if not isinstance(value, str):
             raise ValueError(f"Expected string for jCal date-time, got {type(value)}")
+        if "T" not in value:
+            raise ValueError(f"Expected DATE-TIME with 'T' separator, got: {value}")
 
         timezone: datetime.tzinfo | None = None
-        if tzid := params.get("tzid"):
+        if tzid := params.get("tzid") or params.get("TZID"):
             try:
                 timezone = timezoneinfo.resolve_tzinfo(str(tzid), allow_invalid=False)
             except timezoneinfo.TimezoneInfoError as err:
@@ -105,9 +107,7 @@ class DateTimeEncoder:
 
         try:
             dt = datetime.datetime.fromisoformat(val)
-            if timezone is not None:
-                dt = dt.replace(tzinfo=timezone)
-            return dt
+            return dt.replace(tzinfo=timezone) if timezone is not None else dt
         except ValueError as err:
             raise ValueError(f"Invalid jCal date-time value: {value}") from err
 

--- a/ical/types/date_time.py
+++ b/ical/types/date_time.py
@@ -11,7 +11,7 @@ from typing import Any
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 from ical.tzif import timezoneinfo
 from ical.exceptions import ParameterValueError
-from .data_types import DATA_TYPE
+from .data_types import DATA_TYPE, EncodedJcalValue
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,10 +24,7 @@ ATTR_VALUE = "VALUE"
 def parse_property_value(
     prop: ParsedProperty, allow_invalid_timezone: bool = False
 ) -> datetime.datetime:
-    """Parse a rfc5545 into a datetime.datetime."""
-    if not (match := DATETIME_REGEX.fullmatch(prop.value)):
-        raise ValueError(f"Expected value to match DATE-TIME pattern: {prop.value}")
-
+    """Parse a rfc5545 or ISO 8601 string into a datetime.datetime."""
     # Example: TZID=America/New_York:19980119T020000
     timezone: datetime.tzinfo | None = None
     if param := prop.get_parameter(TZID):
@@ -43,7 +40,14 @@ def parse_property_value(
                     raise ParameterValueError(
                         f"Expected DATE-TIME TZID value '{value}' to be valid timezone"
                     )
-    elif match.group(3):  # Example: 19980119T070000Z
+
+    if isinstance(prop.value, datetime.datetime):
+        return prop.value.replace(tzinfo=timezone) if timezone else prop.value
+
+    if not (match := DATETIME_REGEX.fullmatch(prop.value)):
+        raise ValueError(f"Expected value to match DATE-TIME pattern: {prop.value}")
+
+    if not timezone and match.group(3):  # Example: 19980119T070000Z
         timezone = datetime.timezone.utc
 
     # Example: 19980118T230000
@@ -75,6 +79,39 @@ class DateTimeEncoder:
         return parse_property_value(prop, allow_invalid_timezone=False)
 
     @classmethod
+    def __parse_jcal_value__(
+        cls, value: Any, params: dict[str, Any]
+    ) -> datetime.datetime:
+        """Parse an RFC 7265 jCal date-time into a datetime.datetime."""
+        if isinstance(value, datetime.datetime):
+            return value
+        if not isinstance(value, str):
+            raise ValueError(f"Expected string for jCal date-time, got {type(value)}")
+
+        timezone: datetime.tzinfo | None = None
+        if tzid := params.get("tzid"):
+            try:
+                timezone = timezoneinfo.resolve_tzinfo(str(tzid), allow_invalid=False)
+            except timezoneinfo.TimezoneInfoError as err:
+                raise ParameterValueError(
+                    f"Expected DATE-TIME TZID value '{tzid}' to be valid timezone"
+                ) from err
+
+        val = value
+        if val.endswith("Z"):
+            if timezone is None:
+                timezone = datetime.timezone.utc
+            val = val[:-1]
+
+        try:
+            dt = datetime.datetime.fromisoformat(val)
+            if timezone is not None:
+                dt = dt.replace(tzinfo=timezone)
+            return dt
+        except ValueError as err:
+            raise ValueError(f"Invalid jCal date-time value: {value}") from err
+
+    @classmethod
     def __encode_property_json__(cls, value: datetime.datetime) -> str | dict[str, str]:
         """Encode an ICS value during json serialization."""
         if value.tzinfo is None:
@@ -98,3 +135,16 @@ class DateTimeEncoder:
         if tzid := value.get(TZID):
             prop.params = [ParsedPropertyParameter(name=TZID, values=[str(tzid)])]
         return prop
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if not isinstance(value, datetime.datetime):
+            return None
+        if value.tzinfo is None:
+            return EncodedJcalValue({}, [value.strftime("%Y-%m-%dT%H:%M:%S")])
+        if not value.utcoffset():
+            return EncodedJcalValue({}, [value.strftime("%Y-%m-%dT%H:%M:%SZ")])
+        return EncodedJcalValue(
+            {"tzid": str(value.tzinfo)}, [value.strftime("%Y-%m-%dT%H:%M:%S")]
+        )

--- a/ical/types/duration.py
+++ b/ical/types/duration.py
@@ -2,6 +2,7 @@
 
 import datetime
 import re
+from typing import Any
 
 from ical.compat.duration_compat import is_duration_compat_enabled
 from ical.parsing.property import ParsedProperty
@@ -19,6 +20,24 @@ COMPAT_DATETIME_PART = f"(?:{DATE_PART})?(?:{COMPAT_TIME_PART})?"
 COMPAT_DURATION_REGEX = re.compile(f"([-+]?)P(?:{WEEKS_PART}{COMPAT_DATETIME_PART})$")
 
 
+def _parse_duration(value: str) -> datetime.timedelta:
+    """Parse an ISO 8601 / RFC 5545 duration string into a timedelta."""
+    match = DURATION_REGEX.fullmatch(value)
+    if not match and is_duration_compat_enabled():
+        match = COMPAT_DURATION_REGEX.fullmatch(value)
+    if not match:
+        raise ValueError(f"Expected value to match DURATION pattern: {value}")
+    sign, weeks, days, hours, minutes, seconds = match.groups()
+    result = datetime.timedelta(
+        weeks=int(weeks or 0),
+        days=int(days or 0),
+        hours=int(hours or 0),
+        minutes=int(minutes or 0),
+        seconds=int(seconds or 0),
+    )
+    return -result if sign == "-" else result
+
+
 @DATA_TYPE.register("DURATION")
 class DurationEncoder:
     """Class that can encode DURATION values."""
@@ -29,25 +48,10 @@ class DurationEncoder:
 
     @classmethod
     def __parse_property_value__(cls, prop: ParsedProperty) -> datetime.timedelta:
-        """Parse a rfc5545 into a datetime.date."""
+        """Parse an rfc5545 property into a datetime.timedelta."""
         if not isinstance(prop, ParsedProperty):
             raise ValueError(f"Expected ParsedProperty but was {prop}")
-        match = DURATION_REGEX.fullmatch(prop.value)
-        if not match and is_duration_compat_enabled():
-            match = COMPAT_DURATION_REGEX.fullmatch(prop.value)
-        if not match:
-            raise ValueError(f"Expected value to match DURATION pattern: {prop.value}")
-        sign, weeks, days, hours, minutes, seconds = match.groups()
-        result: datetime.timedelta = datetime.timedelta(
-            weeks=int(weeks or 0),
-            days=int(days or 0),
-            hours=int(hours or 0),
-            minutes=int(minutes or 0),
-            seconds=int(seconds or 0),
-        )
-        if sign == "-":
-            result = -result
-        return result
+        return _parse_duration(prop.value)
 
     @classmethod
     def __parse_jcal_value__(
@@ -58,22 +62,7 @@ class DurationEncoder:
             return value
         if not isinstance(value, str):
             raise ValueError(f"Expected string for jCal duration, got {type(value)}")
-        match = DURATION_REGEX.fullmatch(value)
-        if not match and is_duration_compat_enabled():
-            match = COMPAT_DURATION_REGEX.fullmatch(value)
-        if not match:
-            raise ValueError(f"Expected value to match DURATION pattern: {value}")
-        sign, weeks, days, hours, minutes, seconds = match.groups()
-        result: datetime.timedelta = datetime.timedelta(
-            weeks=int(weeks or 0),
-            days=int(days or 0),
-            hours=int(hours or 0),
-            minutes=int(minutes or 0),
-            seconds=int(seconds or 0),
-        )
-        if sign == "-":
-            result = -result
-        return result
+        return _parse_duration(value)
 
     @classmethod
     def __encode_property_json__(cls, duration: datetime.timedelta) -> str:
@@ -117,6 +106,9 @@ class DurationEncoder:
         cls, duration: str | datetime.timedelta
     ) -> EncodedJcalValue:
         """Encode as jCal parameters and value list."""
-        if isinstance(duration, str):
-            return EncodedJcalValue({}, [duration])
-        return EncodedJcalValue({}, [cls.__encode_property_json__(duration)])
+        val = (
+            duration
+            if isinstance(duration, str)
+            else cls.__encode_property_json__(duration)
+        )
+        return EncodedJcalValue({}, [val])

--- a/ical/types/duration.py
+++ b/ical/types/duration.py
@@ -6,7 +6,7 @@ import re
 from ical.compat.duration_compat import is_duration_compat_enabled
 from ical.parsing.property import ParsedProperty
 
-from .data_types import DATA_TYPE
+from .data_types import DATA_TYPE, EncodedJcalValue
 
 DATE_PART = r"(\d+)D"
 TIME_PART = r"T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?"
@@ -50,6 +50,32 @@ class DurationEncoder:
         return result
 
     @classmethod
+    def __parse_jcal_value__(
+        cls, value: Any, params: dict[str, Any]
+    ) -> datetime.timedelta:
+        """Parse an RFC 7265 jCal duration into a datetime.timedelta."""
+        if isinstance(value, datetime.timedelta):
+            return value
+        if not isinstance(value, str):
+            raise ValueError(f"Expected string for jCal duration, got {type(value)}")
+        match = DURATION_REGEX.fullmatch(value)
+        if not match and is_duration_compat_enabled():
+            match = COMPAT_DURATION_REGEX.fullmatch(value)
+        if not match:
+            raise ValueError(f"Expected value to match DURATION pattern: {value}")
+        sign, weeks, days, hours, minutes, seconds = match.groups()
+        result: datetime.timedelta = datetime.timedelta(
+            weeks=int(weeks or 0),
+            days=int(days or 0),
+            hours=int(hours or 0),
+            minutes=int(minutes or 0),
+            seconds=int(seconds or 0),
+        )
+        if sign == "-":
+            result = -result
+        return result
+
+    @classmethod
     def __encode_property_json__(cls, duration: datetime.timedelta) -> str:
         """Serialize a time delta as a DURATION ICS value."""
         parts = []
@@ -78,3 +104,19 @@ class DurationEncoder:
             if seconds != 0:
                 parts.append(f"{seconds}S")
         return "".join(parts)
+
+    @classmethod
+    def __encode_property__(cls, duration: str | datetime.timedelta) -> ParsedProperty:
+        """Serialize a time delta as a ParsedProperty."""
+        if isinstance(duration, str):
+            return ParsedProperty(name="", value=duration)
+        return ParsedProperty(name="", value=cls.__encode_property_json__(duration))
+
+    @classmethod
+    def __encode_jcal_value__(
+        cls, duration: str | datetime.timedelta
+    ) -> EncodedJcalValue:
+        """Encode as jCal parameters and value list."""
+        if isinstance(duration, str):
+            return EncodedJcalValue({}, [duration])
+        return EncodedJcalValue({}, [cls.__encode_property_json__(duration)])

--- a/ical/types/extra.py
+++ b/ical/types/extra.py
@@ -52,20 +52,19 @@ class ExtraPropertyEncoder:
     def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
         """Encode as jCal parameters and value list."""
         if isinstance(value, ExtraProperty):
-            params_dict: dict[str, Any] = {}
-            if value.params:
-                for p in value.params:
-                    params_dict[p.name.lower()] = (
-                        p.values[0] if len(p.values) == 1 else p.values
-                    )
-            return EncodedJcalValue(params_dict, [value.value])
+            params = {
+                p.name.lower(): (p.values[0] if len(p.values) == 1 else p.values)
+                for p in (value.params or [])
+            }
+            return EncodedJcalValue(params, [value.value])
         if isinstance(value, dict):
-            params_dict = {}
-            for p in value.get("params", []):
-                params_dict[p["name"].lower()] = (
+            params = {
+                p["name"].lower(): (
                     p["values"][0] if len(p["values"]) == 1 else p["values"]
                 )
-            return EncodedJcalValue(params_dict, [value["value"]])
+                for p in value.get("params", [])
+            }
+            return EncodedJcalValue(params, [value["value"]])
         return None
 
     @classmethod

--- a/ical/types/extra.py
+++ b/ical/types/extra.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
-from ical.types.data_types import DATA_TYPE
+from ical.types.data_types import DATA_TYPE, EncodedJcalValue
 
 
 @dataclass
@@ -24,7 +24,7 @@ class ExtraProperty:
     params: list[ExtraPropertyParameter] | None = None
 
 
-@DATA_TYPE.register(name="ExtraProperty", disable_value_param=True)
+@DATA_TYPE.register(name="UNKNOWN", disable_value_param=True)
 class ExtraPropertyEncoder:
     """Encoder for ExtraProperty."""
 
@@ -49,6 +49,26 @@ class ExtraPropertyEncoder:
         )
 
     @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if isinstance(value, ExtraProperty):
+            params_dict: dict[str, Any] = {}
+            if value.params:
+                for p in value.params:
+                    params_dict[p.name.lower()] = (
+                        p.values[0] if len(p.values) == 1 else p.values
+                    )
+            return EncodedJcalValue(params_dict, [value.value])
+        if isinstance(value, dict):
+            params_dict = {}
+            for p in value.get("params", []):
+                params_dict[p["name"].lower()] = (
+                    p["values"][0] if len(p["values"]) == 1 else p["values"]
+                )
+            return EncodedJcalValue(params_dict, [value["value"]])
+        return None
+
+    @classmethod
     def __parse_property_value__(cls, prop: ParsedProperty) -> ExtraProperty:
         """Convert a ParsedProperty to an ExtraProperty."""
         return ExtraProperty(
@@ -65,3 +85,21 @@ class ExtraPropertyEncoder:
             if prop.params
             else None,
         )
+
+    @classmethod
+    def __parse_jcal_value__(
+        cls, value: Any, params: dict[str, Any], name: str = ""
+    ) -> ExtraProperty:
+        """Parse an RFC 7265 jCal property into an ExtraProperty."""
+        params_list = (
+            [
+                ExtraPropertyParameter(
+                    name=k.upper(),
+                    values=[v] if isinstance(v, str) else [str(x) for x in v],
+                )
+                for k, v in params.items()
+            ]
+            if params
+            else None
+        )
+        return ExtraProperty(name=name, value=value, params=params_list)

--- a/ical/types/geo.py
+++ b/ical/types/geo.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from ical.parsing.property import ParsedProperty
-from .data_types import DATA_TYPE
+from .data_types import DATA_TYPE, EncodedJcalValue
 from .text import TextEncoder
 
 
@@ -25,6 +25,22 @@ class Geo:
         if len(parts) != 2:
             raise ValueError(f"Value was not valid geo lat;long: {value}")
         return Geo(lat=float(parts[0]), lng=float(parts[1]))
+
+    @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> Geo:
+        """Parse an RFC 7265 jCal geo property."""
+        if isinstance(value, Geo):
+            return value
+        if isinstance(value, (list, tuple)) and len(value) == 2:
+            return Geo(lat=float(value[0]), lng=float(value[1]))
+        return cls.__parse_property_value__(value)
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if isinstance(value, Geo):
+            return EncodedJcalValue({}, [[value.lat, value.lng]], type_name="float")
+        return None
 
     @classmethod
     def __encode_property_json__(cls, value: Geo) -> str:

--- a/ical/types/image.py
+++ b/ical/types/image.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_valid
 from ical.parsing.property import ParsedProperty
 
 from .const import ExtensibleEnum
-from .data_types import DATA_TYPE, encode_model_property_params
+from .data_types import DATA_TYPE, EncodedJcalValue, encode_model_property_params
 from .parsing import parse_parameter_values
 from .uri import Uri
 
@@ -93,6 +93,43 @@ class Image(BaseModel):
         return base64.b64encode(content).decode("ascii")
 
     __parse_property_value__ = dataclasses.asdict
+
+    @classmethod
+    def __parse_jcal_value__(
+        cls, value: Any, params: dict[str, Any], type_name: str | None = None
+    ) -> Image:
+        """Parse an RFC 7265 jCal image property."""
+        if isinstance(value, Image):
+            return value
+        data: dict[str, Any] = {"value": value, "params": dict(params)}
+        if type_name and type_name.upper() == "BINARY":
+            data["params"]["VALUE"] = "BINARY"
+        return cls.model_validate(data)
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if isinstance(value, Image):
+            params: dict[str, Any] = {}
+            if value.format_type:
+                params["fmttype"] = value.format_type
+            if value.display:
+                params["display"] = (
+                    value.display.value
+                    if isinstance(value.display, enum.Enum)
+                    else str(value.display)
+                )
+            if value.altrep:
+                params["altrep"] = str(value.altrep)
+            if value.content is not None:
+                content_str = (
+                    base64.b64encode(value.content).decode("ascii")
+                    if isinstance(value.content, bytes)
+                    else str(value.content)
+                )
+                return EncodedJcalValue(params, [content_str], type_name="binary")
+            return EncodedJcalValue(params, [str(value.uri or "")], type_name="uri")
+        return None
 
     @classmethod
     def __encode_property__(cls, model_data: dict[str, Any]) -> ParsedProperty:

--- a/ical/types/parsing.py
+++ b/ical/types/parsing.py
@@ -31,14 +31,28 @@ def parse_parameter_values(
         return values
     if params := values.get("params"):
         all_fields = _all_fields(cls)
-        for param in params:
-            if not (field := all_fields.get(param["name"])):
-                continue
-            type_info = get_field_type_info(field.annotation)
-            if type_info.is_repeated:
-                values[param["name"]] = param["values"]
-            else:
-                if len(param["values"]) > 1:
-                    raise ValueError("Unexpected repeated property parameter")
-                values[param["name"]] = param["values"][0]
+        if isinstance(params, dict):
+            for param_name, param_val in params.items():
+                if not (
+                    field := all_fields.get(param_name.upper())
+                    or all_fields.get(param_name)
+                ):
+                    continue
+                key = field.alias or param_name
+                type_info = get_field_type_info(field.annotation)
+                if type_info.is_repeated and not isinstance(param_val, list):
+                    values[key] = [param_val]
+                else:
+                    values[key] = param_val
+        elif isinstance(params, list):
+            for param in params:
+                if not (field := all_fields.get(param["name"])):
+                    continue
+                type_info = get_field_type_info(field.annotation)
+                if type_info.is_repeated:
+                    values[param["name"]] = param["values"]
+                else:
+                    if len(param["values"]) > 1:
+                        raise ValueError("Unexpected repeated property parameter")
+                    values[param["name"]] = param["values"][0]
     return values

--- a/ical/types/period.py
+++ b/ical/types/period.py
@@ -10,7 +10,12 @@ from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_valid
 
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 
-from .data_types import DATA_TYPE, encode_model_property_params, serialize_field
+from .data_types import (
+    DATA_TYPE,
+    EncodedJcalValue,
+    encode_model_property_params,
+    serialize_field,
+)
 from .date_time import DateTimeEncoder
 from .duration import DurationEncoder
 from .parsing import parse_parameter_values
@@ -121,6 +126,68 @@ class Period(BaseModel):
         if "/" not in prop.value:
             raise ValueError(f"Value does not contain a solidus: {prop.value}")
         return dataclasses.asdict(prop)
+
+    @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> "Period":
+        """Parse an RFC 7265 jCal period property."""
+        if isinstance(value, Period):
+            return value
+        if isinstance(value, str) and "/" in value:
+            return cls.__parse_jcal_value__(value.split("/", 1), params)
+        if isinstance(value, (list, tuple)) and len(value) == 2:
+            start_str, end_or_dur = str(value[0]), str(value[1])
+            start = DateTimeEncoder.__parse_jcal_value__(start_str, params)
+            fbtype_val = None
+            if fbtype := params.get("fbtype") or params.get("FBTYPE"):
+                try:
+                    fbtype_val = FreeBusyType(str(fbtype).upper())
+                except ValueError:
+                    pass
+            if (
+                end_or_dur.startswith("P")
+                or end_or_dur.startswith("-P")
+                or end_or_dur.startswith("+P")
+            ):
+                duration = DurationEncoder.__parse_jcal_value__(end_or_dur, {})
+                return cls(
+                    start=start,
+                    duration=duration,
+                    FBTYPE=fbtype_val,
+                )
+            end = DateTimeEncoder.__parse_jcal_value__(end_or_dur, params)
+            return cls(
+                start=start,
+                end=end,
+                FBTYPE=fbtype_val,
+            )
+        raise ValueError(f"Invalid jCal period value: {value}")
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if not isinstance(value, Period):
+            return None
+        start_str = (
+            value.start.strftime("%Y-%m-%dT%H:%M:%SZ")
+            if not value.start.utcoffset() and value.start.tzinfo
+            else value.start.strftime("%Y-%m-%dT%H:%M:%S")
+        )
+        params: dict[str, Any] = {}
+        if value.free_busy_type:
+            params["fbtype"] = value.free_busy_type.value
+        if value.start.tzinfo and value.start.utcoffset():
+            params["tzid"] = str(value.start.tzinfo)
+        if value.end:
+            end_str = (
+                value.end.strftime("%Y-%m-%dT%H:%M:%SZ")
+                if not value.end.utcoffset() and value.end.tzinfo
+                else value.end.strftime("%Y-%m-%dT%H:%M:%S")
+            )
+            return EncodedJcalValue(params, [[start_str, end_str]])
+        if value.duration:
+            dur_str = DurationEncoder.__encode_property_json__(value.duration)
+            return EncodedJcalValue(params, [[start_str, dur_str]])
+        return None
 
     @classmethod
     def __encode_property__(cls, model_data: Any) -> ParsedProperty | None:

--- a/ical/types/recur.py
+++ b/ical/types/recur.py
@@ -58,7 +58,7 @@ from ical.parsing.property import ParsedProperty
 from ical.util import parse_date_and_datetime
 from ical.tzif import timezoneinfo
 
-from .data_types import DATA_TYPE, serialize_field
+from .data_types import DATA_TYPE, EncodedJcalValue, serialize_field
 from .date import DateEncoder
 from .date_time import DateTimeEncoder
 
@@ -196,15 +196,23 @@ class RecurrenceId(str):
         """Convert a string RecurrenceId into a date or time value.
 
         Accepts three formats:
-
-        - Plain date: '20250511'
-        - Plain datetime (naive or UTC): '20250511T020000' or '20250511T020000Z'
+        - Plain date: '20250511' or '2025-05-11'
+        - Plain datetime (naive or UTC): '20250511T020000' or '2025-05-11T02:00:00'
         - Inline TZID parameter: 'TZID=America/New_York:20250511T020000'
         """
         # Handle the inline "TZID=tz:DATETIME" format by re-parsing via ParsedProperty
         if "=" in recurrence_id.split(":")[0]:
             prop = ParsedProperty.from_ics(f"RECURRENCE-ID;{recurrence_id}")
             return DateTimeEncoder.__parse_property_value__(prop)
+
+        # Try ISO 8601 format (from jCal)
+        try:
+            if "T" in recurrence_id:
+                return datetime.datetime.fromisoformat(recurrence_id)
+            if "-" in recurrence_id:
+                return datetime.date.fromisoformat(recurrence_id)
+        except ValueError:
+            pass
 
         errors = []
         try:
@@ -280,6 +288,56 @@ class RecurrenceId(str):
         # is accessible via the .tzinfo attribute.  Unparsable values are
         # stored as-is.
         return RecurrenceId(raw_str, tzinfo=tzinfo, range=range_val)
+
+    @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> "RecurrenceId":
+        """Parse a jCal recurrence-id value, preserving TZID and RANGE params."""
+        tzinfo: datetime.tzinfo | None = None
+        if tzid := params.get("tzid") or params.get("TZID"):
+            try:
+                tzinfo = timezoneinfo.resolve_tzinfo(str(tzid))
+            except timezoneinfo.TimezoneInfoError:
+                _LOGGER.warning("RecurrenceId: unrecognised TZID '%s', ignoring", tzid)
+        range_val = Range.NONE
+        if (r := params.get("range") or params.get("RANGE")) and str(
+            r
+        ).upper() == "THISANDFUTURE":
+            range_val = Range.THIS_AND_FUTURE
+        raw_str = value if isinstance(value, str) else str(value)
+        return RecurrenceId(raw_str, tzinfo=tzinfo, range=range_val)
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        params: dict[str, Any] = {}
+        tzinfo: datetime.tzinfo | None = None
+        range_val = Range.NONE
+        if isinstance(value, RecurrenceId):
+            tzinfo = value.tzinfo
+            range_val = value.range
+
+        if tzinfo and tzinfo != datetime.timezone.utc and str(tzinfo) != "UTC":
+            params["tzid"] = str(tzinfo)
+        if range_val == Range.THIS_AND_FUTURE:
+            params["range"] = "THISANDFUTURE"
+
+        val_str = str(value)
+        try:
+            parsed = cls.to_value(val_str)
+            if isinstance(parsed, datetime.datetime):
+                if tzinfo:
+                    parsed = parsed.replace(tzinfo=tzinfo)
+                if parsed.tzinfo and not parsed.utcoffset():
+                    formatted = parsed.strftime("%Y-%m-%dT%H:%M:%SZ")
+                else:
+                    formatted = parsed.strftime("%Y-%m-%dT%H:%M:%S")
+                return EncodedJcalValue(params, [formatted], type_name="date-time")
+            if isinstance(parsed, datetime.date):
+                return EncodedJcalValue(params, [parsed.isoformat()], type_name="date")
+        except ValueError:
+            pass
+
+        return EncodedJcalValue(params, [val_str], type_name="date-time")
 
     @classmethod
     def __get_pydantic_core_schema__(
@@ -642,3 +700,83 @@ class Recur(BaseModel):
             else:
                 result[key] = value
         return result
+
+    @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> "Recur":
+        """Parse an RFC 7265 jCal recur object into a Recur model."""
+        if isinstance(value, Recur):
+            return value
+        if isinstance(value, str):
+            return cls.from_rrule(value)
+        if not isinstance(value, dict):
+            raise ValueError(f"Expected dict for jCal recur, got {type(value)}")
+
+        data = dict(value)
+        if byday := data.get("byday"):
+            byday_list = byday if isinstance(byday, list) else [byday]
+            parsed_byday = []
+            for item in byday_list:
+                if isinstance(item, str) and (m := WEEKDAY_REGEX.fullmatch(item)):
+                    occ, wd = m.groups()
+                    parsed_byday.append(
+                        {"weekday": wd, "occurrence": int(occ)}
+                        if occ
+                        else {"weekday": wd}
+                    )
+                else:
+                    parsed_byday.append(item)
+            data["byday"] = parsed_byday
+
+        for key in (
+            "bymonth",
+            "bymonthday",
+            "byyearday",
+            "byweekno",
+            "bysetpos",
+            "byhour",
+            "byminute",
+            "bysecond",
+        ):
+            if (val := data.get(key)) is not None and not isinstance(val, list):
+                data[key] = [val]
+
+        return cls.model_validate(data)
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode Recur as jCal parameters and value list."""
+        if isinstance(value, str):
+            value = cls.from_rrule(value)
+        if not isinstance(value, Recur):
+            return None
+
+        d: dict[str, Any] = {"freq": value.freq.value}
+        if value.until:
+            if isinstance(value.until, datetime.datetime):
+                if value.until.tzinfo and not value.until.utcoffset():
+                    d["until"] = value.until.strftime("%Y-%m-%dT%H:%M:%SZ")
+                else:
+                    d["until"] = value.until.strftime("%Y-%m-%dT%H:%M:%S")
+            else:
+                d["until"] = value.until.isoformat()
+        if value.count is not None:
+            d["count"] = value.count
+        if value.interval > 1:
+            d["interval"] = value.interval
+        if value.by_weekday:
+            d["byday"] = [str(w) for w in value.by_weekday]
+        for field, key in [
+            (value.by_month, "bymonth"),
+            (value.by_month_day, "bymonthday"),
+            (value.by_year_day, "byyearday"),
+            (value.by_week_no, "byweekno"),
+            (value.by_setpos, "bysetpos"),
+            (value.by_hour, "byhour"),
+            (value.by_minute, "byminute"),
+            (value.by_second, "bysecond"),
+        ]:
+            if field:
+                d[key] = field
+        if value.wkst:
+            d["wkst"] = value.wkst.value
+        return EncodedJcalValue({}, [d])

--- a/ical/types/relation.py
+++ b/ical/types/relation.py
@@ -9,7 +9,7 @@ from pydantic import model_validator
 
 from ical.parsing.property import ParsedProperty, ParsedPropertyParameter
 
-from .data_types import DATA_TYPE
+from .data_types import DATA_TYPE, EncodedJcalValue
 from .parsing import parse_parameter_values
 
 
@@ -58,6 +58,33 @@ class RelatedTo:
                 data[param.name] = param.values[0]
             return data
         return {"uid": prop}
+
+    @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> "RelatedTo":
+        """Parse an RFC 7265 jCal related-to property."""
+        if isinstance(value, RelatedTo):
+            return value
+        reltype = RelationshipType.PARENT
+        if rt := params.get("reltype") or params.get("RELTYPE"):
+            try:
+                reltype = RelationshipType(str(rt).upper())
+            except ValueError:
+                pass
+        return RelatedTo(uid=str(value), reltype=reltype)
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if isinstance(value, RelatedTo):
+            params: dict[str, Any] = {}
+            if value.reltype != RelationshipType.PARENT:
+                params["reltype"] = (
+                    value.reltype.value
+                    if isinstance(value.reltype, enum.Enum)
+                    else str(value.reltype)
+                )
+            return EncodedJcalValue(params, [value.uid], type_name="text")
+        return None
 
     _parse_parameter_values = model_validator(mode="before")(parse_parameter_values)
 

--- a/ical/types/request_status.py
+++ b/ical/types/request_status.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Optional
 
-from .data_types import DATA_TYPE
+from .data_types import DATA_TYPE, EncodedJcalValue
 from .text import TextEncoder
 
 
 @dataclass
-@DATA_TYPE.register()
+@DATA_TYPE.register("REQUEST-STATUS")
 class RequestStatus:
     """Status code returned for a scheduling request."""
 
@@ -32,6 +32,31 @@ class RequestStatus:
             statdesc=parts[1],
             exdata=exdata,
         )
+
+    @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> RequestStatus:
+        """Parse an RFC 7265 jCal request-status property."""
+        if isinstance(value, RequestStatus):
+            return value
+        if isinstance(value, (list, tuple)):
+            if len(value) < 2:
+                raise ValueError(f"Invalid jCal request-status: {value}")
+            return RequestStatus(
+                statcode=float(value[0]),
+                statdesc=str(value[1]),
+                exdata=str(value[2]) if len(value) > 2 else None,
+            )
+        return cls.__parse_property_value__(value)
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        if not isinstance(value, RequestStatus):
+            return None
+        parts = [f"{value.statcode}", value.statdesc]
+        if value.exdata:
+            parts.append(value.exdata)
+        return EncodedJcalValue({}, [parts], type_name="text")
 
     @classmethod
     def __encode_property_json__(cls, value: RequestStatus) -> str:

--- a/ical/types/text.py
+++ b/ical/types/text.py
@@ -1,11 +1,11 @@
 """Library for parsing TEXT values."""
 
 import re
-
+from typing import Any
 
 from ical.parsing.property import ParsedProperty, RE_CONTROL_CHARS
 
-from .data_types import DATA_TYPE
+from .data_types import DATA_TYPE, EncodedJcalValue
 
 _UNESCAPE_RE = re.compile(r"\\([\\;,Nn])")
 _UNESCAPE_MAP = {
@@ -37,6 +37,11 @@ class TextEncoder:
         return _UNESCAPE_RE.sub(lambda m: _UNESCAPE_MAP[m.group(1)], prop.value)
 
     @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> str:
+        """Parse an RFC 7265 jCal text into a string."""
+        return str(value)
+
+    @classmethod
     def __encode_property__(cls, value: str) -> ParsedProperty:
         """Serialize text as an ICS value."""
         for key, vin in ESCAPE_CHAR.items():
@@ -45,3 +50,12 @@ class TextEncoder:
             value = value.replace(key, vin)
         value = RE_CONTROL_CHARS.sub("", value)
         return ParsedProperty(name="", value=value)
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue:
+        """Encode as jCal parameters and value list."""
+        if isinstance(value, (list, tuple)):
+            values = [v.value if hasattr(v, "value") else str(v) for v in value]
+            return EncodedJcalValue({}, values)
+        str_val = value.value if hasattr(value, "value") else str(value)
+        return EncodedJcalValue({}, [str_val])

--- a/ical/types/text.py
+++ b/ical/types/text.py
@@ -54,8 +54,7 @@ class TextEncoder:
     @classmethod
     def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue:
         """Encode as jCal parameters and value list."""
-        if isinstance(value, (list, tuple)):
-            values = [v.value if hasattr(v, "value") else str(v) for v in value]
-            return EncodedJcalValue({}, values)
-        str_val = value.value if hasattr(value, "value") else str(value)
-        return EncodedJcalValue({}, [str_val])
+        values = value if isinstance(value, (list, tuple)) else [value]
+        return EncodedJcalValue(
+            {}, [v.value if hasattr(v, "value") else str(v) for v in values]
+        )

--- a/ical/types/utc_offset.py
+++ b/ical/types/utc_offset.py
@@ -9,9 +9,9 @@ from typing import Any
 
 from ical.parsing.property import ParsedProperty
 
-from .data_types import DATA_TYPE
+from .data_types import DATA_TYPE, EncodedJcalValue
 
-UTC_OFFSET_REGEX = re.compile(r"^([-+]?)([0-9]{2})([0-9]{2})([0-9]{2})?$")
+UTC_OFFSET_REGEX = re.compile(r"^([-+]?)([0-9]{2}):?([0-9]{2}):?([0-9]{2})?$")
 
 
 @DATA_TYPE.register("UTC-OFFSET")
@@ -40,6 +40,30 @@ class UtcOffset:
         if sign == "-":
             result = -result
         return UtcOffset(result)
+
+    @classmethod
+    def __parse_jcal_value__(cls, value: Any, params: dict[str, Any]) -> UtcOffset:
+        """Parse an RFC 7265 jCal utc-offset property."""
+        if isinstance(value, UtcOffset):
+            return value
+        if isinstance(value, datetime.timedelta):
+            return UtcOffset(value)
+        return cls.__parse_property_value__(value)
+
+    @classmethod
+    def __encode_jcal_value__(cls, value: Any) -> EncodedJcalValue | None:
+        """Encode as jCal parameters and value list."""
+        offset = value.offset if isinstance(value, UtcOffset) else value
+        if not isinstance(offset, datetime.timedelta):
+            return None
+        sign = "-" if offset < datetime.timedelta(0) else "+"
+        total_sec = abs(int(offset.total_seconds()))
+        hours, rem = divmod(total_sec, 3600)
+        minutes, seconds = divmod(rem, 60)
+        formatted = f"{sign}{hours:02}:{minutes:02}"
+        if seconds:
+            formatted += f":{seconds:02}"
+        return EncodedJcalValue({}, [formatted])
 
     @classmethod
     def __encode_property_json__(cls, value: UtcOffset) -> str:

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,4 @@ addopts = --benchmark-skip
 # Allows plain `async def test_...` functions (used by the ical[async] tests)
 # to run without needing an explicit @pytest.mark.asyncio on each of them.
 asyncio_mode = auto
+pythonpath = .

--- a/tests/test_jcal.py
+++ b/tests/test_jcal.py
@@ -1,14 +1,35 @@
-"""Tests for RFC 7265 (jCal) model serialization and parsing."""
-
 import datetime
+import json
 from typing import Any
 import pytest
 
+from ical.alarm import Action, Alarm
 from ical.calendar import Calendar
 from ical.calendar_stream import CalendarStream, JcalCalendarStream
-from ical.event import Event
-from ical.todo import Todo
+from ical.event import Event, EventStatus
+from ical.freebusy import FreeBusy
+from ical.journal import Journal, JournalStatus
+from ical.timezone import Timezone
+from ical.todo import Todo, TodoStatus
 from ical.exceptions import CalendarParseError
+from ical.types import (
+    Attachment,
+    CalAddress,
+    Conference,
+    Frequency,
+    Geo,
+    Image,
+    Period,
+    Priority,
+    Range,
+    Recur,
+    RecurrenceId,
+    RelatedTo,
+    RequestStatus,
+)
+from ical.types.image import Display
+from ical.types.period import FreeBusyType
+from ical.types.uri import Uri
 
 FIXED_DTSTAMP = datetime.datetime(2026, 8, 24, 12, 0, 0, tzinfo=datetime.timezone.utc)
 
@@ -213,6 +234,7 @@ def test_jcal_date_and_extra_properties() -> None:
     assert len(event.extras) == 1
     assert event.extras[0].name == "x-coffee-data"
     assert event.extras[0].value == "Stenophylla"
+    assert event.extras[0].params is not None
     assert event.extras[0].params[0].name == "ORIGIN"
     assert event.extras[0].params[0].values == ["Guinea"]
 
@@ -241,3 +263,530 @@ def test_jcal_invalid_structures(invalid_input: list[Any], error_match: str) -> 
     """Test validation and error handling on malformed jCal structures."""
     with pytest.raises(CalendarParseError, match=error_match):
         CalendarStream.from_jcal(invalid_input)
+
+
+def test_jcal_duration_property() -> None:
+    """Test parsing and serialization of jCal DURATION properties."""
+    jcal_input = [
+        "vcalendar",
+        [
+            ["prodid", {}, "text", "-//Example Corp.//EN"],
+            ["version", {}, "text", "2.0"],
+        ],
+        [
+            [
+                "vevent",
+                [
+                    ["dtstamp", {}, "date-time", "2026-08-24T12:00:00Z"],
+                    ["uid", {}, "text", "event-dur-1"],
+                    ["dtstart", {}, "date-time", "2026-08-24T09:00:00Z"],
+                    ["duration", {}, "duration", "PT1H30M"],
+                ],
+                [],
+            ]
+        ],
+    ]
+
+    cal = Calendar.from_jcal(jcal_input)
+    assert len(cal.events) == 1
+    event = cal.events[0]
+    assert event.duration == datetime.timedelta(hours=1, minutes=30)
+    assert cal.as_jcal() == jcal_input
+
+
+def test_jcal_timezone_and_tzid() -> None:
+    """Test parsing and serialization of jCal DATE-TIME with TZID parameter."""
+    jcal_input = [
+        "vcalendar",
+        [
+            ["prodid", {}, "text", "-//Example Corp.//EN"],
+            ["version", {}, "text", "2.0"],
+        ],
+        [
+            [
+                "vevent",
+                [
+                    ["dtstamp", {}, "date-time", "2026-08-24T12:00:00Z"],
+                    ["uid", {}, "text", "event-tz-1"],
+                    [
+                        "dtstart",
+                        {"tzid": "America/New_York"},
+                        "date-time",
+                        "2026-08-24T09:00:00",
+                    ],
+                ],
+                [],
+            ]
+        ],
+    ]
+
+    cal = Calendar.from_jcal(jcal_input)
+    assert len(cal.events) == 1
+    event = cal.events[0]
+    assert isinstance(event.dtstart, datetime.datetime)
+    assert str(event.dtstart.tzinfo) == "America/New_York"
+    assert event.dtstart.hour == 9
+
+    assert cal.as_jcal() == jcal_input
+
+
+def test_jcal_multi_calendar_stream() -> None:
+    """Test multi-calendar stream parsing and encoding."""
+    multi_jcal = [
+        [
+            "vcalendar",
+            [
+                ["prodid", {}, "text", "-//First//EN"],
+                ["version", {}, "text", "2.0"],
+            ],
+            [],
+        ],
+        [
+            "vcalendar",
+            [
+                ["prodid", {}, "text", "-//Second//EN"],
+                ["version", {}, "text", "2.0"],
+            ],
+            [],
+        ],
+    ]
+
+    stream = CalendarStream.from_jcal(multi_jcal)
+    assert len(stream.calendars) == 2
+    assert stream.calendars[0].prodid == "-//First//EN"
+    assert stream.calendars[1].prodid == "-//Second//EN"
+    assert stream.jcal() == multi_jcal
+
+
+def test_jcal_recurrence_rule_complex() -> None:
+    """Test parsing and serialization of complex jCal recurrence rules."""
+    jcal_input = [
+        "vcalendar",
+        [
+            ["prodid", {}, "text", "-//Example Corp.//EN"],
+            ["version", {}, "text", "2.0"],
+        ],
+        [
+            [
+                "vevent",
+                [
+                    ["dtstamp", {}, "date-time", "2026-08-24T12:00:00Z"],
+                    ["uid", {}, "text", "event-rrule-complex"],
+                    ["dtstart", {}, "date-time", "2026-08-24T09:00:00Z"],
+                    [
+                        "rrule",
+                        {},
+                        "recur",
+                        {
+                            "freq": "MONTHLY",
+                            "byday": ["1SU", "-1SU"],
+                            "bymonth": [4],
+                            "count": 10,
+                            "interval": 2,
+                        },
+                    ],
+                ],
+                [],
+            ]
+        ],
+    ]
+
+    cal = Calendar.from_jcal(jcal_input)
+    assert len(cal.events) == 1
+    event = cal.events[0]
+    assert event.rrule is not None
+    assert event.rrule.freq.value == "MONTHLY"
+    assert event.rrule.count == 10
+    assert event.rrule.interval == 2
+    assert len(event.rrule.by_weekday) == 2
+    assert event.rrule.by_weekday[0].occurrence == 1
+    assert event.rrule.by_weekday[0].weekday.value == "SU"
+    assert event.rrule.by_weekday[1].occurrence == -1
+    assert event.rrule.by_weekday[1].weekday.value == "SU"
+    assert event.rrule.by_month == [4]
+
+    assert cal.as_jcal() == jcal_input
+
+
+def test_jcal_rich_components_and_types() -> None:
+    """Test jCal support for CalAddress, Geo, RelatedTo, Attachment, Conference, and Image."""
+    cal = Calendar(
+        prodid="-//Example Corp.//EN",
+        version="2.0",
+        events=[
+            Event(
+                dtstamp=FIXED_DTSTAMP,
+                uid="event-rich-1",
+                summary="Rich Event",
+                attendees=[
+                    CalAddress(
+                        uri=Uri("mailto:alice@example.com"),
+                        common_name="Alice Smith",
+                        status="ACCEPTED",
+                    )
+                ],
+                geo=Geo(lat=37.386013, lng=-122.082932),
+                related_to=[RelatedTo(uid="parent-event-999")],
+                attach=[
+                    Attachment(
+                        uri=Uri("https://example.com/spec.pdf"),
+                        fmttype="application/pdf",
+                    )
+                ],
+                conference=[
+                    Conference(
+                        uri=Uri("https://meet.example.com/room-1"),
+                        label="Project Meeting",
+                    )
+                ],
+                image=[
+                    Image(
+                        uri=Uri("https://example.com/badge.png"),
+                        format_type="image/png",
+                    )
+                ],
+            )
+        ],
+    )
+
+    jcal_data = cal.as_jcal()
+    # Confirm it serializes to valid JSON without error
+    json_str = json.dumps(jcal_data)
+    assert "alice@example.com" in json_str
+    assert "37.386013" in json_str
+
+    cal_reparsed = Calendar.from_jcal(jcal_data)
+    assert len(cal_reparsed.events) == 1
+    event = cal_reparsed.events[0]
+    assert event.summary == "Rich Event"
+    assert len(event.attendees) == 1
+    assert str(event.attendees[0].uri) == "mailto:alice@example.com"
+    assert event.attendees[0].common_name == "Alice Smith"
+    assert event.attendees[0].status == "ACCEPTED"
+    assert event.geo is not None
+    assert event.geo.lat == 37.386013
+    assert event.geo.lng == -122.082932
+    assert len(event.related_to) == 1
+    assert event.related_to[0].uid == "parent-event-999"
+    assert len(event.attach) == 1
+    assert str(event.attach[0].uri) == "https://example.com/spec.pdf"
+    assert len(event.conference) == 1
+    assert str(event.conference[0].uri) == "https://meet.example.com/room-1"
+    assert len(event.image) == 1
+    assert str(event.image[0].uri) == "https://example.com/badge.png"
+
+
+def test_jcal_vtimezone_and_observance() -> None:
+    """Test jCal parsing and encoding of VTIMEZONE and standard/daylight observances."""
+    jcal_tz = [
+        "vtimezone",
+        [["tzid", {}, "text", "America/New_York"]],
+        [
+            [
+                "standard",
+                [
+                    ["dtstart", {}, "date-time", "2007-11-04T02:00:00"],
+                    ["tzoffsetto", {}, "utc-offset", "-05:00"],
+                    ["tzoffsetfrom", {}, "utc-offset", "-04:00"],
+                    [
+                        "rrule",
+                        {},
+                        "recur",
+                        {
+                            "freq": "YEARLY",
+                            "byday": ["1SU"],
+                            "bymonth": [11],
+                        },
+                    ],
+                    ["tzname", {}, "text", "EST"],
+                ],
+                [],
+            ]
+        ],
+    ]
+
+    tz = Timezone.from_jcal(jcal_tz)
+    assert tz.tz_id == "America/New_York"
+    assert len(tz.standard) == 1
+    std = tz.standard[0]
+    assert std.tz_name == ["EST"]
+    assert std.tz_offset_from.offset == datetime.timedelta(hours=-4)
+    assert std.tz_offset_to.offset == datetime.timedelta(hours=-5)
+    assert std.rrule is not None
+    assert std.rrule.freq.value == "YEARLY"
+
+    assert tz.as_jcal() == jcal_tz
+
+
+def test_jcal_recur_until_formats() -> None:
+    """Test jCal recurrence UNTIL parameter formatted as date and date-time."""
+    # Until as date
+    r_date = Recur(freq=Frequency.DAILY, until=datetime.date(2026, 8, 30))
+    event1 = Event(
+        dtstamp=FIXED_DTSTAMP,
+        uid="recur-until-date",
+        dtstart=datetime.date(2026, 8, 24),
+        rrule=r_date,
+    )
+    jcal1 = event1.as_jcal()
+    assert json.dumps(jcal1)
+    rrule_prop1 = [p for p in jcal1[1] if p[0] == "rrule"][0]
+    assert rrule_prop1[3]["until"] == "2026-08-30"
+
+    event1_reparsed = Event.from_jcal(jcal1)
+    assert event1_reparsed.rrule is not None
+    assert event1_reparsed.rrule.until == datetime.date(2026, 8, 30)
+
+    # Until as date-time
+    r_dt = Recur(
+        freq=Frequency.DAILY,
+        until=datetime.datetime(2026, 8, 30, 12, 0, 0, tzinfo=datetime.timezone.utc),
+    )
+    event2 = Event(
+        dtstamp=FIXED_DTSTAMP,
+        uid="recur-until-dt",
+        dtstart=datetime.datetime(2026, 8, 24, 9, 0, 0, tzinfo=datetime.timezone.utc),
+        rrule=r_dt,
+    )
+    jcal2 = event2.as_jcal()
+    assert json.dumps(jcal2)
+    rrule_prop2 = [p for p in jcal2[1] if p[0] == "rrule"][0]
+    assert rrule_prop2[3]["until"] == "2026-08-30T12:00:00Z"
+
+    event2_reparsed = Event.from_jcal(jcal2)
+    assert event2_reparsed.rrule is not None
+    assert event2_reparsed.rrule.until == datetime.datetime(
+        2026, 8, 30, 12, 0, 0, tzinfo=datetime.timezone.utc
+    )
+
+
+def test_jcal_recurrence_id_handling() -> None:
+    """Test jCal recurrence-id roundtrip and to_value conversions."""
+    rec_id = RecurrenceId(
+        "20260824T090000",
+        tzinfo=datetime.timezone.utc,
+        range=Range.THIS_AND_FUTURE,
+    )
+    event = Event(
+        dtstamp=FIXED_DTSTAMP,
+        uid="event-rec-id",
+        dtstart=datetime.datetime(2026, 8, 24, 9, 0, 0, tzinfo=datetime.timezone.utc),
+        recurrence_id=rec_id,
+    )
+    jcal_data = event.as_jcal()
+    assert json.dumps(jcal_data)
+
+    rec_prop = [p for p in jcal_data[1] if p[0] == "recurrence-id"][0]
+    assert rec_prop[1] == {"range": "THISANDFUTURE"}
+    assert rec_prop[3] == "2026-08-24T09:00:00Z"
+
+    reparsed = Event.from_jcal(jcal_data)
+    assert reparsed.recurrence_id is not None
+    assert reparsed.recurrence_id.range == Range.THIS_AND_FUTURE
+    assert RecurrenceId.to_value(reparsed.recurrence_id) == datetime.datetime(
+        2026, 8, 24, 9, 0, 0, tzinfo=datetime.timezone.utc
+    )
+
+
+def test_jcal_multi_value_and_enums() -> None:
+    """Test exdate, rdate with period, request-status, and enums."""
+    p1 = Period(
+        start=datetime.datetime(2026, 8, 24, 9, 0, tzinfo=datetime.timezone.utc),
+        duration=datetime.timedelta(hours=1),
+    )
+    event = Event(
+        dtstamp=FIXED_DTSTAMP,
+        uid="event-mv-1",
+        dtstart=datetime.datetime(2026, 8, 24, 9, 0, tzinfo=datetime.timezone.utc),
+        status=EventStatus.CONFIRMED,
+        priority=Priority(1),
+        exdate=[
+            datetime.date(2026, 8, 25),
+            datetime.date(2026, 8, 26),
+        ],
+        rdate=[p1],
+        request_status=[RequestStatus(statcode=2.0, statdesc="Success")],
+    )
+
+    jcal_event = event.as_jcal()
+    assert json.dumps(jcal_event)
+
+    reparsed_event = Event.from_jcal(jcal_event)
+    assert reparsed_event.status == EventStatus.CONFIRMED
+    assert reparsed_event.priority == 1
+    assert reparsed_event.exdate == [
+        datetime.date(2026, 8, 25),
+        datetime.date(2026, 8, 26),
+    ]
+    assert len(reparsed_event.rdate) == 1
+    assert isinstance(reparsed_event.rdate[0], Period)
+    assert reparsed_event.rdate[0].duration == datetime.timedelta(hours=1)
+    assert len(reparsed_event.request_status) == 1
+    assert reparsed_event.request_status[0].statcode == 2.0
+    assert reparsed_event.request_status[0].statdesc == "Success"
+
+    # Test Todo and Journal
+    todo = Todo(
+        dtstamp=FIXED_DTSTAMP,
+        uid="todo-1",
+        summary="Task",
+        status=TodoStatus.COMPLETED,
+        percent=75,
+    )
+    jcal_todo = todo.as_jcal()
+    assert json.dumps(jcal_todo)
+    reparsed_todo = Todo.from_jcal(jcal_todo)
+    assert reparsed_todo.status == TodoStatus.COMPLETED
+    assert reparsed_todo.percent == 75
+
+    journal = Journal(
+        dtstamp=FIXED_DTSTAMP,
+        uid="journal-1",
+        summary="Note",
+        status=JournalStatus.FINAL,
+    )
+    jcal_journal = journal.as_jcal()
+    assert json.dumps(jcal_journal)
+    reparsed_journal = Journal.from_jcal(jcal_journal)
+    assert reparsed_journal.status == JournalStatus.FINAL
+
+
+def test_jcal_binary_attachment_and_image() -> None:
+    """Test binary content encoding and decoding for Attachment and Image."""
+    att = Attachment(content=b"hello binary attachment", fmttype="text/plain")
+    img = Image(
+        content=b"\x89PNG\r\n\x1a\nfakeimage",
+        format_type="image/png",
+        display=Display.BADGE,
+    )
+    event = Event(
+        dtstamp=FIXED_DTSTAMP,
+        uid="event-binary-1",
+        summary="Binary Event",
+        attach=[att],
+        image=[img],
+    )
+    jcal = event.as_jcal()
+    assert json.dumps(jcal)
+
+    # Verify property types are binary in jCal
+    attach_prop = [p for p in jcal[1] if p[0] == "attach"][0]
+    assert attach_prop[2] == "binary"
+    assert attach_prop[1] == {"fmttype": "text/plain"}
+
+    image_prop = [p for p in jcal[1] if p[0] == "image"][0]
+    assert image_prop[2] == "binary"
+    assert image_prop[1] == {"fmttype": "image/png", "display": "BADGE"}
+
+    # Reparse and verify content bytes
+    reparsed = Event.from_jcal(jcal)
+    assert len(reparsed.attach) == 1
+    assert reparsed.attach[0].content == b"hello binary attachment"
+    assert reparsed.attach[0].fmttype == "text/plain"
+
+    assert len(reparsed.image) == 1
+    assert reparsed.image[0].content == b"\x89PNG\r\n\x1a\nfakeimage"
+    assert reparsed.image[0].format_type == "image/png"
+    assert reparsed.image[0].display == Display.BADGE
+
+
+def test_jcal_caladdress_and_conference_scalar_params() -> None:
+    """Test CalAddress and Conference parameter handling from jCal dicts."""
+    jcal_input = [
+        "vevent",
+        [
+            ["dtstamp", {}, "date-time", "2026-08-24T12:00:00Z"],
+            ["uid", {}, "text", "event-params-1"],
+            ["summary", {}, "text", "Params Event"],
+            [
+                "attendee",
+                {"delegated-from": "mailto:boss@example.com", "cn": "Alice"},
+                "cal-address",
+                "mailto:alice@example.com",
+            ],
+            [
+                "conference",
+                {"feature": "AUDIO", "label": "Call Link"},
+                "uri",
+                "https://meet.example.com/room",
+            ],
+        ],
+        [],
+    ]
+
+    event = Event.from_jcal(jcal_input)
+    assert len(event.attendees) == 1
+    assert event.attendees[0].common_name == "Alice"
+    assert event.attendees[0].delegator == [Uri("mailto:boss@example.com")]
+
+    assert len(event.conference) == 1
+    assert event.conference[0].label == "Call Link"
+    assert event.conference[0].feature is not None
+    assert event.conference[0].feature[0].value == "AUDIO"
+
+
+def test_jcal_period_variations_and_freebusy() -> None:
+    """Test Period parsing from slash strings and FreeBusy components."""
+    # Test Period from slash string
+    p1 = Period.__parse_jcal_value__(
+        "2026-08-24T09:00:00Z/2026-08-24T10:00:00Z",
+        {"fbtype": "busy"},
+    )
+    assert p1.start == datetime.datetime(
+        2026, 8, 24, 9, 0, tzinfo=datetime.timezone.utc
+    )
+    assert p1.end == datetime.datetime(2026, 8, 24, 10, 0, tzinfo=datetime.timezone.utc)
+    assert p1.free_busy_type == FreeBusyType.BUSY
+
+    p2 = Period(
+        start=datetime.datetime(2026, 8, 24, 13, 0, tzinfo=datetime.timezone.utc),
+        duration=datetime.timedelta(hours=2),
+        FBTYPE=FreeBusyType.BUSY_TENTATIVE,
+    )
+
+    fb = FreeBusy(
+        dtstart=datetime.datetime(2026, 8, 24, 9, 0, tzinfo=datetime.timezone.utc),
+        dtend=datetime.datetime(2026, 8, 24, 17, 0, tzinfo=datetime.timezone.utc),
+        freebusy=[p1, p2],
+    )
+    cal = Calendar(freebusy=[fb])
+    jcal = cal.as_jcal()
+    assert json.dumps(jcal)
+
+    cal_reparsed = Calendar.from_jcal(jcal)
+    assert len(cal_reparsed.freebusy) == 1
+    assert len(cal_reparsed.freebusy[0].freebusy) == 2
+
+
+def test_jcal_alarm_subcomponents() -> None:
+    """Test relative and absolute VALARM subcomponents in jCal."""
+    alarm_rel = Alarm(
+        action=Action.DISPLAY,
+        description="Meeting soon",
+        trigger=-datetime.timedelta(minutes=15),
+    )
+    alarm_abs = Alarm(
+        action=Action.DISPLAY,
+        description="Meeting now",
+        trigger=datetime.datetime(2026, 8, 24, 8, 45, tzinfo=datetime.timezone.utc),
+    )
+    event = Event(
+        dtstamp=FIXED_DTSTAMP,
+        uid="event-alarms",
+        summary="Event with Alarms",
+        alarm=[alarm_rel, alarm_abs],
+    )
+
+    jcal = event.as_jcal()
+    assert json.dumps(jcal)
+    assert len(jcal[2]) == 2
+    assert jcal[2][0][0] == "valarm"
+    assert jcal[2][1][0] == "valarm"
+
+    reparsed = Event.from_jcal(jcal)
+    assert len(reparsed.alarm) == 2
+    assert reparsed.alarm[0].trigger == -datetime.timedelta(minutes=15)
+    assert reparsed.alarm[0].description == "Meeting soon"
+    assert reparsed.alarm[1].trigger == datetime.datetime(
+        2026, 8, 24, 8, 45, tzinfo=datetime.timezone.utc
+    )

--- a/tests/test_jcal.py
+++ b/tests/test_jcal.py
@@ -1,0 +1,243 @@
+"""Tests for RFC 7265 (jCal) model serialization and parsing."""
+
+import datetime
+from typing import Any
+import pytest
+
+from ical.calendar import Calendar
+from ical.calendar_stream import CalendarStream, JcalCalendarStream
+from ical.event import Event
+from ical.todo import Todo
+from ical.exceptions import CalendarParseError
+
+FIXED_DTSTAMP = datetime.datetime(2026, 8, 24, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+@pytest.mark.parametrize(
+    ("calendar", "expected_jcal"),
+    [
+        # 1. Minimal Calendar envelope
+        (
+            Calendar(prodid="-//Example Corp.//EN", version="2.0"),
+            [
+                "vcalendar",
+                [
+                    ["prodid", {}, "text", "-//Example Corp.//EN"],
+                    ["version", {}, "text", "2.0"],
+                ],
+                [],
+            ],
+        ),
+        # 2. Calendar with Event (text, date-time, and integer properties)
+        (
+            Calendar(
+                prodid="-//Example Corp.//EN",
+                version="2.0",
+                vevent=[
+                    Event(
+                        dtstamp=FIXED_DTSTAMP,
+                        uid="event-123",
+                        summary="Architecture Review",
+                        description="Review jCal design with team",
+                        sequence=1,
+                    )
+                ],
+            ),
+            [
+                "vcalendar",
+                [
+                    ["prodid", {}, "text", "-//Example Corp.//EN"],
+                    ["version", {}, "text", "2.0"],
+                ],
+                [
+                    [
+                        "vevent",
+                        [
+                            ["dtstamp", {}, "date-time", "2026-08-24T12:00:00Z"],
+                            ["uid", {}, "text", "event-123"],
+                            ["summary", {}, "text", "Architecture Review"],
+                            ["description", {}, "text", "Review jCal design with team"],
+                            ["sequence", {}, "integer", 1],
+                        ],
+                        [],
+                    ]
+                ],
+            ],
+        ),
+        # 3. Calendar with Todo and multi-valued text categories
+        (
+            Calendar(
+                prodid="-//Example Corp.//EN",
+                version="2.0",
+                vtodo=[
+                    Todo(
+                        dtstamp=FIXED_DTSTAMP,
+                        uid="todo-456",
+                        summary="Write tests",
+                        categories=["Work", "Python"],
+                    )
+                ],
+            ),
+            [
+                "vcalendar",
+                [
+                    ["prodid", {}, "text", "-//Example Corp.//EN"],
+                    ["version", {}, "text", "2.0"],
+                ],
+                [
+                    [
+                        "vtodo",
+                        [
+                            ["dtstamp", {}, "date-time", "2026-08-24T12:00:00Z"],
+                            ["uid", {}, "text", "todo-456"],
+                            ["categories", {}, "text", "Work", "Python"],
+                            ["summary", {}, "text", "Write tests"],
+                        ],
+                        [],
+                    ]
+                ],
+            ],
+        ),
+    ],
+    ids=[
+        "minimal_calendar",
+        "calendar_with_event",
+        "calendar_with_todo_and_categories",
+    ],
+)
+def test_calendar_as_jcal(calendar: Calendar, expected_jcal: list[Any]) -> None:
+    """Test serializing Calendar model instances to jCal format."""
+    assert calendar.as_jcal() == expected_jcal
+
+
+def test_jcal_stream_roundtrip() -> None:
+    """Test parsing jCal into Calendar model and re-encoding."""
+    jcal_input = [
+        "vcalendar",
+        [
+            ["prodid", {}, "text", "-//Example Corp.//EN"],
+            ["version", {}, "text", "2.0"],
+        ],
+        [
+            [
+                "vevent",
+                [
+                    ["dtstamp", {}, "date-time", "2026-08-24T12:00:00Z"],
+                    ["uid", {}, "text", "event-123"],
+                    ["summary", {}, "text", "Architecture Review"],
+                    ["description", {}, "text", "Review jCal design with team"],
+                    ["sequence", {}, "integer", 1],
+                ],
+                [],
+            ]
+        ],
+    ]
+
+    cal = JcalCalendarStream.calendar_from_jcal(jcal_input)
+    assert cal.prodid == "-//Example Corp.//EN"
+    assert cal.version == "2.0"
+    assert len(cal.events) == 1
+    assert cal.events[0].dtstamp == FIXED_DTSTAMP
+    assert cal.events[0].uid == "event-123"
+    assert cal.events[0].summary == "Architecture Review"
+    assert cal.events[0].description == "Review jCal design with team"
+    assert cal.events[0].sequence == 1
+
+    # Re-encode to jCal
+    assert JcalCalendarStream.calendar_to_jcal(cal) == jcal_input
+
+
+def test_ics_to_jcal_model_bridge() -> None:
+    """Test reading ICS content and generating jCal output via CalendarStream."""
+    ics_content = (
+        "BEGIN:VCALENDAR\n"
+        "PRODID:-//Example Corp.//EN\n"
+        "VERSION:2.0\n"
+        "BEGIN:VEVENT\n"
+        "DTSTAMP:20260824T120000Z\n"
+        "UID:event-123\n"
+        "SUMMARY:Meeting with Fred\n"
+        "END:VEVENT\n"
+        "END:VCALENDAR"
+    )
+
+    stream = CalendarStream.from_ics(ics_content)
+    jcal_output = stream.jcal()
+
+    assert jcal_output == [
+        "vcalendar",
+        [
+            ["prodid", {}, "text", "-//Example Corp.//EN"],
+            ["version", {}, "text", "2.0"],
+        ],
+        [
+            [
+                "vevent",
+                [
+                    ["dtstamp", {}, "date-time", "2026-08-24T12:00:00Z"],
+                    ["uid", {}, "text", "event-123"],
+                    ["summary", {}, "text", "Meeting with Fred"],
+                ],
+                [],
+            ]
+        ],
+    ]
+
+
+def test_jcal_date_and_extra_properties() -> None:
+    """Test parsing and serialization of jCal DATE and extra/extension properties."""
+    jcal_input = [
+        "vcalendar",
+        [
+            ["prodid", {}, "text", "-//Example Corp.//EN"],
+            ["version", {}, "text", "2.0"],
+        ],
+        [
+            [
+                "vevent",
+                [
+                    ["dtstamp", {}, "date-time", "2026-08-24T12:00:00Z"],
+                    ["uid", {}, "text", "event-123"],
+                    ["dtstart", {}, "date", "2026-08-24"],
+                    ["x-coffee-data", {"origin": "Guinea"}, "unknown", "Stenophylla"],
+                ],
+                [],
+            ]
+        ],
+    ]
+
+    cal = Calendar.from_jcal(jcal_input)
+    assert len(cal.events) == 1
+    event = cal.events[0]
+    assert event.dtstart == datetime.date(2026, 8, 24)
+    assert len(event.extras) == 1
+    assert event.extras[0].name == "x-coffee-data"
+    assert event.extras[0].value == "Stenophylla"
+    assert event.extras[0].params[0].name == "ORIGIN"
+    assert event.extras[0].params[0].values == ["Guinea"]
+
+    # Re-encode to jCal
+    assert cal.as_jcal() == jcal_input
+
+
+@pytest.mark.parametrize(
+    ("invalid_input", "error_match"),
+    [
+        ([], "Invalid jCal data"),
+        (["vevent", []], "Invalid jCal component structure"),
+        (["vevent", "not-a-list", []], "Invalid jCal component properties"),
+        (["vevent", [], "not-a-list"], "Invalid jCal component properties"),
+        (["vevent", [["summary"]], []], "Invalid jCal property structure"),
+    ],
+    ids=[
+        "empty_stream",
+        "missing_subcomponents",
+        "properties_not_a_list",
+        "subcomponents_not_a_list",
+        "property_too_short",
+    ],
+)
+def test_jcal_invalid_structures(invalid_input: list[Any], error_match: str) -> None:
+    """Test validation and error handling on malformed jCal structures."""
+    with pytest.raises(CalendarParseError, match=error_match):
+        CalendarStream.from_jcal(invalid_input)


### PR DESCRIPTION
## Description
This PR adds support for **RFC 7265 (jCal: The JSON Format for iCalendar)** parsing and encoding:

1. **Symmetric Type System Integration (`DATA_TYPE`)**:
   - `__parse_jcal_value__(value, params)`: Parses native jCal JSON values into Python types (ISO 8601 extended dates/datetimes, durations, texts, etc.).
   - `__encode_jcal_value__(value)`: Encodes Python types into `EncodedJcalValue(params, values)`.
   - `__parse_property_value__` remains strictly dedicated to RFC 5545 wire format.

2. **Model & Stream API**:
   - `ComponentModel.from_jcal(jcal_data)`: Parses jCal component arrays directly into model instances.
   - `ComponentModel.as_jcal()`: Serializes model instances directly into jCal component arrays.
   - `CalendarStream.from_jcal(jcal_data)` & `stream.jcal()`: Stream-level parsing and serialization.
   - `JcalCalendarStream`: High-level convenience stream.

## Testing
- Unit and integration tests covering jCal parsing, serialization, extra properties, and error handling.
- Full test suite passes (1,486 passed, 35 skipped).
- All linters and format checks pass cleanly.